### PR TITLE
Add support for OL8

### DIFF
--- a/scap/oscap/map.jinja
+++ b/scap/oscap/map.jinja
@@ -3,8 +3,11 @@
 {%- set osrel = salt.grains.get('osmajorrelease') %}
 
 {%- set os = salt.grains.filter_by({
+    'AlmaLinux': 'centos',
+    'CentOS': 'centos',
+    'OEL': 'ol',
     'RedHat': 'rhel',
-    'CentOS': 'centos'
+    'Rocky': 'centos'
 }, grain='os') %}
 
 {#- Initialize oscap dictionary with defaults and pillar data #}


### PR DESCRIPTION
Add `OEL` to `ol` mapping

While we're here:
* Add 'AlmaLinux' to 'centos' mapping (reduce need to update content-project)
* Add 'Rocky' to 'centos' mapping (reduce need to update content-project)
* Alphabetize mappings

closes #38