### PR TITLE
Uses scap datastream instead of xccdf when scanning systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ scap:
 
     # Configuration dictionary used by the `oscap` driver.
     oscap:
-      xccdf: ''  # Path to xccdf.xml, relative to content.local_dir
-      cpe: ''    # Path to cpe.xml, relative to content.local_dir
+      ds: ''  # Path to ds.xml, relative to content.local_dir
       profile: common
 
     # Configuration dictionary used by the `scc` driver.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
 init:
   - ps: echo $env:PILLAR_HOME
 install:
+  - ps: '[Net.ServicePointManager]::SecurityProtocol = "Tls12, Tls13"'
   - ps: |
       $null = `
         (new-object net.webclient).DownloadFile(${env:SALT_URL}, `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '{branch}-{build}'
+image: Visual Studio 2019
 build: off
 skip_branch_with_pr: true
 environment:

--- a/pillar.example
+++ b/pillar.example
@@ -13,8 +13,7 @@ scap:
 
     # Configuration dictionary used by the `oscap` driver.
     oscap:
-      xccdf: ''  # Path to xccdf.xml, relative to content.local_dir
-      cpe: ''    # Path to cpe.xml, relative to content.local_dir
+      ds: '' # Path to ds.xml, relative to content.local_dir
       profile: common
 
     # Configuration dictionary used by the `scc` driver.

--- a/scap/oscap/map.jinja
+++ b/scap/oscap/map.jinja
@@ -12,17 +12,14 @@
 
 {#- Initialize oscap dictionary with defaults and pillar data #}
 {%- set oscap = {
-    'cpe': salt.pillar.get('scap:lookup:oscap:cpe') | default('openscap/ssg-rhel' ~ osrel ~ '-cpe-dictionary.xml', true),
-    'xccdf': salt.pillar.get('scap:lookup:oscap:xccdf') | default('openscap/ssg-' ~ os ~ osrel ~ '-xccdf.xml', true),
+    'ds': salt.pillar.get('scap:lookup:oscap:ds') | default('openscap/ssg-' ~ os ~ osrel ~ '-ds.xml', true),
     'profile': salt.pillar.get('scap:lookup:oscap:profile') | default('common', true),
-    'scap1_2': salt.pillar.get('scap:lookup:oscap:scap1_2') | default(false, true)
 } %}
 
 {#- Update oscap dictionary with static values #}
 {%- do oscap.update({
+    'ds': scap.content.local_dir ~ '/' ~ oscap.ds,
     'output_dir': scap.output_dir,
-    'cpe': scap.content.local_dir ~ '/' ~ oscap.cpe,
-    'xccdf': scap.content.local_dir ~ '/' ~ oscap.xccdf,
-    'report': scap.output_dir ~ '/oscap-report.' ~ oscap.xccdf|replace('/','.') ~ '.$(date "+%Y%m%d%H%M").html',
-    'results': scap.output_dir ~ '/oscap-results.' ~ oscap.xccdf|replace('/','.') ~ '.$(date "+%Y%m%d%H%M").xml'
+    'report': scap.output_dir ~ '/oscap-report.' ~ oscap.ds|replace('/','.') ~ '.$(date "+%Y%m%d%H%M").html',
+    'results': scap.output_dir ~ '/oscap-results.' ~ oscap.ds|replace('/','.') ~ '.$(date "+%Y%m%d%H%M").xml'
 }) %}

--- a/scap/oscap/scan.sls
+++ b/scap/oscap/scan.sls
@@ -13,7 +13,7 @@ create oscap output directory:
 
 run oscap scan:
   cmd.run:
-    - name: 'oscap xccdf eval --profile {{ oscap.profile }} --report {{ oscap.report }} --results {{ oscap.results }} {% if not oscap.scap1_2 -%} --cpe {{ oscap.cpe }} {%- endif %} {{ oscap.xccdf }}'
+    - name: 'oscap xccdf eval --profile {{ oscap.profile }} --report {{ oscap.report }} --results {{ oscap.results }} {{ oscap.ds }}'
     - cwd: '/root'
     - success_retcodes:
       - 2

--- a/scap/oscap/scan.sls
+++ b/scap/oscap/scan.sls
@@ -13,8 +13,10 @@ create oscap output directory:
 
 run oscap scan:
   cmd.run:
-    - name: '(oscap xccdf eval --profile {{ oscap.profile }} --report {{ oscap.report }} --results {{ oscap.results }} {% if not oscap.scap1_2 -%} --cpe {{ oscap.cpe }} {%- endif %} {{ oscap.xccdf }}) || true'
+    - name: 'oscap xccdf eval --profile {{ oscap.profile }} --report {{ oscap.report }} --results {{ oscap.results }} {% if not oscap.scap1_2 -%} --cpe {{ oscap.cpe }} {%- endif %} {{ oscap.xccdf }}'
     - cwd: '/root'
+    - success_retcodes:
+      - 2
     - require:
       - file: manage scap content
       - file: create oscap output directory


### PR DESCRIPTION
This matches how we _remediate_ systems in ash-linux also, so ought to be a better representation of the expected baseline...