### PR TITLE
Adds DISA SCAP content

### DIFF
--- a/scap/content/guides/disa/stig-dotnet4.xml
+++ b/scap/content/guides/disa/stig-dotnet4.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" id="scap_mil.disa.stig_collection_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
-  <data-stream id="scap_mil.disa.stig_datastream_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2021-01-04T23:44:55">
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
+  <data-stream id="scap_mil.disa.stig_datastream_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2022-12-30T20:19:59">
     <dictionaries>
-      <component-ref id="scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+          <cat:uri name="U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
         </cat:catalog>
       </component-ref>
     </dictionaries>
     <checklists>
-      <component-ref id="scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-xccdf.xml" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-xccdf.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          <cat:uri name="U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
         </cat:catalog>
       </component-ref>
     </checklists>
     <checks>
-      <component-ref id="scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" />
-      <component-ref id="scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
     </checks>
   </data-stream>
-  <component id="scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2021-01-04T23:44:55">
+  <component id="scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2022-12-30T20:19:59">
     <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0">
       <cpe-item name="cpe:/a:microsoft:.net_framework:4.0">
         <title>Microsoft .NET Framework 4.0</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.dotnet:def:1</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.dotnet:def:1</check>
       </cpe-item>
     </cpe-list>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2021-01-04T23:44:55">
-    <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" id="xccdf_mil.disa.stig_benchmark_MS_Dot_Net_Framework" xml:lang="en" style="SCAP_1.2">
+  <component id="scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2022-12-30T20:19:59">
+    <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_MS_Dot_Net_Framework" xml:lang="en" style="SCAP_1.2">
       <xccdf:status date="2020-12-11">accepted</xccdf:status>
-      <xccdf:title>Microsoft DotNet Framework 4.0 Security Technical Implementation Guide</xccdf:title>
+      <xccdf:title>Microsoft DotNet Framework 4.0 STIG SCAP Benchmark</xccdf:title>
       <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
       <xccdf:notice id="terms-of-use" xml:lang="en" />
       <xccdf:front-matter xml:lang="en" />
@@ -40,11 +40,11 @@
         <dc:publisher>DISA</dc:publisher>
         <dc:source>STIG.DOD.MIL</dc:source>
       </xccdf:reference>
-      <xccdf:plain-text id="release-info">Release: 2.1 Benchmark Date: 22 Jan 2021</xccdf:plain-text>
+      <xccdf:plain-text id="release-info">Release: 2.2 Benchmark Date: 26 Jan 2023</xccdf:plain-text>
       <xccdf:plain-text id="generator">3.2.1.41666</xccdf:plain-text>
       <xccdf:plain-text id="conventionsVersion">1.10.0</xccdf:plain-text>
       <xccdf:platform idref="cpe:/a:microsoft:.net_framework:4.0" />
-      <xccdf:version update="http://iase.disa.mil/stigs">002.001</xccdf:version>
+      <xccdf:version update="http://iase.disa.mil/stigs">002.002</xccdf:version>
       <xccdf:metadata>
         <dc:creator>DISA</dc:creator>
         <dc:publisher>DISA</dc:publisher>
@@ -55,7 +55,6 @@
         <xccdf:title>I - Mission Critical Classified</xccdf:title>
         <xccdf:description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225223" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225224" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225230" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225235" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225238" selected="true" />
@@ -64,7 +63,6 @@
         <xccdf:title>I - Mission Critical Public</xccdf:title>
         <xccdf:description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225223" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225224" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225230" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225235" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225238" selected="true" />
@@ -73,7 +71,6 @@
         <xccdf:title>I - Mission Critical Sensitive</xccdf:title>
         <xccdf:description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225223" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225224" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225230" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225235" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225238" selected="true" />
@@ -82,7 +79,6 @@
         <xccdf:title>II - Mission Support Classified</xccdf:title>
         <xccdf:description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225223" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225224" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225230" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225235" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225238" selected="true" />
@@ -91,7 +87,6 @@
         <xccdf:title>II - Mission Support Public</xccdf:title>
         <xccdf:description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225223" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225224" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225230" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225235" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225238" selected="true" />
@@ -100,7 +95,6 @@
         <xccdf:title>II - Mission Support Sensitive</xccdf:title>
         <xccdf:description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225223" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225224" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225230" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225235" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225238" selected="true" />
@@ -109,7 +103,6 @@
         <xccdf:title>III - Administrative Classified</xccdf:title>
         <xccdf:description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225223" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225224" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225230" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225235" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225238" selected="true" />
@@ -118,7 +111,6 @@
         <xccdf:title>III - Administrative Public</xccdf:title>
         <xccdf:description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225223" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225224" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225230" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225235" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225238" selected="true" />
@@ -127,7 +119,6 @@
         <xccdf:title>III - Administrative Sensitive</xccdf:title>
         <xccdf:description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225223" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225224" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225230" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225235" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225238" selected="true" />
@@ -136,7 +127,6 @@
         <xccdf:title>CAT I Only</xccdf:title>
         <xccdf:description>This profile only includes rules that are Severity Category I.</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225223r615940_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225224r615940_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225230r615940_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225235r615940_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225238r615940_rule" selected="false" />
@@ -165,47 +155,7 @@ All assemblies must require strong name verification in a production environment
 Strong name assemblies that do not require verification in a development or test environment must have documented approvals from the IAO.</xccdf:fixtext>
           <xccdf:fix id="F-26910r467985_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.dotnet:def:2" href="U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-225224">
-        <xccdf:title>SRG-APP-000175</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225224r615940_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">APPNET0046</xccdf:version>
-          <xccdf:title>The Trust Providers Software Publishing State must be set to 0x23C00.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Microsoft Windows operating systems provide a feature called Authenticode.  Authenticode technology and its underlying code signing mechanisms serve to provide a structure to identify software publishers and ensure that software applications have not been tampered with.  Authenticode technology relies on digital certificates and is based on Public Key Cryptography Standards (PKCS) #7 (encrypted key specification), PKCS #10 (certificate request formats), X.509 (certificate specification), and Secure Hash Algorithm (SHA) and MD5 hash algorithms.
-
-The manner in which the Authenticode technology validates a certificate and determines what is considered a valid certificate can be modified to meet the mission of the Microsoft Windows system.  Each facade of certificate validation is controlled through the bits that makeup the hexadecimal value for the Authenticode setting.  An improper setting will allow non-valid certificates to be accepted and can put the integrity of the system into jeopardy.
-
-The hexadecimal value of 0x23C00 will implement the following certificate enforcement policy:
-- Trust the Test Root = FALSE
-- Use expiration date on certificates = TRUE
-- Check the revocation list = TRUE
-- Offline revocation server OK (Individual) = TRUE
-- Offline revocation server OK (Commercial) = TRUE
-- Java offline revocation server OK (Individual) = TRUE
-- Java offline revocation server OK (Commercial) = TRUE
-- Invalidate version 1 signed objects = FALSE
-- Check the revocation list on Time Stamp Signer = FALSE
-- Only trust items found in the Trust DB = FALSE&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Microsoft DotNet Framework 4-0</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Microsoft DotNet Framework 4-0</dc:subject>
-            <dc:identifier>4213</dc:identifier>
-          </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/legacy">SV-7444</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">V-7061</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:fixtext fixref="F-26911r467988_fix">This fix must be performed for each user on the system.
-
-Using regedit, change the hexadecimal value of the "HKEY_USER\[UNIQUE USER SID VALUE]\Software\Microsoft\Windows\CurrentVersion\WinTrust\Trust Providers\Software Publishing\State" registry key to 0x23C00.</xccdf:fixtext>
-          <xccdf:fix id="F-26911r467988_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.dotnet:def:15" href="U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.dotnet:def:2" href="U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -216,26 +166,26 @@ Using regedit, change the hexadecimal value of the "HKEY_USER\[UNIQUE USER SID V
           <xccdf:version update="http://iase.disa.mil/stigs">APPNET0062</xccdf:version>
           <xccdf:title>The .NET CLR must be configured to use FIPS approved encryption modules.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;FIPS encryption is configured via .NET configuration files.  There are numerous configuration files that affect different aspects of .Net behavior.  The .NET config files are described below.
- 
+
 Machine Configuration Files:
 The machine configuration file, Machine.config, contains settings that apply to an entire computer. This file is located in the %SYSTEMROOT%\Microsoft.NET\Framework\v4.0.30319\Config directory for 32 bit .NET 4 installations and %SYSTEMROOT%\Microsoft.NET\Framework64\v4.0.30319\Config for 64 bit systems.   Machine.config contains configuration settings for machine-wide assembly binding, built-in remoting channels, and ASP.NET.
 
 Application Configuration Files:
-Application configuration files contain settings specific to an application. If checking these files, a .NET review of a specific .NET application is most likely being conducted. These files contain configuration settings that the Common Language Runtime reads (such as assembly binding policy, remoting objects, and so on), and settings that the application can read. 
+Application configuration files contain settings specific to an application. If checking these files, a .NET review of a specific .NET application is most likely being conducted. These files contain configuration settings that the Common Language Runtime reads (such as assembly binding policy, remoting objects, and so on), and settings that the application can read.
 
-The name and location of the application configuration file depends on the application's host, which can be one of the following: 
+The name and location of the application configuration file depends on the application's host, which can be one of the following:
 
-Executable–hosted application configuration files. 
+Executable–hosted application configuration files.
 
-The configuration file for an application hosted by the executable host is in the same directory as the application. The name of the configuration file is the name of the application with a .config extension. For example, an application called myApp.exe can be associated with a configuration file called myApp.exe.config. 
+The configuration file for an application hosted by the executable host is in the same directory as the application. The name of the configuration file is the name of the application with a .config extension. For example, an application called myApp.exe can be associated with a configuration file called myApp.exe.config.
 
-Internet Explorer-hosted application configuration files. 
+Internet Explorer-hosted application configuration files.
 
 If an application hosted in Internet Explorer has a configuration file, the location of this file is specified in a &lt;link&gt; tag with the following syntax.
 
 &lt;link rel="ConfigurationFileName" href="location"&gt;
 
-In this tag, "location" represents a URL that point to the configuration file. This sets the application base. The configuration file must be located on the same web site as the application. 
+In this tag, "location" represents a URL that point to the configuration file. This sets the application base. The configuration file must be located on the same web site as the application.
 
 .NET 4.0 allows the CLR runtime to be configured to ignore FIPS encryption requirements.  If the CLR is not configured to use FIPS encryption modules, insecure encryption modules might be employed which could introduce an application confidentiality or integrity issue.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -251,8 +201,8 @@ In this tag, "location" represents a URL that point to the configuration file. T
           <xccdf:fixtext fixref="F-26917r468006_fix">Examine the .NET CLR configuration files to find the runtime element and then the "enforceFIPSPolicy" element.
 
 Example:
-&lt;configuration&gt; 
-  &lt;runtime&gt; 
+&lt;configuration&gt;
+  &lt;runtime&gt;
                 &lt;enforceFIPSPolicy enabled="true|false" /&gt;
   &lt;/runtime&gt;
 &lt;/configuration&gt;
@@ -260,7 +210,7 @@ Example:
 Delete the "enforceFIPSPolicy" runtime element, change the setting to "true" or there must be documented IAO approvals for the FIPS setting.</xccdf:fixtext>
           <xccdf:fix id="F-26917r468006_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.dotnet:def:9" href="U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.dotnet:def:9" href="U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -270,7 +220,7 @@ Delete the "enforceFIPSPolicy" runtime element, change the setting to "true" or 
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225235r615940_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">APPNET0067</xccdf:version>
           <xccdf:title>Event tracing for Windows (ETW) for Common Language Runtime events must be enabled.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Event tracing captures information about applications utilizing the .NET CLR and the .NET CLR itself. This includes security oriented information, such as Strong Name and Authenticode verification.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Event tracing captures information about applications utilizing the .NET CLR and the .NET CLR itself. This includes security oriented information, such as Strong Name and Authenticode verification.
 
 Beginning with Windows Vista, ETW is enabled by default however, the .Net CLR and .Net applications can be configured to not utilize Event Tracing. If ETW event tracing is disabled, critical events that occurred within the runtime will not be captured in event logs.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -285,13 +235,13 @@ Beginning with Windows Vista, ETW is enabled by default however, the .Net CLR an
           <xccdf:ident system="http://cyber.mil/cci">CCI-000130</xccdf:ident>
           <xccdf:fixtext fixref="F-26922r468021_fix">Open Windows explorer and search for all .NET config files including application config files (*.exe.config).
 
-Examine the configuration settings for 
+Examine the configuration settings for
 &lt;etwEnable enabled="false" /&gt;.
 
 Enable ETW Tracing by setting the etwEnable flag to "true" or obtain documented IAO approvals.</xccdf:fixtext>
           <xccdf:fix id="F-26922r468021_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.dotnet:def:12" href="U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.dotnet:def:12" href="U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -317,7 +267,7 @@ Enable ETW Tracing by setting the etwEnable flag to "true" or obtain documented 
 For 32-bit systems:
 HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\v4.0.30319\
 
-For 64-bit systems: 
+For 64-bit systems:
 HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\v4.0.30319\
 HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319\
 
@@ -326,18 +276,18 @@ Modify or create the following Windows registry value: SchUseStrongCrypto
 Set SchUseStrongCrypto to a REG_DWORD value of “1”.</xccdf:fixtext>
           <xccdf:fix id="F-26925r612667_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.dotnet:def:16" href="U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.dotnet:def:16" href="U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
     </xccdf:Benchmark>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2021-01-04T23:44:55">
+  <component id="scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2022-12-30T20:19:59">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2021-01-04T23:44:55</oval:timestamp>
+        <oval:timestamp>2022-12-30T20:19:59</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.dotnet:def:2" version="1" class="compliance">
@@ -389,23 +339,6 @@ Set SchUseStrongCrypto to a REG_DWORD value of “1”.</xccdf:fixtext>
             <criterion test_ref="oval:mil.disa.fso.dotnet:tst:1201" comment="Verifies Event tracing for Windows (ETW) for Common Language Runtime events is enabled for machine configiguration files" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.dotnet:def:15" version="1" class="compliance">
-          <metadata>
-            <title>APPNET0046 The Trust Providers Software Publishing State must be set to 0x23c00</title>
-            <affected family="windows">
-              <platform>Microsoft Windows XP</platform>
-              <platform>Microsoft Windows Server 2003</platform>
-              <platform>Microsoft Windows Vista</platform>
-              <platform>Microsoft Windows Server 2008</platform>
-              <platform>Microsoft Windows Server 2008 R2</platform>
-              <platform>Microsoft Windows 7</platform>
-            </affected>
-            <description>The Trust Providers Software Publishing State must be set to 0x23c00 (SCC-only check)</description>
-          </metadata>
-          <criteria>
-            <criterion comment="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\WinTrust\Trust Providers\Software Publishing\State == 0x23c00" test_ref="oval:mil.disa.fso.dotnet:tst:1500" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.fso.dotnet:def:16" version="1" class="compliance">
           <metadata>
             <title>Disable TLS RC4 cipher in .Net</title>
@@ -447,10 +380,6 @@ Set SchUseStrongCrypto to a REG_DWORD value of “1”.</xccdf:fixtext>
           <object object_ref="oval:mil.disa.fso.dotnet:obj:1201" />
           <state state_ref="oval:mil.disa.fso.dotnet:ste:1200" />
         </xmlfilecontent_test>
-        <windows-def:registry_test xmlns:windows-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.dotnet:tst:1500" version="1" comment="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\WinTrust\Trust Providers\Software Publishing\State == 0x23c00" check_existence="any_exist" check="all">
-          <windows-def:object object_ref="oval:mil.disa.fso.dotnet:obj:300" />
-          <windows-def:state state_ref="oval:mil.disa.fso.dotnet:ste:1500" />
-        </windows-def:registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.dotnet:tst:1600" version="1" check="all" comment="SchUseStrongCrypto key for applications that match the bitness of the system" check_existence="at_least_one_exists">
           <object object_ref="oval:mil.disa.fso.dotnet:obj:1600" />
           <state state_ref="oval:mil.disa.fso.dotnet:ste:1600" />
@@ -470,11 +399,6 @@ Set SchUseStrongCrypto to a REG_DWORD value of “1”.</xccdf:fixtext>
           <windows-def:hive datatype="string">HKEY_LOCAL_MACHINE</windows-def:hive>
           <windows-def:key datatype="string">SOFTWARE\Microsoft\StrongName\Verification</windows-def:key>
           <windows-def:name datatype="string" operation="pattern match">.*</windows-def:name>
-        </windows-def:registry_object>
-        <windows-def:registry_object xmlns:windows-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.dotnet:obj:300" version="1">
-          <windows-def:hive datatype="string">HKEY_CURRENT_USER</windows-def:hive>
-          <windows-def:key datatype="string">Software\Microsoft\Windows\CurrentVersion\WinTrust\Trust Providers\Software Publishing</windows-def:key>
-          <windows-def:name datatype="string">State</windows-def:name>
         </windows-def:registry_object>
         <xmlfilecontent_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.fso.dotnet:obj:900" version="4" comment="*.exe.config enforceFIPSPolicy/@enabled">
           <filepath datatype="string" operation="equals" var_check="at least one" var_ref="oval:mil.disa.fso.dotnet:var:903" />
@@ -564,10 +488,6 @@ Set SchUseStrongCrypto to a REG_DWORD value of “1”.</xccdf:fixtext>
         <xmlfilecontent_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.fso.dotnet:ste:1200" version="2" comment="etwEnable/@enabled = true">
           <value_of datatype="boolean" operation="equals">true</value_of>
         </xmlfilecontent_state>
-        <windows-def:registry_state xmlns:windows-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.dotnet:ste:1500" version="1" comment="0x23c00 (reg_dword)">
-          <windows-def:type>reg_dword</windows-def:type>
-          <windows-def:value datatype="int" operation="equals">146432</windows-def:value>
-        </windows-def:registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.dotnet:ste:1600" version="1" comment="reg_dword value set to 1">
           <type datatype="string" operation="equals">reg_dword</type>
           <value datatype="int" operation="equals">1</value>
@@ -616,12 +536,12 @@ Set SchUseStrongCrypto to a REG_DWORD value of “1”.</xccdf:fixtext>
       </variables>
     </oval_definitions>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R1_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2021-01-04T23:44:55">
+  <component id="scap_mil.disa.stig_comp_U_MS_DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2022-12-30T20:19:59">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2021-01-04T23:44:55</oval:timestamp>
+        <oval:timestamp>2022-12-30T20:19:59</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.dotnet:def:1" version="2" class="inventory">
@@ -676,4 +596,3 @@ Set SchUseStrongCrypto to a REG_DWORD value of “1”.</xccdf:fixtext>
     </oval_definitions>
   </component>
 </data-stream-collection>
-

--- a/scap/content/guides/disa/stig-el7-scap_1-2.xml
+++ b/scap/content/guides/disa/stig-el7-scap_1-2.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#unix http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/unix-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
-  <data-stream id="scap_mil.disa.stig_datastream_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2022-06-28T15:26:15">
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#unix http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/unix-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
+  <data-stream id="scap_mil.disa.stig_datastream_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2023-03-28T17:40:59">
     <dictionaries>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+          <cat:uri name="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
         </cat:catalog>
       </component-ref>
     </dictionaries>
     <checklists>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-xccdf.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-xccdf.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          <cat:uri name="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
         </cat:catalog>
       </component-ref>
     </checklists>
     <checks>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
     </checks>
   </data-stream>
-  <component id="scap_mil.disa.stig_comp_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2022-06-28T15:26:15">
+  <component id="scap_mil.disa.stig_comp_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2023-03-28T17:40:59">
     <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0">
       <cpe-item name="cpe:/o:redhat:enterprise_linux:7">
         <title xml:lang="en-us">Red Hat Enterprise Linux 7</title>
         <!-- the check references an OVAL file that contains an inventory definition -->
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.rhel7:def:1</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.rhel7:def:1</check>
       </cpe-item>
     </cpe-list>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2022-06-28T15:26:15">
+  <component id="scap_mil.disa.stig_comp_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2023-03-28T17:40:59">
     <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_RHEL_7_STIG" xml:lang="en" style="SCAP_1.2">
-      <xccdf:status date="2022-06-06">accepted</xccdf:status>
-      <xccdf:title>Red Hat Enterprise Linux 7 Security Technical Implementation Guide</xccdf:title>
-      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
+      <xccdf:status date="2023-03-08">accepted</xccdf:status>
+      <xccdf:title>Red Hat Enterprise Linux 7 STIG SCAP Benchmark</xccdf:title>
+      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
       <xccdf:notice id="terms-of-use" xml:lang="en" />
       <xccdf:front-matter xml:lang="en" />
       <xccdf:rear-matter xml:lang="en" />
@@ -41,11 +41,11 @@
         <dc:publisher>DISA</dc:publisher>
         <dc:source>STIG.DOD.MIL</dc:source>
       </xccdf:reference>
-      <xccdf:plain-text id="release-info">Release: 3.8 Benchmark Date: 27 Jul 2022</xccdf:plain-text>
-      <xccdf:plain-text id="generator">3.3.0.27375</xccdf:plain-text>
+      <xccdf:plain-text id="release-info">Release: 3.11 Benchmark Date: 27 Apr 2023</xccdf:plain-text>
+      <xccdf:plain-text id="generator">3.4.0.34222</xccdf:plain-text>
       <xccdf:plain-text id="conventionsVersion">1.10.0</xccdf:plain-text>
       <xccdf:platform idref="cpe:/o:redhat:enterprise_linux:7" />
-      <xccdf:version update="http://iase.disa.mil/stigs">003.008</xccdf:version>
+      <xccdf:version update="http://iase.disa.mil/stigs">003.011</xccdf:version>
       <xccdf:metadata>
         <dc:creator>DISA</dc:creator>
         <dc:publisher>DISA</dc:publisher>
@@ -1532,15 +1532,15 @@
         <xccdf:title>CAT I Only</xccdf:title>
         <xccdf:description>This profile only includes rules that are Severity Category I.</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204393r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204396r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204397r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204398r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204399r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204402r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204403r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204404r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204396r880746_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204397r853879_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204398r880770_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204399r880773_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204402r880782_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204403r880785_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204404r880788_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204405r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204406r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204406r902704_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204407r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204408r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204409r603261_rule" selected="false" />
@@ -1549,27 +1549,27 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204412r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204413r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204414r809186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204415r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204416r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204417r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204415r880833_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204416r877397_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204417r877397_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204418r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204419r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204420r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204421r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204422r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204422r880836_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204423r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204426r809190_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204429r833190_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204430r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204429r861003_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204430r853885_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204431r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204434r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204435r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204434r877377_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204435r877377_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204437r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204445r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204449r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204450r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204451r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204452r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204445r902698_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204449r853891_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204450r853892_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204451r853893_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204452r853894_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204457r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204461r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204466r603261_rule" selected="false" />
@@ -1584,92 +1584,92 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204495r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204496r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204503r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204504r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204506r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204507r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204508r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204509r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204510r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204511r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204512r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204514r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204515r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204516r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204504r880761_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204506r877390_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204507r877390_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204508r877390_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204509r877390_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204510r877390_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204511r877390_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204512r877390_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204514r877389_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204515r877389_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204516r853914_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204517r809570_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204521r809772_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204524r809775_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204531r809815_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204536r833109_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204537r833112_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204538r833115_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204539r833118_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204540r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204541r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204542r833121_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204543r833124_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204544r833127_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204545r833130_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204546r833133_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204547r833136_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204548r833139_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204549r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204550r833142_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204551r833145_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204552r833148_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204553r833151_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204554r833154_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204555r833157_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204556r833160_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204557r833163_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204531r853917_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204536r861014_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204537r861017_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204538r861020_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204539r861023_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204540r853930_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204541r853931_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204542r861026_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204543r861029_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204544r861032_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204545r861035_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204546r861038_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204547r861041_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204548r861044_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204549r853953_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204550r861047_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204551r861050_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204552r861053_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204553r861056_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204554r861059_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204555r861062_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204556r861065_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204557r861068_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204558r833166_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204559r833169_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204560r833172_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204562r833175_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204563r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204564r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204565r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204566r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204567r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204568r744115_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204572r809825_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204576r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204578r744116_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204579r646844_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204584r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204585r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204587r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204563r858498_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204564r853978_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204565r853979_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204566r853980_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204567r853981_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204568r853982_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204572r853985_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204576r877399_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204578r877398_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204579r861070_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204584r880794_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204585r853989_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204587r861072_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204588r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204589r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204589r853992_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204590r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204591r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204591r858477_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204592r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204593r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204595r744117_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204595r877394_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204596r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204597r792834_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204598r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204599r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204597r880743_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204598r853993_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204599r853994_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204600r603261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204601r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204602r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204605r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204609r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204612r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204613r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204614r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204615r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204616r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204617r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204602r880758_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204605r858478_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204609r880797_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204612r880806_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204613r880809_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204614r880812_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204615r880815_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204616r880818_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204617r880821_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204622r603849_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204624r646847_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204625r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204630r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204631r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204632r603261_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204633r603261_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204625r880824_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204630r880827_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204631r853997_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204632r853998_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-204633r853999_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237633r646850_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237634r833177_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237635r833179_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237634r880755_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237635r861075_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Value id="xccdf_mil.disa.stig_value_var_password_pam_unix_remember" operator="equals" type="number">
         <xccdf:title xml:lang="en-US">remember</xccdf:title>
@@ -1804,17 +1804,6 @@ password</xccdf:description>
         <xccdf:value selector="120">120</xccdf:value>
         <xccdf:value selector="180">180</xccdf:value>
       </xccdf:Value>
-      <xccdf:Value id="xccdf_mil.disa.stig_value_var_accounts_max_concurrent_login_sessions" operator="equals" type="number">
-        <xccdf:title xml:lang="en-US">Maximum concurrent login sessions</xccdf:title>
-        <xccdf:description xml:lang="en-US">Maximum number of concurrent sessions by a user</xccdf:description>
-        <xccdf:value>10</xccdf:value>
-        <xccdf:value selector="1">1</xccdf:value>
-        <xccdf:value selector="3">3</xccdf:value>
-        <xccdf:value selector="5">5</xccdf:value>
-        <xccdf:value selector="10">10</xccdf:value>
-        <xccdf:value selector="15">15</xccdf:value>
-        <xccdf:value selector="20">20</xccdf:value>
-      </xccdf:Value>
       <xccdf:Value id="xccdf_mil.disa.stig_value_var_accounts_fail_delay" operator="equals" type="number">
         <xccdf:title xml:lang="en-US">Maximum login attempts delay</xccdf:title>
         <xccdf:description xml:lang="en-US">Maximum time in seconds between fail login attempts before re-prompting.</xccdf:description>
@@ -1948,14 +1937,14 @@ Update the system databases:
 Users must log out and back in again before the system-wide settings take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4517r88372_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:922" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:922" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204396">
         <xccdf:title>SRG-OS-000028-GPOS-00009</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204396r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204396r880746_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010060</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must enable a user session lock until that user re-establishes access using established identification and authentication procedures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
@@ -1976,32 +1965,32 @@ Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000030-GPOS-00011&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-86515</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-71891</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000056</xccdf:ident>
-          <xccdf:fixtext fixref="F-4520r88381_fix">Configure the operating system to enable a user's session lock until that user re-establishes access using established identification and authentication procedures.
+          <xccdf:fixtext fixref="F-4520r880745_fix">Configure the operating system to enable a user's session lock until that user re-establishes access using established identification and authentication procedures.
 
 Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following example:
 
-# touch /etc/dconf/db/local.d/00-screensaver
+     # touch /etc/dconf/db/local.d/00-screensaver
 
 Edit the "[org/gnome/desktop/screensaver]" section of the database file and add or update the following lines:
 
-# Set this to true to lock the screen when the screensaver activates
-lock-enabled=true
+     # Set this to true to lock the screen when the screensaver activates
+     lock-enabled=true
 
 Update the system databases:
 
-# dconf update
+     # dconf update
 
 Users must log out and back in again before the system-wide settings take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4520r88381_fix" />
+          <xccdf:fix id="F-4520r880745_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:988" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:988" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204397">
         <xccdf:title>SRG-OS-000375-GPOS-00160</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204397r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204397r853879_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010061</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must uniquely identify and must authenticate users using multifactor authentication via a graphical user logon.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To assure accountability and prevent unauthenticated access, users must be identified and authenticated to prevent potential misuse and compromise of the system.
@@ -2038,14 +2027,14 @@ Update the system databases:
 # dconf update</xccdf:fixtext>
           <xccdf:fix id="F-4521r88384_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:92515" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:92515" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204398">
         <xccdf:title>SRG-OS-000029-GPOS-00010</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204398r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204398r880770_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010070</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must initiate a screensaver after a 15-minute period of inactivity for graphical user interfaces.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A session time-out lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not log out because of the temporary nature of the absence. Rather than relying on the user to manually lock their operating system session prior to vacating the vicinity, operating systems need to be able to identify when a user's session has idled and take action to initiate the session lock.
@@ -2062,36 +2051,36 @@ The session lock is implemented at the point where session activity can be deter
           <xccdf:ident system="http://cyber.mil/legacy">V-71893</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86517</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
-          <xccdf:fixtext fixref="F-4522r88387_fix">Configure the operating system to initiate a screensaver after a 15-minute period of inactivity for graphical user interfaces.
+          <xccdf:fixtext fixref="F-4522r880769_fix">Configure the operating system to initiate a screensaver after a 15-minute period of inactivity for graphical user interfaces.
 
 Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command:
 
-# touch /etc/dconf/db/local.d/00-screensaver
+     # touch /etc/dconf/db/local.d/00-screensaver
 
 Edit /etc/dconf/db/local.d/00-screensaver and add or update the following lines:
 
-[org/gnome/desktop/session]
-# Set the lock time out to 900 seconds before the session is considered idle
-idle-delay=uint32 900
+     [org/gnome/desktop/session]
+     # Set the lock time out to 900 seconds before the session is considered idle
+     idle-delay=uint32 900
 
 You must include the "uint32" along with the integer key values as shown.
 
 Update the system databases:
 
-# dconf update
+     # dconf update
 
 Users must log out and back in again before the system-wide settings take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4522r88387_fix" />
+          <xccdf:fix id="F-4522r880769_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3828" value-id="xccdf_mil.disa.stig_value_inactivity_timeout_value" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:981" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:981" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204399">
         <xccdf:title>SRG-OS-000029-GPOS-00010</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204399r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204399r880773_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010081</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must prevent a user from overriding the screensaver lock-delay setting for the graphical user interface.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A session time-out lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not log out because of the temporary nature of the absence. Rather than relying on the user to manually lock their operating system session prior to vacating the vicinity, operating systems need to be able to identify when a user's session has idled and take action to initiate the session lock.
@@ -2108,27 +2097,27 @@ The session lock is implemented at the point where session activity can be deter
           <xccdf:ident system="http://cyber.mil/legacy">V-73155</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-87807</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
-          <xccdf:fixtext fixref="F-4523r88390_fix">Configure the operating system to prevent a user from overriding a screensaver lock after a 15-minute period of inactivity for graphical user interfaces.
+          <xccdf:fixtext fixref="F-4523r880772_fix">Configure the operating system to prevent a user from overriding a screensaver lock after a 15-minute period of inactivity for graphical user interfaces.
 
 Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command: 
 
 Note: The example below is using the database "local" for the system, so if the system is using another database in "/etc/dconf/profile/user", the file should be created under the appropriate subdirectory.
 
-# touch /etc/dconf/db/local.d/locks/session
+     # touch /etc/dconf/db/local.d/locks/session
 
 Add the setting to lock the screensaver lock delay:
 
-/org/gnome/desktop/screensaver/lock-delay</xccdf:fixtext>
-          <xccdf:fix id="F-4523r88390_fix" />
+     /org/gnome/desktop/screensaver/lock-delay</xccdf:fixtext>
+          <xccdf:fix id="F-4523r880772_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:999" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:999" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204402">
         <xccdf:title>SRG-OS-000029-GPOS-00010</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204402r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204402r880782_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010100</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must initiate a session lock for the screensaver after a period of inactivity for graphical user interfaces.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A session time-out lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not log out because of the temporary nature of the absence. Rather than relying on the user to manually lock their operating system session prior to vacating the vicinity, operating systems need to be able to identify when a user's session has idled and take action to initiate the session lock.
@@ -2145,33 +2134,33 @@ The session lock is implemented at the point where session activity can be deter
           <xccdf:ident system="http://cyber.mil/legacy">V-71899</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86523</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
-          <xccdf:fixtext fixref="F-4526r88399_fix">Configure the operating system to initiate a session lock after a 15-minute period of inactivity for graphical user interfaces.
+          <xccdf:fixtext fixref="F-4526r880781_fix">Configure the operating system to initiate a session lock after a 15-minute period of inactivity for graphical user interfaces.
 
 Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command: 
 
-# touch /etc/dconf/db/local.d/00-screensaver
+     # touch /etc/dconf/db/local.d/00-screensaver
 
 Add the setting to enable screensaver locking after 15 minutes of inactivity:
 
-[org/gnome/desktop/screensaver]
+     [org/gnome/desktop/screensaver]
 
-idle-activation-enabled=true
+     idle-activation-enabled=true
 
 Update the system databases:
 
-# dconf update
+     # dconf update
 
 Users must log out and back in again before the system-wide settings take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4526r88399_fix" />
+          <xccdf:fix id="F-4526r880781_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:978" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:978" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204403">
         <xccdf:title>SRG-OS-000029-GPOS-00010</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204403r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204403r880785_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010101</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must prevent a user from overriding the screensaver idle-activation-enabled setting for the graphical user interface.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
@@ -2189,27 +2178,27 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <xccdf:ident system="http://cyber.mil/legacy">V-78997</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-93703</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
-          <xccdf:fixtext fixref="F-4527r88402_fix">Configure the operating system to prevent a user from overriding a screensaver lock after a 15-minute period of inactivity for graphical user interfaces.
+          <xccdf:fixtext fixref="F-4527r880784_fix">Configure the operating system to prevent a user from overriding a screensaver lock after a 15-minute period of inactivity for graphical user interfaces.
 
 Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command: 
 
 Note: The example below is using the database "local" for the system, so if the system is using another database in "/etc/dconf/profile/user", the file should be created under the appropriate subdirectory.
 
-# touch /etc/dconf/db/local.d/locks/session
+     # touch /etc/dconf/db/local.d/locks/session
 
 Add the setting to lock the screensaver idle-activation-enabled setting:
 
-/org/gnome/desktop/screensaver/idle-activation-enabled</xccdf:fixtext>
-          <xccdf:fix id="F-4527r88402_fix" />
+     /org/gnome/desktop/screensaver/idle-activation-enabled</xccdf:fixtext>
+          <xccdf:fix id="F-4527r880784_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:93703" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:93703" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204404">
         <xccdf:title>SRG-OS-000029-GPOS-00010</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204404r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204404r880788_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010110</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must initiate a session lock for graphical user interfaces when the screensaver is activated.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A session time-out lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not log out because of the temporary nature of the absence. Rather than relying on the user to manually lock their operating system session prior to vacating the vicinity, operating systems need to be able to identify when a user's session has idled and take action to initiate the session lock.
@@ -2226,27 +2215,27 @@ The session lock is implemented at the point where session activity can be deter
           <xccdf:ident system="http://cyber.mil/legacy">V-71901</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86525</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
-          <xccdf:fixtext fixref="F-4528r88405_fix">Configure the operating system to initiate a session lock for graphical user interfaces when a screensaver is activated.
+          <xccdf:fixtext fixref="F-4528r880787_fix">Configure the operating system to initiate a session lock for graphical user interfaces when a screensaver is activated.
 
 Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command: 
 
-# touch /etc/dconf/db/local.d/00-screensaver
+     # touch /etc/dconf/db/local.d/00-screensaver
 
 Add the setting to enable session locking when a screensaver is activated:
 
-[org/gnome/desktop/screensaver]
-lock-delay=uint32 5
+     [org/gnome/desktop/screensaver]
+     lock-delay=uint32 5
 
 The "uint32" must be included along with the integer key values as shown.
 
 Update the system databases:
 
-# dconf update
+     # dconf update
 
 Users must log out and back in again before the system-wide settings take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4528r88405_fix" />
+          <xccdf:fix id="F-4528r880787_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:985" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:985" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2274,14 +2263,14 @@ Add the following line to "/etc/pam.d/passwd" (or modify the line to have the re
 password     substack    system-auth</xccdf:fixtext>
           <xccdf:fix id="F-4529r88408_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95715" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95715" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204406">
         <xccdf:title>SRG-OS-000069-GPOS-00037</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204406r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204406r902704_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010119</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that when passwords are changed or new passwords are established, pwquality must be used.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2292,20 +2281,19 @@ password     substack    system-auth</xccdf:fixtext>
             <dc:subject>Red Hat Enterprise Linux 7</dc:subject>
             <dc:identifier>2899</dc:identifier>
           </xccdf:reference>
-          <xccdf:ident system="http://cce.mitre.org">CCE-27160-1</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-87811</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-73159</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000192</xccdf:ident>
-          <xccdf:fixtext fixref="F-4530r88411_fix">Configure the operating system to use "pwquality" to enforce password complexity rules.
+          <xccdf:fixtext fixref="F-4530r902703_fix">Configure the operating system to use "pwquality" to enforce password complexity rules.
 
 Add the following line to "/etc/pam.d/system-auth" (or modify the line to have the required value):
 
-password required pam_pwquality.so retry=3
+     password requisite pam_pwquality.so retry=3
 
 Note: The value of "retry" should be between "1" and "3".</xccdf:fixtext>
-          <xccdf:fix id="F-4530r88411_fix" />
+          <xccdf:fix id="F-4530r902703_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:481" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7os:def:204406" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2337,7 +2325,7 @@ ucredit = -1</xccdf:fixtext>
           <xccdf:fix id="F-4531r88414_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3805" value-id="xccdf_mil.disa.stig_value_var_password_pam_ucredit" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:484" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:484" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2370,7 +2358,7 @@ lcredit = -1</xccdf:fixtext>
           <xccdf:fix id="F-4532r88417_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3798" value-id="xccdf_mil.disa.stig_value_var_password_pam_lcredit" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:468" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:468" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2402,7 +2390,7 @@ dcredit = -1</xccdf:fixtext>
           <xccdf:fix id="F-4533r88420_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3796" value-id="xccdf_mil.disa.stig_value_var_password_pam_dcredit" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:463" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:463" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2434,7 +2422,7 @@ ocredit = -1</xccdf:fixtext>
           <xccdf:fix id="F-4534r88423_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3803" value-id="xccdf_mil.disa.stig_value_var_password_pam_ocredit" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:478" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:478" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2466,7 +2454,7 @@ difok = 8</xccdf:fixtext>
           <xccdf:fix id="F-4535r88426_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3797" value-id="xccdf_mil.disa.stig_value_var_password_pam_difok" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:466" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:466" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2498,7 +2486,7 @@ minclass = 4</xccdf:fixtext>
           <xccdf:fix id="F-4536r88429_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3801" value-id="xccdf_mil.disa.stig_value_var_password_pam_minclass" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:474" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:474" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2530,7 +2518,7 @@ maxrepeat = 3</xccdf:fixtext>
           <xccdf:fix id="F-4537r88432_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3800" value-id="xccdf_mil.disa.stig_value_var_password_pam_maxrepeat" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:472" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:472" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2562,14 +2550,14 @@ maxclassrepeat = 4</xccdf:fixtext>
           <xccdf:fix id="F-4538r88435_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3799" value-id="xccdf_mil.disa.stig_value_var_password_pam_maxclassrepeat" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:470" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:470" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204415">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204415r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204415r880833_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010200</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the PAM system service is configured to store only encrypted representations of passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised. Passwords encrypted with a weak algorithm are no more protected than if they are kept in plain text.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2584,25 +2572,25 @@ maxclassrepeat = 4</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">V-71919</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86543</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000196</xccdf:ident>
-          <xccdf:fixtext fixref="F-4539r88438_fix">Configure the operating system to store only SHA512 encrypted representations of passwords.
+          <xccdf:fixtext fixref="F-4539r880832_fix">Configure the operating system to store only SHA512 encrypted representations of passwords.
 
 Add the following line in "/etc/pam.d/system-auth":
-pam_unix.so sha512 shadow try_first_pass use_authtok
+     pam_unix.so sha512 shadow try_first_pass use_authtok
 
 Add the following line in "/etc/pam.d/password-auth":
-pam_unix.so sha512 shadow try_first_pass use_authtok
+     pam_unix.so sha512 shadow try_first_pass use_authtok
 
-Note: Manual changes to the listed files may be overwritten by the "authconfig" program. The "authconfig" program should not be used to update the configurations listed in this requirement.</xccdf:fixtext>
-          <xccdf:fix id="F-4539r88438_fix" />
+Note: Per requirement RHEL-07-010199, RHEL 7 must be configured to not overwrite custom authentication configuration settings while using the authconfig utility, otherwise manual changes to the listed files will be overwritten whenever the authconfig utility is used.</xccdf:fixtext>
+          <xccdf:fix id="F-4539r880832_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1367" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1367" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204416">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204416r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204416r877397_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010210</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured to use the shadow file to store only encrypted representations of passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised. Passwords encrypted with a weak algorithm are no more protected than if they are kept in plain text.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2624,14 +2612,14 @@ Add or update the following line in "/etc/login.defs":
 ENCRYPT_METHOD SHA512</xccdf:fixtext>
           <xccdf:fix id="F-4540r88441_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1365" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1365" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204417">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204417r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204417r877397_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010220</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that user and group account administration utilities are configured to store only encrypted representations of passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised. Passwords encrypted with a weak algorithm are no more protected than if they are kept in plain text.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2653,7 +2641,7 @@ Add or update the following line in "/etc/libuser.conf" in the [defaults] sectio
 crypt_style = sha512</xccdf:fixtext>
           <xccdf:fix id="F-4541r88444_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1363" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1363" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2683,7 +2671,7 @@ PASS_MIN_DAYS     1</xccdf:fixtext>
           <xccdf:fix id="F-4542r88447_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3794" value-id="xccdf_mil.disa.stig_value_var_accounts_minimum_age_login_defs" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:455" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:455" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2709,7 +2697,7 @@ PASS_MIN_DAYS     1</xccdf:fixtext>
 # chage -m 1 [user]</xccdf:fixtext>
           <xccdf:fix id="F-4543r88450_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86551" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86551" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2739,7 +2727,7 @@ PASS_MAX_DAYS     60</xccdf:fixtext>
           <xccdf:fix id="F-4544r88453_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3793" value-id="xccdf_mil.disa.stig_value_var_accounts_maximum_age_login_defs" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:453" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:453" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2765,14 +2753,14 @@ PASS_MAX_DAYS     60</xccdf:fixtext>
 # chage -M 60 [user]</xccdf:fixtext>
           <xccdf:fix id="F-4545r88456_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86555" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86555" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204422">
         <xccdf:title>SRG-OS-000077-GPOS-00045</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204422r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204422r880836_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010270</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that passwords are prohibited from reuse for a minimum of five generations.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. If the information system or application allows the user to consecutively reuse their password when that password has exceeded its defined lifetime, the end result is a password that is not changed per policy requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2787,17 +2775,17 @@ PASS_MAX_DAYS     60</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">V-71933</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86557</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000200</xccdf:ident>
-          <xccdf:fixtext fixref="F-4546r88459_fix">Configure the operating system to prohibit password reuse for a minimum of five generations.
+          <xccdf:fixtext fixref="F-4546r880835_fix">Configure the operating system to prohibit password reuse for a minimum of five generations.
 
 Add the following line in "/etc/pam.d/system-auth" and "/etc/pam.d/password-auth" (or modify the line to have the required value):
 
-password    requisite     pam_pwhistory.so use_authtok remember=5 retry=3
+     password     requisite     pam_pwhistory.so use_authtok remember=5 retry=3
    
-Note: Manual changes to the listed files may be overwritten by the "authconfig" program. The "authconfig" program should not be used to update the configurations listed in this requirement.</xccdf:fixtext>
-          <xccdf:fix id="F-4546r88459_fix" />
+Note: Per requirement RHEL-07-010199, RHEL 7 must be configured to not overwrite custom authentication configuration settings while using the authconfig utility, otherwise manual changes to the listed files will be overwritten whenever the authconfig utility is used.</xccdf:fixtext>
+          <xccdf:fix id="F-4546r880835_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3806" value-id="xccdf_mil.disa.stig_value_var_password_pam_unix_remember" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:486" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:486" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2829,14 +2817,14 @@ minlen = 15</xccdf:fixtext>
           <xccdf:fix id="F-4547r88462_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3802" value-id="xccdf_mil.disa.stig_value_var_password_pam_minlen" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:476" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:476" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204424">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204424r809187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204424r880839_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010290</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not allow accounts configured with blank or null passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If an account has an empty password, anyone could log on and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2851,14 +2839,14 @@ minlen = 15</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">V-71937</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86561</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4548r88465_fix">If an account is configured for password authentication but does not have an assigned password, it may be possible to log on to the account without authenticating.
+          <xccdf:fixtext fixref="F-4548r880838_fix">If an account is configured for password authentication but does not have an assigned password, it may be possible to log on to the account without authenticating.
 
 Remove any instances of the "nullok" option in "/etc/pam.d/system-auth" and "/etc/pam.d/password-auth" to prevent logons with empty passwords.
 
-Note: Manual changes to the listed files may be overwritten by the "authconfig" program. The "authconfig" program should not be used to update the configurations listed in this requirement.</xccdf:fixtext>
-          <xccdf:fix id="F-4548r88465_fix" />
+Note: Per requirement RHEL-07-010199, RHEL 7 must be configured to not overwrite custom authentication configuration settings while using the authconfig utility, otherwise manual changes to the listed files will be overwritten whenever the authconfig utility is used.</xccdf:fixtext>
+          <xccdf:fix id="F-4548r880838_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1229" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1229" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2887,7 +2875,7 @@ PermitEmptyPasswords no
 The SSH service must be restarted for changes to take effect.  Any accounts with empty passwords should be disabled immediately, and PAM configuration should prevent users from being able to assign themselves empty passwords.</xccdf:fixtext>
           <xccdf:fix id="F-4549r88468_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1375" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1375" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2919,14 +2907,14 @@ INACTIVE=35
 DoD recommendation is 35 days, but a lower value is acceptable. The value "-1" will disable this feature, and "0" will disable the account immediately after the password expires.</xccdf:fixtext>
           <xccdf:fix id="F-4550r809189_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:443" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:443" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204429">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204429r833190_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204429r861003_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010340</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that users must provide a password for privilege escalation.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
@@ -2945,7 +2933,7 @@ Satisfies: SRG-OS-000373-GPOS-00156, SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPO
           <xccdf:ident system="http://cyber.mil/legacy">V-71947</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86571</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002038</xccdf:ident>
-          <xccdf:fixtext fixref="F-36303r833189_fix">Configure the operating system to require users to supply a password for privilege escalation.
+          <xccdf:fixtext fixref="F-36303r861002_fix">Configure the operating system to require users to supply a password for privilege escalation.
 
 Check the configuration of the "/etc/sudoers" file with the following command:
 $ sudo visudo
@@ -2956,16 +2944,16 @@ Check the configuration of the /etc/sudoers.d/* files with the following command
 $ sudo grep -ir nopasswd /etc/sudoers.d
 
 Remove any occurrences of "NOPASSWD" tags in the file.</xccdf:fixtext>
-          <xccdf:fix id="F-36303r833189_fix" />
+          <xccdf:fix id="F-36303r861002_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:176" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:176" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204430">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204430r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204430r853885_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010350</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that users must re-authenticate for privilege escalation.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
@@ -2997,7 +2985,7 @@ Check the configuration of the "/etc/sudoers.d/*" files with the following comma
 Remove any occurrences of "!authenticate" tags in the file(s).</xccdf:fixtext>
           <xccdf:fix id="F-4554r88483_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:173" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:173" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3029,14 +3017,14 @@ FAIL_DELAY 4</xccdf:fixtext>
           <xccdf:fix id="F-4555r88486_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3761" value-id="xccdf_mil.disa.stig_value_var_accounts_fail_delay" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:101" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:101" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204432">
         <xccdf:title>SRG-OS-000480-GPOS-00229</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204432r603261_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204432r877377_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010440</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not allow an unattended or automatic logon to the system via a graphical user interface.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Failure to restrict system access to authenticated users negatively impacts operating system security.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3061,14 +3049,14 @@ Add or edit the line for the "AutomaticLoginEnable" parameter in the [daemon] se
 AutomaticLoginEnable=false</xccdf:fixtext>
           <xccdf:fix id="F-4556r88489_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1119" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1119" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204433">
         <xccdf:title>SRG-OS-000480-GPOS-00229</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204433r603261_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204433r877377_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010450</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not allow an unrestricted logon to the system.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Failure to restrict system access to authenticated users negatively impacts operating system security.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3093,14 +3081,14 @@ Add or edit the line for the "TimedLoginEnable" parameter in the [daemon] sectio
 TimedLoginEnable=false</xccdf:fixtext>
           <xccdf:fix id="F-4557r88492_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1122" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1122" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204434">
         <xccdf:title>SRG-OS-000480-GPOS-00229</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204434r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204434r877377_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010460</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not allow users to override SSH environment variables.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Failure to restrict system access to authenticated users negatively impacts operating system security.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3124,14 +3112,14 @@ PermitUserEnvironment no
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4558r88495_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1385" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1385" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204435">
         <xccdf:title>SRG-OS-000480-GPOS-00229</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204435r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204435r877377_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010470</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not allow a non-certificate trusted host SSH logon to the system.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Failure to restrict system access to authenticated users negatively impacts operating system security.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3155,7 +3143,7 @@ HostbasedAuthentication no
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4559r88498_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1011" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1011" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3183,7 +3171,7 @@ Add or modify the "ExecStart" line in "/usr/lib/systemd/system/rescue.service" t
 ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"</xccdf:fixtext>
           <xccdf:fix id="F-4561r88504_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:92519" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:92519" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3214,7 +3202,7 @@ Enter password:
 Confirm password:</xccdf:fixtext>
           <xccdf:fix id="F-4562r744094_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95717" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95717" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3245,7 +3233,7 @@ Enter password:
 Confirm password:</xccdf:fixtext>
           <xccdf:fix id="F-4564r744097_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95719" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95719" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3278,7 +3266,7 @@ If a privileged user were to log on using this service, the privileged user pass
 # yum remove rsh-server</xccdf:fixtext>
           <xccdf:fix id="F-4566r88519_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1271" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1271" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3305,19 +3293,19 @@ If a privileged user were to log on using this service, the privileged user pass
 # yum remove ypserv</xccdf:fixtext>
           <xccdf:fix id="F-4567r88522_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1309" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1309" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204445">
         <xccdf:title>SRG-OS-000363-GPOS-00150</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204445r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204445r902698_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-020030</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that a file integrity tool verifies the baseline operating system configuration at least weekly.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unauthorized changes to the baseline configuration could make the system vulnerable to various attacks or allow unauthorized access to the operating system. Changes to operating system configurations can have unintended side effects, some of which may be relevant to security.
 
-Detecting such changes and providing an automated response can help avoid unintended, negative consequences that could ultimately affect the security state of the operating system. The operating system's Information Management Officer (IMO)/Information System Security Officer (ISSO) and System Administrators (SAs) must be notified via email and/or monitoring system trap when there is an unauthorized modification of a configuration item.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+Detecting such changes and providing an automated response can help avoid unintended, negative consequences that could ultimately affect the security state of the operating system. The operating system's Information System Security Manager (ISSM)/Information System Security Officer (ISSO) and System Administrators (SAs) must be notified via email and/or monitoring system trap when there is an unauthorized modification of a configuration item.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Red Hat Enterprise Linux 7</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -3325,26 +3313,29 @@ Detecting such changes and providing an automated response can help avoid uninte
             <dc:subject>Red Hat Enterprise Linux 7</dc:subject>
             <dc:identifier>2899</dc:identifier>
           </xccdf:reference>
-          <xccdf:ident system="http://cce.mitre.org">CCE-26952-2</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86597</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-71973</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001744</xccdf:ident>
-          <xccdf:fixtext fixref="F-36304r602622_fix">Configure the file integrity tool to run automatically on the system at least weekly. The following example output is generic. It will set cron to run AIDE daily, but other file integrity tools may be used:  
+          <xccdf:fixtext fixref="F-36304r902697_fix">Configure the file integrity tool to run automatically on the system at least weekly. 
 
-# more /etc/cron.daily/aide
-#!/bin/bash
+The following example output is generic. It will set cron to run AIDE daily, but other file integrity tools may be used:  
 
-/usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil</xccdf:fixtext>
-          <xccdf:fix id="F-36304r602622_fix" />
+     # more /etc/cron.daily/aide
+     #!/bin/bash
+
+     /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
+
+Note: Per requirement RHEL-07-020028, the "mailx" package must be installed on the system to enable email functionality.</xccdf:fixtext>
+          <xccdf:fix id="F-36304r902697_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:525" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7os:def:204445" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204447">
         <xccdf:title>SRG-OS-000366-GPOS-00153</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204447r603261_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204447r877463_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-020050</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must prevent the installation of software, patches, service packs, device drivers, or operating system components from a repository without verification they have been digitally signed using a certificate that is issued by a Certificate Authority (CA) that is recognized and approved by the organization.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor.
@@ -3368,14 +3359,14 @@ Verifying the authenticity of the software prior to installation validates the i
 gpgcheck=1</xccdf:fixtext>
           <xccdf:fix id="F-4571r88534_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1027" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1027" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204448">
         <xccdf:title>SRG-OS-000366-GPOS-00153</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204448r603261_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204448r877463_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-020060</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must prevent the installation of software, patches, service packs, device drivers, or operating system components of local packages without verification they have been digitally signed using a certificate that is issued by a Certificate Authority (CA) that is recognized and approved by the organization.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor.
@@ -3399,14 +3390,14 @@ Verifying the authenticity of the software prior to installation validates the i
 localpkg_gpgcheck=1</xccdf:fixtext>
           <xccdf:fix id="F-4572r88537_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:110" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:110" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204449">
         <xccdf:title>SRG-OS-000114-GPOS-00059</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204449r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204449r853891_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-020100</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured to disable USB mass storage.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;USB mass storage permits easy introduction of unknown devices, thereby facilitating malicious activity.
@@ -3443,14 +3434,14 @@ Add or update the line:
 blacklist usb-storage</xccdf:fixtext>
           <xccdf:fix id="F-4573r462538_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1141" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1141" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204450">
         <xccdf:title>SRG-OS-000378-GPOS-00163</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204450r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204450r853892_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-020101</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the Datagram Congestion Control Protocol (DCCP) kernel module is disabled unless required.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Disabling DCCP protects the system against exploitation of any flaws in the protocol implementation.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3483,14 +3474,14 @@ Add or update the line:
 blacklist dccp</xccdf:fixtext>
           <xccdf:fix id="F-4574r88543_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:92517" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:92517" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204451">
         <xccdf:title>SRG-OS-000114-GPOS-00059</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204451r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204451r853893_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-020110</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must disable the file system automounter unless required.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Automatically mounting file systems permits easy introduction of unknown devices, thereby facilitating malicious activity.
@@ -3519,14 +3510,14 @@ Turn off the automount service with the following commands:
 If "autofs" is required for Network File System (NFS), it must be documented with the ISSO.</xccdf:fixtext>
           <xccdf:fix id="F-4575r88546_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86609" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86609" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204452">
         <xccdf:title>SRG-OS-000437-GPOS-00194</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204452r603261_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204452r853894_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-020200</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must remove all software components after updated versions have been installed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Previous versions of software components that are not removed from the information system after updates have been installed may be exploited by adversaries. Some information technology products may remove older versions of software automatically from the information system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3548,7 +3539,7 @@ Set the "clean_requirements_on_remove" option to "1" in the "/etc/yum.conf" file
 clean_requirements_on_remove=1</xccdf:fixtext>
           <xccdf:fix id="F-4576r88549_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:108" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:108" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3578,7 +3569,7 @@ UMASK  077</xccdf:fixtext>
           <xccdf:fix id="F-4581r88564_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:4211" value-id="xccdf_mil.disa.stig_value_var_accounts_user_umask" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:518" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:518" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3605,7 +3596,7 @@ Red Hat offers the Extended Update Support (EUS) Add-On to a Red Hat Enterprise 
           <xccdf:fixtext fixref="F-4582r462547_fix">Upgrade to a supported version of the operating system.</xccdf:fixtext>
           <xccdf:fix id="F-4582r462547_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:169" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:169" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3630,7 +3621,7 @@ Red Hat offers the Extended Update Support (EUS) Add-On to a Red Hat Enterprise 
           <xccdf:fixtext fixref="F-4585r88576_fix">Configure the system to define all GIDs found in the "/etc/passwd" file by modifying the "/etc/group" file to add any non-existent group referenced in the "/etc/passwd" file, or change the GIDs referenced in the "/etc/passwd" file to a group that exists in "/etc/group".</xccdf:fixtext>
           <xccdf:fix id="F-4585r88576_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1117" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1117" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3657,7 +3648,7 @@ Red Hat offers the Extended Update Support (EUS) Add-On to a Red Hat Enterprise 
 If the account is associated with system commands or applications, the UID should be changed to one greater than "0" but less than "1000". Otherwise, assign a UID of greater than "1000" that has not already been assigned.</xccdf:fixtext>
           <xccdf:fix id="F-4586r88579_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:457" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:457" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3684,7 +3675,7 @@ If the account is associated with system commands or applications, the UID shoul
 CREATE_HOME yes</xccdf:fixtext>
           <xccdf:fix id="F-4590r88591_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:447" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:447" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3717,7 +3708,7 @@ Note: The example will be for the user smithj, who has a home directory of "/hom
 # chmod 0750 /home/smithj</xccdf:fixtext>
           <xccdf:fix id="F-4591r462550_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86639" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86639" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3742,7 +3733,7 @@ Note: The example will be for the user smithj, who has a home directory of "/hom
           <xccdf:fixtext fixref="F-4606r88639_fix">Configure the "/etc/fstab" to use the "nosuid" option on file systems that are being imported via NFS.</xccdf:fixtext>
           <xccdf:fix id="F-4606r88639_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1186" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1186" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3767,7 +3758,7 @@ Note: The example will be for the user smithj, who has a home directory of "/hom
           <xccdf:fixtext fixref="F-4607r88642_fix">Configure the "/etc/fstab" to use the "noexec" option on file systems that are being imported via NFS.</xccdf:fixtext>
           <xccdf:fix id="F-4607r88642_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1178" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1178" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3794,7 +3785,7 @@ The only authorized public directories are those temporary directories supplied 
           <xccdf:fixtext fixref="F-36308r602634_fix">All directories in local partitions which are world-writable should be group-owned by root or another system account. If any world-writable directories are not group-owned by a system account, this should be investigated. Following this, the directories should be deleted or assigned to an appropriate group.</xccdf:fixtext>
           <xccdf:fix id="F-36308r602634_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1009" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1009" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3821,7 +3812,7 @@ The only authorized public directories are those temporary directories supplied 
 # chown root /etc/cron.allow</xccdf:fixtext>
           <xccdf:fix id="F-4614r88663_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:116" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:116" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3848,7 +3839,7 @@ The only authorized public directories are those temporary directories supplied 
 # chgrp root /etc/cron.allow</xccdf:fixtext>
           <xccdf:fix id="F-4615r88666_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:114" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:114" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3873,7 +3864,7 @@ The only authorized public directories are those temporary directories supplied 
           <xccdf:fixtext fixref="F-4617r88672_fix">Migrate the "/home" directory onto a separate file system/partition.</xccdf:fixtext>
           <xccdf:fix id="F-4617r88672_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1311" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1311" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3898,7 +3889,7 @@ The only authorized public directories are those temporary directories supplied 
           <xccdf:fixtext fixref="F-4618r88675_fix">Migrate the "/var" path onto a separate file system.</xccdf:fixtext>
           <xccdf:fix id="F-4618r88675_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1315" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1315" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3922,7 +3913,7 @@ The only authorized public directories are those temporary directories supplied 
           <xccdf:fixtext fixref="F-4619r88678_fix">Migrate the system audit data path onto a separate file system.</xccdf:fixtext>
           <xccdf:fix id="F-4619r88678_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1319" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1319" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3953,14 +3944,14 @@ OR
 Edit the "/etc/fstab" file and ensure the "/tmp" directory is defined in the fstab with a device and mount point.</xccdf:fixtext>
           <xccdf:fix id="F-36309r602637_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86689" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86689" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204497">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204497r603261_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204497r877398_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-021350</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect data requiring data-at-rest protections in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of weak or untested encryption algorithms undermines the purposes of using encryption to protect data. The operating system must implement cryptographic modules adhering to the higher standards approved by the federal government since this provides assurance they have been tested and validated.
@@ -4034,7 +4025,7 @@ If the file /etc/system-fips does not exists, recreate it:
 Reboot the system for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-36310r602640_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:126" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:126" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4065,7 +4056,7 @@ Examples of non-essential capabilities include, but are not limited to, games, s
 # yum remove telnet-server</xccdf:fixtext>
           <xccdf:fix id="F-4626r88699_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1292" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1292" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4101,14 +4092,14 @@ Enable the auditd service with the following command:
 # systemctl start auditd.service</xccdf:fixtext>
           <xccdf:fix id="F-36311r602643_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86703" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86703" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204504">
         <xccdf:title>SRG-OS-000046-GPOS-00022</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204504r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204504r880761_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030010</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must shut down upon audit processing failure, unless availability is an overriding concern. If availability is a concern, the system must alert the designated staff (System Administrator [SA] and Information System Security Officer [ISSO] at a minimum) in the event of an audit processing failure.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is critical for the appropriate personnel to be aware if a system is at risk of failing to process audit logs as required. Without this notification, the security personnel may be unaware of an impending failure of the audit capability, and system operation may be adversely affected.
@@ -4129,37 +4120,37 @@ Satisfies: SRG-OS-000046-GPOS-00022, SRG-OS-000047-GPOS-00023&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">V-72081</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86705</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000139</xccdf:ident>
-          <xccdf:fixtext fixref="F-4628r462467_fix">Configure the operating system to shut down in the event of an audit processing failure.
+          <xccdf:fixtext fixref="F-4628r880760_fix">Configure the operating system to shut down in the event of an audit processing failure.
 
 Add or correct the option to shut down the operating system with the following command:
 
-# auditctl -f 2
+     # auditctl -f 2
 
 Edit the "/etc/audit/rules.d/audit.rules" file and add the following line:
 
--f 2
+     -f 2
 
 If availability has been determined to be more important, and this decision is documented with the ISSO, configure the operating system to notify system administration staff and ISSO staff in the event of an audit processing failure with the following command:
 
-# auditctl -f 1
+     # auditctl -f 1
 
 Edit the "/etc/audit/rules.d/audit.rules" file and add the following line:
 
--f 1
+     -f 1
 
 Kernel log monitoring must also be configured to properly alert designated staff.
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4628r462467_fix" />
+          <xccdf:fix id="F-4628r880760_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:776" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:776" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204506">
         <xccdf:title>SRG-OS-000342-GPOS-00133</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204506r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204506r877390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030201</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured to off-load audit logs onto a different system or storage media from the system being audited.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
@@ -4179,8 +4170,9 @@ Satisfies: SRG-OS-000342-GPOS-00133, SRG-OS-000479-GPOS-00224&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-95729</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-81017</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001851</xccdf:ident>
-          <xccdf:fixtext fixref="F-4630r462470_fix">Edit the /etc/audisp/plugins.d/au-remote.conf file and add or update the following values:
+          <xccdf:fixtext fixref="F-4630r858479_fix">Edit the /etc/audisp/plugins.d/au-remote.conf file and add or update the following values:
 
+active = yes
 direction = out
 path = /sbin/audisp-remote
 type = always
@@ -4188,16 +4180,16 @@ type = always
 The audit daemon must be restarted for changes to take effect:
 
 # service auditd restart</xccdf:fixtext>
-          <xccdf:fix id="F-4630r462470_fix" />
+          <xccdf:fix id="F-4630r858479_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95729" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95729" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204507">
         <xccdf:title>SRG-OS-000342-GPOS-00133</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204507r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204507r877390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030210</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must take appropriate action when the remote logging buffer is full.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
@@ -4226,14 +4218,14 @@ The audit daemon must be restarted for changes to take effect:
 # service auditd restart</xccdf:fixtext>
           <xccdf:fix id="F-36312r602646_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95731" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95731" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204508">
         <xccdf:title>SRG-OS-000342-GPOS-00133</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204508r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204508r877390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030211</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must label all off-loaded audit logs before sending them to the central log server.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
@@ -4262,14 +4254,14 @@ The audit daemon must be restarted for changes to take effect:
 # service auditd restart</xccdf:fixtext>
           <xccdf:fix id="F-36313r602649_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95733" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:95733" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204509">
         <xccdf:title>SRG-OS-000342-GPOS-00133</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204509r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204509r877390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030300</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must off-load audit records onto a different system or media from the system being audited.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
@@ -4292,14 +4284,14 @@ Satisfies: SRG-OS-000342-GPOS-00133, SRG-OS-000479-GPOS-00224&lt;/VulnDiscussion
 Set the remote server option in "/etc/audisp/audisp-remote.conf" with the IP address of the log aggregation server.</xccdf:fixtext>
           <xccdf:fix id="F-4633r88720_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86707" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86707" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204510">
         <xccdf:title>SRG-OS-000342-GPOS-00133</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204510r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204510r877390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030310</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must encrypt the transfer of audit records off-loaded onto a different system or media from the system being audited.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
@@ -4324,14 +4316,14 @@ Uncomment the "enable_krb5" option in "/etc/audisp/audisp-remote.conf" and set i
 enable_krb5 = yes</xccdf:fixtext>
           <xccdf:fix id="F-4634r88723_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86709" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86709" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204511">
         <xccdf:title>SRG-OS-000342-GPOS-00133</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204511r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204511r877390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030320</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the audit system takes appropriate action when the audit storage volume is full.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Taking appropriate action in case of a filled audit storage volume will minimize the possibility of losing audit records.
@@ -4353,14 +4345,14 @@ Uncomment or edit the "disk_full_action" option in "/etc/audisp/audisp-remote.co
 disk_full_action = single</xccdf:fixtext>
           <xccdf:fix id="F-36314r602652_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86711" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86711" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204512">
         <xccdf:title>SRG-OS-000342-GPOS-00133</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204512r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204512r877390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030321</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the audit system takes appropriate action when there is an error sending audit records to a remote system.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Taking appropriate action when there is an error sending audit records to a remote system will minimize the possibility of losing audit records.
@@ -4382,14 +4374,14 @@ Uncomment the "network_failure_action" option in "/etc/audisp/audisp-remote.conf
 network_failure_action = syslog</xccdf:fixtext>
           <xccdf:fix id="F-36315r602655_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:87815" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:87815" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204514">
         <xccdf:title>SRG-OS-000343-GPOS-00134</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204514r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204514r877389_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030340</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must immediately notify the System Administrator (SA) and Information System Security Officer (ISSO) (at a minimum) via email when the threshold for the repository maximum audit record storage capacity is reached.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If security personnel are not notified immediately when the threshold for the repository maximum audit record storage capacity is reached, they are unable to expand the audit record storage capacity before records are lost.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4410,14 +4402,14 @@ Uncomment or edit the "space_left_action" keyword in "/etc/audit/auditd.conf" an
 space_left_action = email</xccdf:fixtext>
           <xccdf:fix id="F-4638r88735_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86715" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86715" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204515">
         <xccdf:title>SRG-OS-000343-GPOS-00134</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204515r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204515r877389_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030350</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must immediately notify the System Administrator (SA) and Information System Security Officer (ISSO) (at a minimum) when the threshold for the repository maximum audit record storage capacity is reached.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If security personnel are not notified immediately when the threshold for the repository maximum audit record storage capacity is reached, they are unable to expand the audit record storage capacity before records are lost.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4440,14 +4432,14 @@ action_mail_acct = root</xccdf:fixtext>
           <xccdf:fix id="F-4639r88738_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3821" value-id="xccdf_mil.disa.stig_value_var_auditd_action_mail_acct" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:885" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:885" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204516">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204516r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204516r853914_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030360</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all executions of privileged functions.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Misuse of privileged functions, either intentionally or unintentionally by authorized users, or by unauthorized external entities that have compromised information system accounts, is a serious and ongoing concern and can have significant adverse impacts on organizations. Auditing the use of privileged functions is one way to detect such misuse and identify the risk from insider threats and the advanced persistent threat.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4473,7 +4465,7 @@ Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4640r88741_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:710" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:710" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4513,7 +4505,7 @@ Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000392-GPOS-00172, SRG-OS-000458-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4641r809192_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:552" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:552" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4554,7 +4546,7 @@ Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4645r809771_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:546" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:546" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4595,14 +4587,14 @@ Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4648r809774_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:607" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:607" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204531">
         <xccdf:title>SRG-OS-000064-GPOS-00033</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204531r809815_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204531r853917_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030510</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the creat, open, openat, open_by_handle_at, truncate, and ftruncate syscalls.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -4626,7 +4618,7 @@ Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000458-GPOS-00203, SRG-OS-000461-GPO
           <xccdf:ident system="http://cyber.mil/legacy">V-72125</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4655r809814_fix">Configure the operating system to generate audit records upon successful/unsuccessful attempts to use the "creat", "open", "openat", "open_by_handle_at", "truncate", and "ftruncate" syscalls.
+          <xccdf:fixtext fixref="F-4655r853916_fix">Configure the operating system to generate audit records upon successful/unsuccessful attempts to use the "creat", "open", "openat", "open_by_handle_at", "truncate", and "ftruncate" syscalls.
 
 Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 
@@ -4639,16 +4631,16 @@ Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 -a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -k access
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4655r809814_fix" />
+          <xccdf:fix id="F-4655r853916_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:805" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:805" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204536">
         <xccdf:title>SRG-OS-000392-GPOS-00172</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204536r833109_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204536r861014_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030560</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the semanage command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -4670,23 +4662,23 @@ Satisfies: SRG-OS-000392-GPOS-00172, SRG-OS-000463-GPOS-00207, SRG-OS-000465-GPO
           <xccdf:ident system="http://cyber.mil/legacy">V-72135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4660r833108_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "semanage" command occur.
+          <xccdf:fixtext fixref="F-4660r861013_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "semanage" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4660r833108_fix" />
+          <xccdf:fix id="F-4660r861013_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:618" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:618" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204537">
         <xccdf:title>SRG-OS-000392-GPOS-00172</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204537r833112_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204537r861017_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030570</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the setsebool command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -4708,23 +4700,23 @@ Satisfies: SRG-OS-000392-GPOS-00172, SRG-OS-000463-GPOS-00207, SRG-OS-000465-GPO
           <xccdf:ident system="http://cyber.mil/legacy">SV-86761</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4661r833111_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "setsebool" command occur.
+          <xccdf:fixtext fixref="F-4661r861016_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "setsebool" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4661r833111_fix" />
+          <xccdf:fix id="F-4661r861016_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:621" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:621" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204538">
         <xccdf:title>SRG-OS-000392-GPOS-00172</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204538r833115_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204538r861020_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030580</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the chcon command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -4746,23 +4738,23 @@ Satisfies: SRG-OS-000392-GPOS-00172, SRG-OS-000463-GPOS-00207, SRG-OS-000465-GPO
           <xccdf:ident system="http://cyber.mil/legacy">SV-86763</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4662r833114_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "chcon" command occur.
+          <xccdf:fixtext fixref="F-4662r861019_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "chcon" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4662r833114_fix" />
+          <xccdf:fix id="F-4662r861019_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:612" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:612" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204539">
         <xccdf:title>SRG-OS-000392-GPOS-00172</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204539r833118_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204539r861023_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030590</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the setfiles command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -4783,23 +4775,23 @@ Satisfies: SRG-OS-000392-GPOS-00172, SRG-OS-000463-GPOS-00207, SRG-OS-000465-GPO
           <xccdf:ident system="http://cyber.mil/legacy">SV-86765</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4663r833117_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "setfiles" command occur.
+          <xccdf:fixtext fixref="F-4663r861022_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "setfiles" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4663r833117_fix" />
+          <xccdf:fix id="F-4663r861022_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86765" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86765" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204540">
         <xccdf:title>SRG-OS-000392-GPOS-00172</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204540r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204540r853930_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030610</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must generate audit records for all unsuccessful account access events.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -4829,14 +4821,14 @@ Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4664r88813_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:675" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:675" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204541">
         <xccdf:title>SRG-OS-000392-GPOS-00172</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204541r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204541r853931_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030620</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must generate audit records for all successful account access events.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -4866,14 +4858,14 @@ Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4665r88816_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:676" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:676" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204542">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204542r833121_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204542r861026_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030630</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the passwd command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -4896,23 +4888,23 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4666r833120_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "passwd" command occur.
+          <xccdf:fixtext fixref="F-4666r861025_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "passwd" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-passwd
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4666r833120_fix" />
+          <xccdf:fix id="F-4666r861025_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:733" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:733" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204543">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204543r833124_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204543r861029_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030640</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the unix_chkpwd command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -4935,23 +4927,23 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4667r833123_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "unix_chkpwd" command occur.
+          <xccdf:fixtext fixref="F-4667r861028_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "unix_chkpwd" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-passwd
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4667r833123_fix" />
+          <xccdf:fix id="F-4667r861028_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:760" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:760" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204544">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204544r833127_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204544r861032_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030650</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the gpasswd command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -4974,23 +4966,23 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4668r833126_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "gpasswd" command occur.
+          <xccdf:fixtext fixref="F-4668r861031_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "gpasswd" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-passwd
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4668r833126_fix" />
+          <xccdf:fix id="F-4668r861031_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:724" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:724" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204545">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204545r833130_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204545r861035_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030660</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the chage command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5013,23 +5005,23 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4669r833129_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "chage" command occur.
+          <xccdf:fixtext fixref="F-4669r861034_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "chage" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-passwd
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4669r833129_fix" />
+          <xccdf:fix id="F-4669r861034_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:715" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:715" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204546">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204546r833133_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204546r861038_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030670</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the userhelper command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5052,23 +5044,23 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4670r833132_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "userhelper" command occur.
+          <xccdf:fixtext fixref="F-4670r861037_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "userhelper" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-passwd
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4670r833132_fix" />
+          <xccdf:fix id="F-4670r861037_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:763" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:763" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204547">
         <xccdf:title>SRG-OS-000037-GPOS-00015</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204547r833136_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204547r861041_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030680</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the su command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5092,23 +5084,23 @@ Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4671r833135_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "su" command occur.
+          <xccdf:fixtext fixref="F-4671r861040_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "su" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
 
 -a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change 
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4671r833135_fix" />
+          <xccdf:fix id="F-4671r861040_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:748" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:748" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204548">
         <xccdf:title>SRG-OS-000037-GPOS-00015</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204548r833139_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204548r861044_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030690</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the sudo command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5132,23 +5124,23 @@ Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4672r833138_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "sudo" command occur.
+          <xccdf:fixtext fixref="F-4672r861043_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "sudo" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
 
 -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change 
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4672r833138_fix" />
+          <xccdf:fix id="F-4672r861043_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:751" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:751" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204549">
         <xccdf:title>SRG-OS-000037-GPOS-00015</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204549r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204549r853953_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030700</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the sudoers file and all files in the /etc/sudoers.d/ directory.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5181,14 +5173,14 @@ Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4673r88840_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:773" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:773" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204550">
         <xccdf:title>SRG-OS-000037-GPOS-00015</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204550r833142_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204550r861047_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030710</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the newgrp command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5212,23 +5204,23 @@ Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4674r833141_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "newgrp" command occur.
+          <xccdf:fixtext fixref="F-4674r861046_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "newgrp" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
 
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4674r833141_fix" />
+          <xccdf:fix id="F-4674r861046_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:727" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:727" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204551">
         <xccdf:title>SRG-OS-000037-GPOS-00015</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204551r833145_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204551r861050_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030720</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the chsh command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5252,23 +5244,23 @@ Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4675r833144_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "chsh" command occur.
+          <xccdf:fixtext fixref="F-4675r861049_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "chsh" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
 
 -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4675r833144_fix" />
+          <xccdf:fix id="F-4675r861049_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:718" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:718" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204552">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204552r833148_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204552r861053_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030740</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the mount command and syscall.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5290,7 +5282,7 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-86795</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4676r833147_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "mount" command and syscall occur.
+          <xccdf:fixtext fixref="F-4676r861052_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "mount" command and syscall occur.
 
 Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 
@@ -5299,16 +5291,16 @@ Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 -a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-mount
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4676r833147_fix" />
+          <xccdf:fix id="F-4676r861052_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:686" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:686" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204553">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204553r833151_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204553r861056_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030750</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the umount command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5330,23 +5322,23 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-86797</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4677r833150_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "umount" command occur.
+          <xccdf:fixtext fixref="F-4677r861055_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "umount" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
 
 -a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-mount
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4677r833150_fix" />
+          <xccdf:fix id="F-4677r861055_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:757" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:757" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204554">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204554r833154_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204554r861059_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030760</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the postdrop command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5368,23 +5360,23 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-86799</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4678r833153_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "postdrop" command occur.
+          <xccdf:fixtext fixref="F-4678r861058_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "postdrop" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
 
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-postfix
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4678r833153_fix" />
+          <xccdf:fix id="F-4678r861058_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:736" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:736" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204555">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204555r833157_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204555r861062_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030770</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the postqueue command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5406,23 +5398,23 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">V-72177</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4679r833156_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "postqueue" command occur. 
+          <xccdf:fixtext fixref="F-4679r861061_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "postqueue" command occur. 
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
 
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-postfix
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4679r833156_fix" />
+          <xccdf:fix id="F-4679r861061_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:739" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:739" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204556">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204556r833160_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204556r861065_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030780</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the ssh-keysign command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5445,23 +5437,23 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4680r833159_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "ssh-keysign" command occur. 
+          <xccdf:fixtext fixref="F-4680r861064_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "ssh-keysign" command occur. 
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
 
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-ssh
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4680r833159_fix" />
+          <xccdf:fix id="F-4680r861064_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:745" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:745" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204557">
         <xccdf:title>SRG-OS-000042-GPOS-00020</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204557r833163_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204557r861068_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030800</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the crontab command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
@@ -5484,16 +5476,16 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4681r833162_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "crontab" command occur. 
+          <xccdf:fixtext fixref="F-4681r861067_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "crontab" command occur. 
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
 
 -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-cron
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4681r833162_fix" />
+          <xccdf:fix id="F-4681r861067_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:721" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:721" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5526,7 +5518,7 @@ Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4682r833165_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:730" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:730" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5562,7 +5554,7 @@ Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4683r833168_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:93705" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:93705" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5601,7 +5593,7 @@ Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4684r833171_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:657" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:657" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5638,14 +5630,14 @@ Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4686r833174_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:658" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:658" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204563">
         <xccdf:title>SRG-OS-000471-GPOS-00216</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204563r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204563r858498_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030840</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the kmod command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
@@ -5665,23 +5657,23 @@ Satisfies: SRG-OS-000471-GPOS-00216, SRG-OS-000477-GPOS-00222&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-86815</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72191</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:fixtext fixref="F-4687r462673_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "kmod" command occur. 
+          <xccdf:fixtext fixref="F-4687r858497_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "kmod" command occur. 
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
--w /usr/bin/kmod -p x -F auid!=unset -k module-change
+-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid&gt;=1000 -F auid!=unset -k modules
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4687r462673_fix" />
+          <xccdf:fix id="F-4687r858497_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86815" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86815" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204564">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204564r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204564r853978_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030870</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/passwd.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -5712,14 +5704,14 @@ Add or update the following rule "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4688r88885_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:875" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:875" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204565">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204565r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204565r853979_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030871</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -5748,14 +5740,14 @@ Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4689r88888_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:866" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:866" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204566">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204566r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204566r853980_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030872</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/gshadow.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -5784,14 +5776,14 @@ Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4690r88891_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:869" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:869" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204567">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204567r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204567r853981_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030873</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/shadow.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -5820,14 +5812,14 @@ Add or update the following file system rule in "/etc/audit/rules.d/audit.rules"
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4691r88894_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:878" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:878" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204568">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204568r744115_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204568r853982_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030874</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/security/opasswd.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
@@ -5857,14 +5849,14 @@ The audit daemon must be restarted for the changes to take effect:
 # systemctl restart auditd</xccdf:fixtext>
           <xccdf:fix id="F-4692r744114_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:872" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:872" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204572">
         <xccdf:title>SRG-OS-000466-GPOS-00210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204572r809825_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204572r853985_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030910</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the unlink, unlinkat, rename, renameat, and rmdir syscalls.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If the system is not configured to audit certain activities and write them to an audit log, it is more difficult to detect and track system compromises and damages incurred during a system compromise.
@@ -5886,7 +5878,7 @@ Satisfies: SRG-OS-000466-GPOS-00210, SRG-OS-000467-GPOS-00211, SRG-OS-000468-GPO
           <xccdf:ident system="http://cyber.mil/legacy">SV-86829</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4696r809824_fix">Configure the operating system to generate audit records upon successful/unsuccessful attempts to use the "unlink", "unlinkat", "rename", "renameat", and "rmdir" syscalls.
+          <xccdf:fixtext fixref="F-4696r853984_fix">Configure the operating system to generate audit records upon successful/unsuccessful attempts to use the "unlink", "unlinkat", "rename", "renameat", and "rmdir" syscalls.
 
 Add the following rules in "/etc/audit/rules.d/audit.rules":
 
@@ -5895,16 +5887,16 @@ Add the following rules in "/etc/audit/rules.d/audit.rules":
 -a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat,rmdir -F auid&gt;=1000 -F auid!=unset -k delete
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4696r809824_fix" />
+          <xccdf:fix id="F-4696r853984_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:626" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:626" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204576">
         <xccdf:title>SRG-OS-000027-GPOS-00008</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204576r603261_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204576r877399_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040000</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must limit the number of concurrent sessions to 10 for all accounts and/or account types.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Operating system management includes the ability to control the number of users and user sessions that utilize an operating system. Limiting the number of allowed users and sessions per user is helpful in reducing the risks related to DoS attacks.
@@ -5917,7 +5909,6 @@ This requirement addresses concurrent sessions for information system accounts a
             <dc:subject>Red Hat Enterprise Linux 7</dc:subject>
             <dc:identifier>2899</dc:identifier>
           </xccdf:reference>
-          <xccdf:ident system="http://cce.mitre.org">CCE-27081-9</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72217</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86841</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000054</xccdf:ident>
@@ -5928,15 +5919,14 @@ Add the following line to the top of the /etc/security/limits.conf or in a ".con
 * hard maxlogins 10</xccdf:fixtext>
           <xccdf:fix id="F-4700r88921_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3792" value-id="xccdf_mil.disa.stig_value_var_accounts_max_concurrent_login_sessions" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:449" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7os:def:204576" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204578">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204578r744116_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204578r877398_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040110</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux 7 operating system must implement DoD-approved encryption to protect the confidentiality of SSH connections.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unapproved mechanisms that are used for authentication to the cryptographic module are not verified and therefore cannot be relied upon to provide confidentiality or integrity, and DoD data may be compromised.
@@ -5970,14 +5960,14 @@ Ciphers aes256-ctr,aes192-ctr,aes128-ctr
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4702r622306_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1399" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1399" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204579">
         <xccdf:title>SRG-OS-000163-GPOS-00072</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204579r646844_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204579r861070_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040160</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that all network connections associated with a communication session are terminated at the end of the session or after 15 minutes of inactivity from the user at a command prompt, except to fulfill documented and validated mission requirements.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle session will also free up resources committed by the managed network element. 
@@ -6005,14 +5995,14 @@ Create a script to enforce the inactivity timeout (for example /etc/profile.d/tm
 declare -xr TMOUT=900</xccdf:fixtext>
           <xccdf:fix id="F-4703r646843_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:510" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:510" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204584">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204584r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204584r880794_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040201</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must implement virtual address space randomization.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Address space layout randomization (ASLR) makes it more difficult for an attacker to predict the location of attack code he or she has introduced into a process's address space during an attempt at exploitation. Additionally, ASLR also makes it more difficult for an attacker to know the location of existing code in order to repurpose it using return-oriented programming (ROP) techniques.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6026,25 +6016,25 @@ declare -xr TMOUT=900</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">SV-92521</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-77825</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4708r88945_fix">Configure the operating system implement virtual address space randomization.
+          <xccdf:fixtext fixref="F-4708r880793_fix">Configure the operating system implement virtual address space randomization.
 
 Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a config file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-kernel.randomize_va_space = 2
+     kernel.randomize_va_space = 2
 
 Issue the following command to make the changes take effect:
 
-# sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-4708r88945_fix" />
+     # sysctl --system</xccdf:fixtext>
+          <xccdf:fix id="F-4708r880793_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:92521" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:92521" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204585">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204585r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204585r853989_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040300</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that all networked systems have SSH installed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered. 
@@ -6073,14 +6063,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188, SRG-OS-000425-GPO
 # yum install openssh-server.x86_64</xccdf:fixtext>
           <xccdf:fix id="F-4709r88948_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:4248" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:4248" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204587">
         <xccdf:title>SRG-OS-000163-GPOS-00072</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204587r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204587r861072_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040320</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that all network connections associated with SSH traffic are terminated at the end of the session or after 10 minutes of inactivity, except to fulfill documented and validated mission requirements.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Terminating an idle SSH session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle SSH session will also free up resources committed by the managed network element.
@@ -6110,7 +6100,7 @@ The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4711r88954_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3866" value-id="xccdf_mil.disa.stig_value_sshd_idle_timeout_value" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1391" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1391" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6141,14 +6131,14 @@ RhostsRSAAuthentication no
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4712r88957_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1379" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1379" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204589">
         <xccdf:title>SRG-OS-000163-GPOS-00072</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204589r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204589r853992_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040340</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that all network connections associated with SSH traffic terminate after a period of inactivity.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Terminating an idle SSH session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle SSH session will also free up resources committed by the managed network element.
@@ -6177,7 +6167,7 @@ ClientAliveCountMax 0
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4713r88960_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1393" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1393" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6206,14 +6196,14 @@ Add the following line in "/etc/ssh/sshd_config", or uncomment the line and set 
 IgnoreRhosts yes</xccdf:fixtext>
           <xccdf:fix id="F-4714r88963_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1377" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1377" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204591">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204591r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204591r858477_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040360</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must display the date and time of the last successful account logon upon an SSH logon.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Providing users with feedback on when account accesses via SSH last occurred facilitates user recognition and reporting of unauthorized account use.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6227,7 +6217,7 @@ IgnoreRhosts yes</xccdf:fixtext>
           <xccdf:ident system="http://cce.mitre.org">CCE-80225-6</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72245</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86869</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-000052</xccdf:ident>
           <xccdf:fixtext fixref="F-4715r88966_fix">Configure SSH to provide users with feedback on when account accesses last occurred by setting the required configuration options in "/etc/pam.d/sshd" or in the "sshd_config" file used by the system ("/etc/ssh/sshd_config" will be used in the example) (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor).
 
 Modify the "PrintLastLog" line in "/etc/ssh/sshd_config" to match the following:
@@ -6237,7 +6227,7 @@ PrintLastLog yes
 The SSH service must be restarted for changes to "sshd_config" to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4715r88966_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:166" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:166" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6268,7 +6258,7 @@ PermitRootLogin no
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4716r88969_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1381" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1381" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6299,14 +6289,14 @@ IgnoreUserKnownHosts yes
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4717r88972_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1383" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1383" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204594">
         <xccdf:title>SRG-OS-000074-GPOS-00042</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204594r603261_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204594r877396_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040390</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the SSH daemon is configured to only use the SSHv2 protocol.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;SSHv1 is an insecure implementation of the SSH protocol and has many well-known vulnerability exploits. Exploits of the SSH daemon could provide immediate root access to the system.
@@ -6331,14 +6321,14 @@ Protocol 2
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4718r88975_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1373" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1373" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204595">
         <xccdf:title>SRG-OS-000250-GPOS-00093</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204595r744117_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204595r877394_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040400</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the SSH daemon is configured to only use Message Authentication Codes (MACs) employing FIPS 140-2 approved cryptographic hash algorithms.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;DoD information systems are required to use FIPS 140-2 approved cryptographic hash functions. The only SSHv2 hash algorithm meeting this requirement is SHA.
@@ -6362,7 +6352,7 @@ MACs hmac-sha2-512,hmac-sha2-256
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4719r622309_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:168" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:168" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6391,16 +6381,16 @@ Change the mode of public host key files under "/etc/ssh" to "0644" with the fol
 # chmod 0644 /etc/ssh/*.key.pub</xccdf:fixtext>
           <xccdf:fix id="F-4720r88981_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:120" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:120" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204597">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204597r792834_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204597r880743_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040420</xccdf:version>
-          <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the SSH private host key files have mode 0600 or less permissive.</xccdf:title>
+          <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the SSH private host key files have mode 0640 or less permissive.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If an unauthorized user obtains the private SSH host key file, the host could be impersonated.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Red Hat Enterprise Linux 7</dc:title>
@@ -6413,19 +6403,19 @@ Change the mode of public host key files under "/etc/ssh" to "0644" with the fol
           <xccdf:ident system="http://cyber.mil/legacy">V-72257</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86881</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4721r792833_fix">Configure the mode of SSH private host key files under "/etc/ssh" to "0600" with the following command:
+          <xccdf:fixtext fixref="F-4721r880742_fix">Configure the mode of SSH private host key files under "/etc/ssh" to "0640" with the following command:
 
-# chmod 0600 /path/to/file/ssh_host*key</xccdf:fixtext>
-          <xccdf:fix id="F-4721r792833_fix" />
+# chmod 0640 /path/to/file/ssh_host*key</xccdf:fixtext>
+          <xccdf:fix id="F-4721r880742_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:118" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:118" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204598">
         <xccdf:title>SRG-OS-000364-GPOS-00151</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204598r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204598r853993_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040430</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the SSH daemon does not permit Generic Security Service Application Program Interface (GSSAPI) authentication unless needed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;GSSAPI authentication is used to provide additional authentication mechanisms to applications. Allowing GSSAPI authentication through SSH exposes the system's GSSAPI to remote hosts, increasing the attack surface of the system. GSSAPI authentication must be disabled unless needed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6452,14 +6442,14 @@ The SSH service must be restarted for changes to take effect.
 If GSSAPI authentication is required, it must be documented, to include the location of the configuration file, with the ISSO.</xccdf:fixtext>
           <xccdf:fix id="F-4722r88987_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:160" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:160" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204599">
         <xccdf:title>SRG-OS-000364-GPOS-00151</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204599r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204599r853994_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040440</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the SSH daemon does not permit Kerberos authentication unless needed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Kerberos authentication for SSH is often implemented using Generic Security Service Application Program Interface (GSSAPI). If Kerberos is enabled through SSH, the SSH daemon provides a means of access to the system's Kerberos implementation. Vulnerabilities in the system's Kerberos implementation may then be subject to exploitation. To reduce the attack surface of the system, the Kerberos authentication mechanism within SSH must be disabled for systems not using this capability.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6487,7 +6477,7 @@ The SSH service must be restarted for changes to take effect.
 If Kerberos authentication is required, it must be documented, to include the location of the configuration file, with the ISSO.</xccdf:fixtext>
           <xccdf:fix id="F-4723r88990_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:162" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:162" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6516,7 +6506,7 @@ StrictModes yes
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4724r88993_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:164" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:164" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6545,14 +6535,14 @@ UsePrivilegeSeparation sandbox
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4725r88996_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:171" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:171" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204602">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204602r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204602r880758_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040470</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the SSH daemon does not allow compression or only allows compression after successful authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If compression is allowed in an SSH connection prior to authentication, vulnerabilities in the compression software could result in compromise of the system from an unauthenticated connection, potentially with root privileges.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6566,21 +6556,21 @@ The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86891</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72267</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4726r88999_fix">Uncomment the "Compression" keyword in "/etc/ssh/sshd_config" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor) on the system and set the value to "delayed" or "no":
+          <xccdf:fixtext fixref="F-4726r880757_fix">Uncomment the "Compression" keyword in "/etc/ssh/sshd_config" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor) on the system and set the value to "delayed" or "no":
 
-Compression no
+     Compression no
 
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-4726r88999_fix" />
+          <xccdf:fix id="F-4726r880757_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:158" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:158" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204605">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204605r603261_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204605r858478_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040530</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must display the date and time of the last successful account logon upon logon.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Providing users with feedback on when account accesses last occurred facilitates user recognition and reporting of unauthorized account use.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6593,7 +6583,7 @@ The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86899</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72275</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-000052</xccdf:ident>
           <xccdf:fixtext fixref="F-4729r89008_fix">Configure the operating system to provide users with feedback on when account accesses last occurred by setting the required configuration options in "/etc/pam.d/postlogin". 
 
 Add the following line to the top of "/etc/pam.d/postlogin":
@@ -6601,7 +6591,7 @@ Add the following line to the top of "/etc/pam.d/postlogin":
 session required pam_lastlog.so showfailed</xccdf:fixtext>
           <xccdf:fix id="F-4729r89008_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1020" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1020" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6627,7 +6617,7 @@ session required pam_lastlog.so showfailed</xccdf:fixtext>
 # rm /[path]/[to]/[file]/.shosts</xccdf:fixtext>
           <xccdf:fix id="F-4730r89011_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86901" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86901" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6653,14 +6643,14 @@ session required pam_lastlog.so showfailed</xccdf:fixtext>
 # rm /[path]/[to]/[file]/shosts.equiv</xccdf:fixtext>
           <xccdf:fix id="F-4731r89014_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86903" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:86903" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204609">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204609r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204609r880797_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040610</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not forward Internet Protocol version 4 (IPv4) source-routed packets.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Source-routed packets allow the source of the packet to suggest that routers forward the packet along a different path than configured on the router, which can be used to bypass network security measures. This requirement applies only to the forwarding of source-routed traffic, such as when IPv4 forwarding is enabled and the system is functioning as a router.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6675,24 +6665,24 @@ session required pam_lastlog.so showfailed</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">V-72283</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86907</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4733r89020_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
+          <xccdf:fixtext fixref="F-4733r880796_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-net.ipv4.conf.all.accept_source_route = 0   
+     net.ipv4.conf.all.accept_source_route = 0   
 
 Issue the following command to make the changes take effect:
  
-# sysctl -system</xccdf:fixtext>
-          <xccdf:fix id="F-4733r89020_fix" />
+     # sysctl -system</xccdf:fixtext>
+          <xccdf:fix id="F-4733r880796_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3771" value-id="xccdf_mil.disa.stig_value_sysctl_net_ipv4_conf_all_accept_source_route_value" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:251" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:251" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204612">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204612r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204612r880806_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040620</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not forward Internet Protocol version 4 (IPv4) source-routed packets by default.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Source-routed packets allow the source of the packet to suggest that routers forward the packet along a different path than configured on the router, which can be used to bypass network security measures. This requirement applies only to the forwarding of source-routed traffic, such as when IPv4 forwarding is enabled and the system is functioning as a router.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6707,24 +6697,24 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/legacy">V-72285</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86909</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4736r89029_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
+          <xccdf:fixtext fixref="F-4736r880805_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-net.ipv4.conf.default.accept_source_route = 0   
+     net.ipv4.conf.default.accept_source_route = 0   
 
 Issue the following command to make the changes take effect:
  
-# sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-4736r89029_fix" />
+     # sysctl --system</xccdf:fixtext>
+          <xccdf:fix id="F-4736r880805_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3776" value-id="xccdf_mil.disa.stig_value_sysctl_net_ipv4_conf_default_accept_source_route_value" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:269" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:269" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204613">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204613r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204613r880809_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040630</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not respond to Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) echoes sent to a broadcast address.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Responding to broadcast (ICMP) echoes facilitates network mapping and provides a vector for amplification attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6739,24 +6729,24 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/legacy">V-72287</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86911</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4737r89032_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
+          <xccdf:fixtext fixref="F-4737r880808_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-net.ipv4.icmp_echo_ignore_broadcasts = 1
+     net.ipv4.icmp_echo_ignore_broadcasts = 1
 
 Issue the following command to make the changes take effect: 
 
-# sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-4737r89032_fix" />
+     # sysctl --system</xccdf:fixtext>
+          <xccdf:fix id="F-4737r880808_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3780" value-id="xccdf_mil.disa.stig_value_sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:284" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:284" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204614">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204614r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204614r880812_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040640</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must prevent Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirect messages from being accepted.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages modify the host's route table and are unauthenticated. An illicit ICMP redirect message could result in a man-in-the-middle attack.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6771,24 +6761,24 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/legacy">SV-86913</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72289</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4738r89035_fix">Set the system to not accept IPv4 ICMP redirect messages by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
+          <xccdf:fixtext fixref="F-4738r880811_fix">Set the system to not accept IPv4 ICMP redirect messages by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-net.ipv4.conf.default.accept_redirects = 0   
+     net.ipv4.conf.default.accept_redirects = 0   
 
 Issue the following command to make the changes take effect:
 
-# sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-4738r89035_fix" />
+     # sysctl --system</xccdf:fixtext>
+          <xccdf:fix id="F-4738r880811_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3775" value-id="xccdf_mil.disa.stig_value_sysctl_net_ipv4_conf_default_accept_redirects_value" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:266" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:266" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204615">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204615r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204615r880815_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040641</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must ignore Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirect messages.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages modify the host's route table and are unauthenticated. An illicit ICMP redirect message could result in a man-in-the-middle attack.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6803,24 +6793,24 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/legacy">SV-87827</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-73175</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4739r89038_fix">Set the system to ignore IPv4 ICMP redirect messages by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
+          <xccdf:fixtext fixref="F-4739r880814_fix">Set the system to ignore IPv4 ICMP redirect messages by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-net.ipv4.conf.all.accept_redirects = 0   
+     net.ipv4.conf.all.accept_redirects = 0   
 
 Issue the following command to make the changes take effect:
 
-# sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-4739r89038_fix" />
+     # sysctl --system</xccdf:fixtext>
+          <xccdf:fix id="F-4739r880814_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3770" value-id="xccdf_mil.disa.stig_value_sysctl_net_ipv4_conf_all_accept_redirects_value" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:248" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:248" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204616">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204616r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204616r880818_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040650</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not allow interfaces to perform Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirects by default.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages contain information from the system's route table, possibly revealing portions of the network topology.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6835,25 +6825,25 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/legacy">V-72291</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86915</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4740r89041_fix">Configure the system to not allow interfaces to perform IPv4 ICMP redirects by default. 
+          <xccdf:fixtext fixref="F-4740r880817_fix">Configure the system to not allow interfaces to perform IPv4 ICMP redirects by default. 
 
 Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-net.ipv4.conf.default.send_redirects = 0
+     net.ipv4.conf.default.send_redirects = 0
 
 Issue the following command to make the changes take effect:
 
-# sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-4740r89041_fix" />
+     # sysctl --system</xccdf:fixtext>
+          <xccdf:fix id="F-4740r880817_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:281" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:281" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204617">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204617r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204617r880821_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040660</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not send Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirects.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages contain information from the system's route table, possibly revealing portions of the network topology.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6868,18 +6858,18 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/legacy">V-72293</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86917</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4741r89044_fix">Configure the system to not allow interfaces to perform IPv4 ICMP redirects. 
+          <xccdf:fixtext fixref="F-4741r880820_fix">Configure the system to not allow interfaces to perform IPv4 ICMP redirects. 
 
 Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-net.ipv4.conf.all.send_redirects = 0
+     net.ipv4.conf.all.send_redirects = 0
 
 Issue the following command to make the changes take effect:
 
-# sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-4741r89044_fix" />
+     # sysctl --system</xccdf:fixtext>
+          <xccdf:fix id="F-4741r880820_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:263" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:263" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6905,14 +6895,14 @@ Issue the following command to make the changes take effect:
 # yum remove vsftpd</xccdf:fixtext>
           <xccdf:fix id="F-4744r89053_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1301" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1301" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204621">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204621r603261_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204621r853996_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040700</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not have the Trivial File Transfer Protocol (TFTP) server package installed if not required for operational support.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If TFTP is required for operational support (such as the transmission of router configurations) its use must be documented with the Information System Security Officer (ISSO), restricted to only authorized personnel, and have access control rules established.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6936,7 +6926,7 @@ Issue the following command to make the changes take effect:
 # yum remove tftp-server</xccdf:fixtext>
           <xccdf:fix id="F-4745r89056_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1296" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1296" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6969,7 +6959,7 @@ The SSH service must be restarted for changes to take effect:
 # systemctl restart sshd</xccdf:fixtext>
           <xccdf:fix id="F-4746r622312_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1389" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1389" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7002,14 +6992,14 @@ $ sudo yum remove xorg-x11-server-Xorg xorg-x11-server-common xorg-x11-server-ut
 A reboot is required for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-36316r646846_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1305" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1305" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204625">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204625r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204625r880824_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040740</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not be performing packet forwarding unless the system is a router.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Routing protocol daemons are typically used on routers to exchange network topology information with other routers. If this software is used when not required, system network information may be unnecessarily transmitted across the network.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7024,16 +7014,16 @@ A reboot is required for the changes to take effect.</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86933</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72309</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4749r89068_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
+          <xccdf:fixtext fixref="F-4749r880823_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-net.ipv4.ip_forward = 0
+     net.ipv4.ip_forward = 0
 
 Issue the following command to make the changes take effect:
 
-# sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-4749r89068_fix" />
+     # sysctl --system</xccdf:fixtext>
+          <xccdf:fix id="F-4749r880823_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:290" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:290" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7058,14 +7048,14 @@ Issue the following command to make the changes take effect:
           <xccdf:fixtext fixref="F-4751r89074_fix">If the "/etc/snmp/snmpd.conf" file exists, modify any lines that contain a community string value of "public" or "private" to another string value.</xccdf:fixtext>
           <xccdf:fix id="F-4751r89074_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1369" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1369" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204630">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204630r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204630r880827_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040830</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must not forward IPv6 source-routed packets.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Source-routed packets allow the source of the packet to suggest that routers forward the packet along a different path than configured on the router, which can be used to bypass network security measures. This requirement applies only to the forwarding of source-routed traffic, such as when IPv6 forwarding is enabled and the system is functioning as a router.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7080,24 +7070,24 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/legacy">V-72319</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86943</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4754r89083_fix">Set the system to the required kernel parameter, if IPv6 is enabled, by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
+          <xccdf:fixtext fixref="F-4754r880826_fix">Set the system to the required kernel parameter, if IPv6 is enabled, by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-net.ipv6.conf.all.accept_source_route = 0
+     net.ipv6.conf.all.accept_source_route = 0
 
 Issue the following command to make the changes take effect:
 
-# sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-4754r89083_fix" />
+     # sysctl --system</xccdf:fixtext>
+          <xccdf:fix id="F-4754r880826_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export export-name="oval:mil.disa.stig.rhel7:var:3785" value-id="xccdf_mil.disa.stig_value_sysctl_net_ipv6_conf_all_accept_source_route_value" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:303" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:303" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204631">
         <xccdf:title>SRG-OS-000375-GPOS-00160</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204631r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204631r853997_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-041001</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must have the required packages for multifactor authentication installed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Using an authentication device, such as a CAC or token that is separate from the information system, ensures that even if the information system is compromised, that compromise will not affect credentials stored on the authentication device.
@@ -7130,14 +7120,14 @@ Install the pam_pkcs11 package with the following command:
 # yum install pam_pkcs11</xccdf:fixtext>
           <xccdf:fix id="F-4755r462473_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:87041" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:87041" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204632">
         <xccdf:title>SRG-OS-000375-GPOS-00160</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204632r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204632r853998_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-041002</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must implement multifactor authentication for access to privileged accounts via pluggable authentication modules (PAM).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Using an authentication device, such as a CAC or token that is separate from the information system, ensures that even if the information system is compromised, that compromise will not affect credentials stored on the authentication device.
@@ -7169,14 +7159,14 @@ Satisfies: SRG-OS-000375-GPOS-00160, SRG-OS-000375-GPOS-00161, SRG-OS-000375-GPO
 Modify all of the services lines in "/etc/sssd/sssd.conf" or in configuration files found under "/etc/sssd/conf.d" to include pam.</xccdf:fixtext>
           <xccdf:fix id="F-4756r89089_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1405" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1405" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-204633">
         <xccdf:title>SRG-OS-000375-GPOS-00160</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204633r603261_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204633r853999_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-041003</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must implement certificate status checking for PKI authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Using an authentication device, such as a CAC or token that is separate from the information system, ensures that even if the information system is compromised, that compromise will not affect credentials stored on the authentication device.
@@ -7207,14 +7197,14 @@ Satisfies: SRG-OS-000375-GPOS-00160, SRG-OS-000375-GPOS-00161, SRG-OS-000375-GPO
 Modify all of the "cert_policy" lines in "/etc/pam_pkcs11/pam_pkcs11.conf" to include "ocsp_on".</xccdf:fixtext>
           <xccdf:fix id="F-4757r89092_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:87057" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:87057" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-214799">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-214799r603261_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-214799r854001_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010020</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that the cryptographic hash of system files and commands matches vendor values.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without cryptographic integrity protections, system command and files can be altered by unauthorized users without detection.
@@ -7244,7 +7234,7 @@ Alternatively, the package can be reinstalled from trusted media using the comma
 # sudo rpm -Uvh &lt;packagename&gt;</xccdf:fixtext>
           <xccdf:fix id="F-15997r192363_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1340" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:1340" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7268,14 +7258,14 @@ ALL     ALL=(ALL) ALL
 ALL     ALL=(ALL:ALL) ALL</xccdf:fixtext>
           <xccdf:fix id="F-40815r646849_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:177" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:177" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-237634">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237634r833177_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237634r880755_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010342</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must use the invoking user's password for privilege escalation when using "sudo".</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The sudoers security policy requires that users authenticate themselves before they can use sudo. When sudoers requires authentication, it validates the invoking user's credentials. If the rootpw, targetpw, or runaspw flags are defined and not disabled, by default the operating system will prompt the invoking user for the "root" user password. 
@@ -7288,20 +7278,24 @@ For more information on each of the listed configurations, reference the sudoers
             <dc:identifier>2899</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002227</xccdf:ident>
-          <xccdf:fixtext fixref="F-40816r646852_fix">Define the following in the Defaults section of the /etc/sudoers file or a configuration file in the /etc/sudoers.d/ directory:
-Defaults !targetpw
-Defaults !rootpw
-Defaults !runaspw</xccdf:fixtext>
-          <xccdf:fix id="F-40816r646852_fix" />
+          <xccdf:fixtext fixref="F-40816r880754_fix">Define the following in the Defaults section of the /etc/sudoers file or a configuration file in the /etc/sudoers.d/ directory:
+     Defaults !targetpw
+     Defaults !rootpw
+     Defaults !runaspw
+
+Remove any configurations that conflict with the above from the following locations: 
+     /etc/sudoers
+     /etc/sudoers.d/</xccdf:fixtext>
+          <xccdf:fix id="F-40816r880754_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:178" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:178" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-237635">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237635r833179_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237635r861075_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010343</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must require re-authentication when using the "sudo" command.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
@@ -7317,29 +7311,67 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <dc:identifier>2899</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002038</xccdf:ident>
-          <xccdf:fixtext fixref="F-40817r646855_fix">Configure the "sudo" command to require re-authentication.
+          <xccdf:fixtext fixref="F-40817r858491_fix">Configure the "sudo" command to require re-authentication.
 Edit the /etc/sudoers file:
 $ sudo visudo
 
 Add or modify the following line:
 Defaults timestamp_timeout=[value]
-Note: The "[value]" must be a number that is greater than or equal to "0".</xccdf:fixtext>
-          <xccdf:fix id="F-40817r646855_fix" />
+Note: The "[value]" must be a number that is greater than or equal to "0".
+
+Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ files.</xccdf:fixtext>
+          <xccdf:fix id="F-40817r858491_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:179" href="U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel7:def:179" href="U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
     </xccdf:Benchmark>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2022-06-28T15:26:15">
+  <component id="scap_mil.disa.stig_comp_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2023-03-28T17:40:59">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-06-28T15:26:15</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:40:58</oval:timestamp>
       </generator>
       <definitions>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:204445" version="1">
+          <metadata>
+            <title>The operating system must be configured so that a file integrity tool verifies the baseline operating system configuration at least weekly.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.linux:tst:20444500" comment="AIDE package is installed" />
+            <criteria operator="OR">
+              <criterion test_ref="oval:mil.disa.stig.ind:tst:20444501" comment="AIDE is configured to run daily with /etc/crontab" />
+              <criterion test_ref="oval:mil.disa.stig.ind:tst:20444502" comment="AIDE is configured to run daily with /etc/cron.d" />
+              <criterion test_ref="oval:mil.disa.stig.ind:tst:20444503" comment="AIDE is configured to run daily with /var/spool/cron/root" />
+              <criterion test_ref="oval:mil.disa.stig.ind:tst:20444504" comment="AIDE is configured to run daily with cron.daily" />
+              <criterion test_ref="oval:mil.disa.stig.ind:tst:20444505" comment="AIDE is configured to run daily with cron.weekly" />
+              <criterion test_ref="oval:mil.disa.stig.ind:tst:20444506" comment="AIDE is configured to run daily with cron.hourly" />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230346" version="1">
+          <metadata>
+            <title>The operating system must limit the number of concurrent sessions to ten for all accounts and/or account types.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23034600" comment="limits.conf and limits.d/*.conf:maxlogins is set to 10 or less by default" />
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23034601" comment="limits.conf and limits.d/*.conf:maxlogins is set to 10 or less for non-default domains" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:251714" version="1">
+          <metadata>
+            <title>Systems below version 8.4 must ensure the password complexity module in the system-auth file is configured for three retries or less.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:25171400" comment="/etc/pam.d/system-auth:retry not greater than 3 and not 0" />
+          </criteria>
+        </definition>
         <definition class="inventory" id="oval:mil.disa.stig.rhel7:def:1" version="2">
           <metadata>
             <title>Red Hat Enterprise Linux 7</title>
@@ -7356,7 +7388,6 @@ Note: The "[value]" must be a number that is greater than or equal to "0".</xccd
             <criterion comment="RHEL 7 Workstation is installed" test_ref="oval:mil.disa.stig.rhel7:tst:18" />
             <criterion comment="RHEL 7 Server is installed" test_ref="oval:mil.disa.stig.rhel7:tst:19" />
             <criterion comment="RHEL 7 Compute Node is installed" test_ref="oval:mil.disa.stig.rhel7:tst:20" />
-            <criterion comment="CentOS Enterprise Linux 7 is installed" test_ref="oval:mil.fso.centos.centos7:tst:220" />
             <criteria comment="Red Hat Enterpise Virtualization Host is installed" operator="AND">
               <criterion comment="redhat-release-virtualization-host RPM package is installed" test_ref="oval:mil.disa.stig.rhel7:tst:21" />
               <criterion comment="Red Hat Enterpise Virtualization Host is based on RHEL 7" test_ref="oval:mil.disa.stig.rhel7:tst:22" />
@@ -7439,9 +7470,9 @@ Note: The "[value]" must be a number that is greater than or equal to "0".</xccd
             <criterion comment="Check file ownership of /etc/cron.allow" test_ref="oval:mil.disa.stig.rhel7:tst:117" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:118" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:118" version="4">
           <metadata>
-            <title>RHEL-07-040420 - The Red Hat Enterprise Linux operating system must be configured so that the SSH private host key files have mode 0600 or less permissive.</title>
+            <title>RHEL-07-040420 - The Red Hat Enterprise Linux operating system must be configured so that the SSH private host key files have mode 0640 or less permissive.</title>
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 7</platform>
             </affected>
@@ -7540,7 +7571,7 @@ Note: The "[value]" must be a number that is greater than or equal to "0".</xccd
             <criterion comment="package openssh-server is removed" test_ref="oval:mil.disa.stig.rhel7:tst:1269" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:158" version="2">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:158" version="4">
           <metadata>
             <title>Disable Compression Or Set Compression to delayed</title>
             <affected family="unix">
@@ -7550,9 +7581,10 @@ Note: The "[value]" must be a number that is greater than or equal to "0".</xccd
             <reference ref_id="sshd_disable_compression" source="ssg" />
             <description>SSH should either have compression disabled or set to delayed.</description>
           </metadata>
-          <criteria comment="SSH is not being used or conditions are met" operator="OR">
+          <criteria operator="OR">
             <extend_definition comment="openssh-server is not installed" definition_ref="oval:mil.disa.stig.rhel7:def:156" />
             <criterion comment="Check Compression in /etc/ssh/sshd_config" test_ref="oval:mil.disa.stig.rhel7:tst:159" />
+            <criterion comment="RHEL 7 version is 7.4 or above" test_ref="oval:mil.disa.stig.rhel7:tst:15900" negate="true" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:160" version="2">
@@ -7767,7 +7799,7 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <extend_definition comment="net.ipv4.conf.all.accept_redirects runtime setting check" definition_ref="oval:mil.disa.stig.rhel7:def:250" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:249" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:249" version="4">
           <metadata>
             <title>Kernel "net.ipv4.conf.all.accept_redirects" Parameter Configuration Check</title>
             <affected family="unix">
@@ -7776,11 +7808,8 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <description>The kernel "net.ipv4.conf.all.accept_redirects" parameter should be set to the appropriate value in the system configuration.</description>
             <reference ref_id="sysctl_static_net_ipv4_conf_all_accept_redirects" source="ssg" />
           </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv4.conf.all.accept_redirects set to the appropriate value in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:351" />
-            <criterion comment="kernel static parameter net.ipv4.conf.all.accept_redirects set to the appropriate value in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:352" />
-            <criterion comment="kernel static parameter net.ipv4.conf.all.accept_redirects set to the appropriate value in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:353" />
-            <criterion comment="kernel static parameter net.ipv4.conf.all.accept_redirects set to the appropriate value in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:354" />
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.rhel7:tst:351" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:250" version="3">
@@ -7796,7 +7825,7 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <criterion comment="kernel runtime parameter net.ipv4.conf.all.accept_redirects set to the appropriate value" test_ref="oval:mil.disa.stig.rhel7:tst:320" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:251" version="4">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:251" version="5">
           <metadata>
             <title>Kernel "net.ipv4.conf.all.accept_source_route" Parameter Configuration and Runtime Check</title>
             <affected family="unix">
@@ -7807,125 +7836,38 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <description>The "net.ipv4.conf.all.accept_source_route" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
           </metadata>
           <criteria operator="AND">
-            <extend_definition comment="net.ipv4.conf.all.accept_source_route configuration setting check" definition_ref="oval:mil.disa.stig.rhel7:def:252" />
-            <extend_definition comment="net.ipv4.conf.all.accept_source_route runtime setting check" definition_ref="oval:mil.disa.stig.rhel7:def:253" />
+            <criterion comment="kernel runtime parameter net.ipv4.conf.all.accept_source_route set to the appropriate value" test_ref="oval:mil.disa.stig.rhel7:tst:25100" />
+            <criterion comment="net.ipv4.conf.all.accept_source_route setting in acceptable directory is set to 0, and nothing else, and there are no conflicting settings in other files" test_ref="oval:mil.disa.stig.rhel7:tst:25101" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:252" version="5">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:263" version="5">
           <metadata>
-            <title>Kernel "net.ipv4.conf.all.accept_source_route" Parameter Configuration Check</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 7</platform>
-            </affected>
-            <description>The kernel "net.ipv4.conf.all.accept_source_route" parameter should be set to the appropriate value in the system configuration.</description>
-            <reference ref_id="sysctl_static_net_ipv4_conf_all_accept_source_route" source="ssg" />
-          </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv4.conf.all.accept_source_route set to the appropriate value in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:355" />
-            <criterion comment="kernel static parameter net.ipv4.conf.all.accept_source_route set to the appropriate value in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:356" />
-            <criterion comment="kernel static parameter net.ipv4.conf.all.accept_source_route set to the appropriate value in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:357" />
-            <criterion comment="kernel static parameter net.ipv4.conf.all.accept_source_route set to the appropriate value in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:358" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:253" version="3">
-          <metadata>
-            <title>Kernel "net.ipv4.conf.all.accept_source_route" Parameter Runtime Check</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 7</platform>
-            </affected>
-            <description>The kernel "net.ipv4.conf.all.accept_source_route" parameter should be set to the appropriate value in system runtime.</description>
-            <reference ref_id="sysctl_runtime_net_ipv4_conf_all_accept_source_route" source="ssg" />
-          </metadata>
-          <criteria operator="AND">
-            <criterion comment="kernel runtime parameter net.ipv4.conf.all.accept_source_route set to the appropriate value" test_ref="oval:mil.disa.stig.rhel7:tst:321" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:263" version="4">
-          <metadata>
-            <title>Kernel "net.ipv4.conf.all.send_redirects" Parameter Configuration and Runtime Check</title>
+            <title>The Red Hat Enterprise Linux operating system must not send Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirects.</title>
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 7</platform>
             </affected>
             <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-80156-3" />
             <reference ref_id="sysctl_net_ipv4_conf_all_send_redirects" source="ssg" />
-            <description>The "net.ipv4.conf.all.send_redirects" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
+            <description>ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages contain information from the system's route table, possibly revealing portions of the network topology.</description>
           </metadata>
           <criteria operator="AND">
-            <extend_definition comment="net.ipv4.conf.all.send_redirects configuration setting check" definition_ref="oval:mil.disa.stig.rhel7:def:264" />
-            <extend_definition comment="net.ipv4.conf.all.send_redirects runtime setting check" definition_ref="oval:mil.disa.stig.rhel7:def:265" />
+            <criterion comment="net.ipv4.conf.all.send_redirects setting in kernel is 0" test_ref="oval:mil.disa.stig.rhel7:tst:325" />
+            <criterion comment="net.ipv4.conf.all.send_redirects setting in acceptable directory is set to 0, and nothing else, and there are no conflicting settings in other files" test_ref="oval:mil.disa.stig.rhel7:tst:371" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:264" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:266" version="5">
           <metadata>
-            <title>Kernel "net.ipv4.conf.all.send_redirects" Parameter Configuration Check</title>
+            <title>The Red Hat Enterprise Linux operating system must prevent Internet Protocol version 4 (IPv4) Internet Control Message Protocol (ICMP) redirect messages from being accepted.</title>
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 7</platform>
             </affected>
-            <description>The kernel "net.ipv4.conf.all.send_redirects" parameter should be set to "0" in the system configuration.</description>
-            <reference ref_id="sysctl_static_net_ipv4_conf_all_send_redirects" source="ssg" />
-          </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv4.conf.all.send_redirects set to 0 in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:371" />
-            <criterion comment="kernel static parameter net.ipv4.conf.all.send_redirects set to 0 in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:372" />
-            <criterion comment="kernel static parameter net.ipv4.conf.all.send_redirects set to 0 in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:373" />
-            <criterion comment="kernel static parameter net.ipv4.conf.all.send_redirects set to 0 in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:374" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:265" version="3">
-          <metadata>
-            <title>Kernel "net.ipv4.conf.all.send_redirects" Parameter Runtime Check</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 7</platform>
-            </affected>
-            <description>The kernel "net.ipv4.conf.all.send_redirects" parameter should be set to "0" in system runtime.</description>
-            <reference ref_id="sysctl_runtime_net_ipv4_conf_all_send_redirects" source="ssg" />
-          </metadata>
-          <criteria operator="AND">
-            <criterion comment="kernel runtime parameter net.ipv4.conf.all.send_redirects set to 0" test_ref="oval:mil.disa.stig.rhel7:tst:325" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:266" version="4">
-          <metadata>
-            <title>Kernel "net.ipv4.conf.default.accept_redirects" Parameter Configuration and Runtime Check</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 7</platform>
-            </affected>
-            <description>The "net.ipv4.conf.default.accept_redirects" kernel parameter should be set to the appropriate value in both system configuration and system runtime.</description>
+            <description>ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages modify the host's route table and are unauthenticated. An illicit ICMP redirect message could result in a man-in-the-middle attack.</description>
             <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-80163-9" />
             <reference ref_id="sysctl_net_ipv4_conf_default_accept_redirects" source="ssg" />
           </metadata>
           <criteria operator="AND">
-            <extend_definition comment="net.ipv4.conf.default.accept_redirects configuration setting check" definition_ref="oval:mil.disa.stig.rhel7:def:267" />
-            <extend_definition comment="net.ipv4.conf.default.accept_redirects runtime setting check" definition_ref="oval:mil.disa.stig.rhel7:def:268" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:267" version="5">
-          <metadata>
-            <title>Kernel "net.ipv4.conf.default.accept_redirects" Parameter Configuration Check</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 7</platform>
-            </affected>
-            <description>The kernel "net.ipv4.conf.default.accept_redirects" parameter should be set to the appropriate value in the system configuration.</description>
-            <reference ref_id="sysctl_static_net_ipv4_conf_default_accept_redirects" source="ssg" />
-          </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv4.conf.default.accept_redirects set to the appropriate value in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:375" />
-            <criterion comment="kernel static parameter net.ipv4.conf.default.accept_redirects set to the appropriate value in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:376" />
-            <criterion comment="kernel static parameter net.ipv4.conf.default.accept_redirects set to the appropriate value in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:377" />
-            <criterion comment="kernel static parameter net.ipv4.conf.default.accept_redirects set to the appropriate value in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:378" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:268" version="3">
-          <metadata>
-            <title>Kernel "net.ipv4.conf.default.accept_redirects" Parameter Runtime Check</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 7</platform>
-            </affected>
-            <description>The kernel "net.ipv4.conf.default.accept_redirects" parameter should be set to the appropriate value in system runtime.</description>
-            <reference ref_id="sysctl_runtime_net_ipv4_conf_default_accept_redirects" source="ssg" />
-          </metadata>
-          <criteria operator="AND">
-            <criterion comment="kernel runtime parameter net.ipv4.conf.default.accept_redirects set to the appropriate value" test_ref="oval:mil.disa.stig.rhel7:tst:326" />
+            <criterion comment="net.ipv4.conf.default.accept_redirects setting in kernel is 0" test_ref="oval:mil.disa.stig.rhel7:tst:326" />
+            <criterion comment="net.ipv4.conf.default.accept_redirects setting in acceptable directory is set to 0, and nothing else, and it only appears once" test_ref="oval:mil.disa.stig.rhel7:tst:375" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:269" version="4">
@@ -7943,7 +7885,7 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <extend_definition comment="net.ipv4.conf.default.accept_source_route runtime setting check" definition_ref="oval:mil.disa.stig.rhel7:def:271" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:270" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:270" version="4">
           <metadata>
             <title>Kernel "net.ipv4.conf.default.accept_source_route" Parameter Configuration Check</title>
             <affected family="unix">
@@ -7952,11 +7894,8 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <description>The kernel "net.ipv4.conf.default.accept_source_route" parameter should be set to the appropriate value in the system configuration.</description>
             <reference ref_id="sysctl_static_net_ipv4_conf_default_accept_source_route" source="ssg" />
           </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv4.conf.default.accept_source_route set to the appropriate value in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:379" />
-            <criterion comment="kernel static parameter net.ipv4.conf.default.accept_source_route set to the appropriate value in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:380" />
-            <criterion comment="kernel static parameter net.ipv4.conf.default.accept_source_route set to the appropriate value in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:381" />
-            <criterion comment="kernel static parameter net.ipv4.conf.default.accept_source_route set to the appropriate value in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:382" />
+          <criteria>
+            <criterion comment="kernel static parameter net.ipv4.conf.default.accept_source_route set to 0 in /etc/sysctl.conf or any of the other sysctl.d directories." test_ref="oval:mil.disa.stig.rhel7:tst:379" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:271" version="3">
@@ -7987,7 +7926,7 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <extend_definition comment="net.ipv4.conf.default.send_redirects runtime setting check" definition_ref="oval:mil.disa.stig.rhel7:def:283" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:282" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:282" version="4">
           <metadata>
             <title>Kernel "net.ipv4.conf.default.send_redirects" Parameter Configuration Check</title>
             <affected family="unix">
@@ -7996,11 +7935,8 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <description>The kernel "net.ipv4.conf.default.send_redirects" parameter should be set to "0" in the system configuration.</description>
             <reference ref_id="sysctl_static_net_ipv4_conf_default_send_redirects" source="ssg" />
           </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv4.conf.default.send_redirects set to 0 in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:395" />
-            <criterion comment="kernel static parameter net.ipv4.conf.default.send_redirects set to 0 in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:396" />
-            <criterion comment="kernel static parameter net.ipv4.conf.default.send_redirects set to 0 in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:397" />
-            <criterion comment="kernel static parameter net.ipv4.conf.default.send_redirects set to 0 in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:398" />
+          <criteria>
+            <criterion comment="kernel static parameter net.ipv4.conf.default.send_redirects set to 0 in /etc/sysctl.conf, or any of the other sysctl.d directories, is set to 1, and nothing else, and there are no conflicting settings in other files" test_ref="oval:mil.disa.stig.rhel7:tst:395" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:283" version="3">
@@ -8031,7 +7967,7 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <extend_definition comment="net.ipv4.icmp_echo_ignore_broadcasts runtime setting check" definition_ref="oval:mil.disa.stig.rhel7:def:286" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:285" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:285" version="4">
           <metadata>
             <title>Kernel "net.ipv4.icmp_echo_ignore_broadcasts" Parameter Configuration Check</title>
             <affected family="unix">
@@ -8040,11 +7976,8 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <description>The kernel "net.ipv4.icmp_echo_ignore_broadcasts" parameter should be set to the appropriate value in the system configuration.</description>
             <reference ref_id="sysctl_static_net_ipv4_icmp_echo_ignore_broadcasts" source="ssg" />
           </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv4.icmp_echo_ignore_broadcasts set to the appropriate value in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:399" />
-            <criterion comment="kernel static parameter net.ipv4.icmp_echo_ignore_broadcasts set to the appropriate value in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:400" />
-            <criterion comment="kernel static parameter net.ipv4.icmp_echo_ignore_broadcasts set to the appropriate value in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:401" />
-            <criterion comment="kernel static parameter net.ipv4.icmp_echo_ignore_broadcasts set to the appropriate value in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:402" />
+          <criteria>
+            <criterion comment="net.ipv4.icmp_echo_ignore_broadcasts setting in /etc/sysctl.conf, or any of the other sysctl.d directories, is set to 1, and nothing else, and there are no conflicting settings in other files" test_ref="oval:mil.disa.stig.rhel7:tst:399" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:286" version="3">
@@ -8075,7 +8008,7 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <extend_definition comment="net.ipv4.ip_forward runtime setting check" definition_ref="oval:mil.disa.stig.rhel7:def:292" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:291" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:291" version="4">
           <metadata>
             <title>Kernel "net.ipv4.ip_forward" Parameter Configuration Check</title>
             <affected family="unix">
@@ -8084,11 +8017,8 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <description>The kernel "net.ipv4.ip_forward" parameter should be set to "0" in the system configuration.</description>
             <reference ref_id="sysctl_static_net_ipv4_ip_forward" source="ssg" />
           </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv4.ip_forward set to 0 in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:407" />
-            <criterion comment="kernel static parameter net.ipv4.ip_forward set to 0 in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:408" />
-            <criterion comment="kernel static parameter net.ipv4.ip_forward set to 0 in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:409" />
-            <criterion comment="kernel static parameter net.ipv4.ip_forward set to 0 in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:410" />
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.rhel7:tst:407" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:292" version="3">
@@ -8140,7 +8070,7 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             </criteria>
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:304" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:304" version="4">
           <metadata>
             <title>Kernel "net.ipv6.conf.all.accept_source_route" Parameter Configuration Check</title>
             <affected family="unix">
@@ -8149,11 +8079,8 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <description>The kernel "net.ipv6.conf.all.accept_source_route" parameter should be set to the appropriate value in the system configuration.</description>
             <reference ref_id="sysctl_static_net_ipv6_conf_all_accept_source_route" source="ssg" />
           </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv6.conf.all.accept_source_route set to the appropriate value in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:423" />
-            <criterion comment="kernel static parameter net.ipv6.conf.all.accept_source_route set to the appropriate value in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:424" />
-            <criterion comment="kernel static parameter net.ipv6.conf.all.accept_source_route set to the appropriate value in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:425" />
-            <criterion comment="kernel static parameter net.ipv6.conf.all.accept_source_route set to the appropriate value in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:426" />
+          <criteria>
+            <criterion comment="kernel static parameter net.ipv6.conf.all.accept_source_route set to the appropriate value in at least one of the acceptable sysctl directories" test_ref="oval:mil.disa.stig.rhel7:tst:423" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:305" version="3">
@@ -8197,32 +8124,6 @@ Operating systems need to track periods of inactivity and disable application id
           </metadata>
           <criteria operator="AND">
             <criterion comment="Check CREATE_HOME in /etc/login.defs" test_ref="oval:mil.disa.stig.rhel7:tst:448" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:449" version="4">
-          <metadata>
-            <title>Set Maximum Number of Concurrent Login Sessions Per User</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 7</platform>
-            </affected>
-            <reference ref_id="CCE-27081-9" source="http://cce.mitre.org" />
-            <description>The maximum number of concurrent login sessions per user should meet
-      minimum requirements.</description>
-            <reference ref_id="accounts_max_concurrent_login_sessions" source="ssg" />
-          </metadata>
-          <criteria>
-            <criteria operator="OR" comment="global domain">
-              <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:450" />
-              <criteria operator="AND">
-                <criterion comment="the value maxlogins should not be set at all in /etc/security/limits.d/*.conf" negate="true" test_ref="oval:mil.disa.stig.rhel7:tst:451" />
-                <criterion comment="the value maxlogins should be set appropriately in /etc/security/limits.conf" test_ref="oval:mil.disa.stig.rhel7:tst:452" />
-              </criteria>
-            </criteria>
-            <criteria comment="all domains">
-              <criterion comment="limits.d maxlogins in all domains configured correctly" test_ref="oval:mil.disa.stig.rhel7:tst:8684100" />
-              <criterion comment="limits.conf maxlogins in all domains configured correctly" test_ref="oval:mil.disa.stig.rhel7:tst:8684101" />
-            </criteria>
-            <criterion comment="all values are integers" test_ref="oval:mil.disa.stig.rhel7:tst:8684102" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:453" version="4">
@@ -8410,20 +8311,6 @@ Password complexity is one factor of several that determines how long it takes t
             <criterion comment="pwquality.conf" test_ref="oval:mil.disa.stig.rhel7:tst:479" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:481" version="2">
-          <metadata>
-            <title>Set Password retry Requirements</title>
-            <affected family="unix">
-              <platform>RedHat Enterprise Linux 7</platform>
-            </affected>
-            <description>The password retry should meet minimum requirements</description>
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-27160-1" />
-            <reference ref_id="accounts_password_pam_retry" source="ssg" />
-          </metadata>
-          <criteria comment="Conditions for retry are satisfied" operator="OR">
-            <criterion comment="pam_pwquality" test_ref="oval:mil.disa.stig.rhel7:tst:483" />
-          </criteria>
-        </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:484" version="2">
           <metadata>
             <title>Set Password ucredit Requirements</title>
@@ -8440,7 +8327,7 @@ Password complexity is one factor of several that determines how long it takes t
             <criterion comment="pwquality.conf" test_ref="oval:mil.disa.stig.rhel7:tst:485" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:486" version="5">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:486" version="6">
           <metadata>
             <title>Limit Password Reuse</title>
             <affected family="unix">
@@ -8451,15 +8338,9 @@ Password complexity is one factor of several that determines how long it takes t
             <reference ref_id="accounts_password_pam_unix_remember" source="ssg" />
             <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-26923-3" />
           </metadata>
-          <criteria comment="remember parameter is set correctly in both/etc/pam.d/system.auth and /etc/pam.d/password-auth" operator="OR">
-            <criteria comment="remember parameter of pam_unix.so or pam_pwhistory.so is set correctly in /etc/pam.d/system-auth" operator="OR">
-              <criterion comment="remember parameter of pam_unix.so is set correctly in /etc/pam.d/system-auth" test_ref="oval:mil.disa.stig.rhel7:tst:487" />
-              <criterion comment="remember parameter of pam_pwhistory.so is set correctly in /etc/pam.d/system-auth" test_ref="oval:mil.disa.stig.rhel7:tst:488" />
-            </criteria>
-            <criteria comment="remember parameter of pam_unix.so or pam_pwhistory.so is set correctly in /etc/pam.d/password-auth" operator="OR">
-              <criterion comment="remember parameter of pam_unix.so is set correctly in /etc/pam.d/password-auth" test_ref="oval:mil.disa.stig.rhel7:tst:48700" />
-              <criterion comment="remember parameter of pam_pwhistory.so is set correctly in /etc/pam.d/password-auth" test_ref="oval:mil.disa.stig.rhel7:tst:48800" />
-            </criteria>
+          <criteria comment="remember parameter is set correctly in both/etc/pam.d/system.auth and /etc/pam.d/password-auth" operator="AND">
+            <criterion comment="remember parameter of pam_pwhistory.so is set correctly in /etc/pam.d/system-auth" test_ref="oval:mil.disa.stig.rhel7:tst:488" />
+            <criterion comment="remember parameter of pam_pwhistory.so is set correctly in /etc/pam.d/password-auth" test_ref="oval:mil.disa.stig.rhel7:tst:48800" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:510" version="3">
@@ -8489,43 +8370,6 @@ Terminating network connections associated with communications sessions includes
           </metadata>
           <criteria operator="AND">
             <criterion test_ref="oval:mil.disa.stig.rhel7:tst:51800" comment="/etc/login.defs:UMASK == 077" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:525" version="5">
-          <metadata>
-            <title>Configure Periodic Execution of AIDE</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 7</platform>
-            </affected>
-            <description>By default, AIDE does not install itself for periodic
-      execution. Periodically running AIDE is necessary to reveal
-      unexpected changes in installed files.</description>
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-26952-2" />
-            <reference ref_id="aide_periodic_cron_checking" source="ssg" />
-          </metadata>
-          <criteria operator="AND">
-            <extend_definition comment="Aide is installed" definition_ref="oval:mil.disa.stig.rhel7:def:526" />
-            <criteria operator="OR">
-              <criterion comment="run aide daily with /etc/crontab" test_ref="oval:mil.disa.stig.rhel7:tst:527" />
-              <criterion comment="run aide daily with /etc/cron.d" test_ref="oval:mil.disa.stig.rhel7:tst:528" />
-              <criterion comment="run aide daily with /var/spool/cron/root" test_ref="oval:mil.disa.stig.rhel7:tst:529" />
-              <criterion comment="run aide daily with cron.daily" test_ref="oval:mil.disa.stig.rhel7:tst:530" />
-              <criterion comment="run aide daily with cron.weekly" test_ref="oval:mil.disa.stig.rhel7:tst:8659700" />
-              <criterion comment="run aide daily with cron.hourly" test_ref="oval:mil.disa.stig.rhel7:tst:8659701" />
-            </criteria>
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:526" version="1">
-          <metadata>
-            <title>Package aide Installed</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 7</platform>
-            </affected>
-            <description>The RPM package aide should be installed.</description>
-            <reference ref_id="package_aide_installed" source="ssg" />
-          </metadata>
-          <criteria>
-            <criterion comment="package aide is installed" test_ref="oval:mil.disa.stig.rhel7:tst:1249" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:542" version="3">
@@ -10366,7 +10210,7 @@ By specifying a cipher list with the order of ciphers being in a "strongest to w
             <criterion comment="check if pam is configured in the services setting of a conf file in the sssd conf.d directory" test_ref="oval:mil.disa.stig.rhel7:tst:140601" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:1416" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:1416" version="4">
           <metadata>
             <title>Kernel "net.ipv6.conf.all.disable_ipv6" Parameter Configuration Check</title>
             <affected family="unix">
@@ -10376,11 +10220,8 @@ By specifying a cipher list with the order of ciphers being in a "strongest to w
             <description>The kernel "net.ipv6.conf.all.disable_ipv6" parameter should be set to "1" in the system configuration.</description>
             <reference ref_id="sysctl_static_net_ipv6_conf_all_disable_ipv6" source="ssg" />
           </metadata>
-          <criteria operator="OR">
-            <criterion comment="kernel static parameter net.ipv6.conf.all.disable_ipv6 set to 1 in /etc/sysctl.conf" test_ref="oval:mil.disa.stig.rhel7:tst:1423" />
-            <criterion comment="kernel static parameter net.ipv6.conf.all.disable_ipv6 set to 1 in /etc/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:1424" />
-            <criterion comment="kernel static parameter net.ipv6.conf.all.disable_ipv6 set to 1 in /run/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:1425" />
-            <criterion comment="kernel static parameter net.ipv6.conf.all.disable_ipv6 set to 1 in /usr/lib/sysctl.d/*.conf" test_ref="oval:mil.disa.stig.rhel7:tst:1426" />
+          <criteria>
+            <criterion comment="kernel static parameter net.ipv6.conf.all.disable_ipv6 set to 1 in any acceptable directory" test_ref="oval:mil.disa.stig.rhel7:tst:1423" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:1417" version="3">
@@ -10760,7 +10601,7 @@ This requirement only applies to components where this is specific to the functi
             <criterion comment="/usr/sbin/sulogin has been assigned as an option to ExecStart in the /usr/lib/systemd/system/rescue.service file" test_ref="oval:mil.disa.stig.rhel7:tst:9251900" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:92521" version="2">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:92521" version="3">
           <metadata>
             <title>RHEL-07-040201 - The Red Hat Enterprise Linux operating system must implement virtual address space randomization.</title>
             <affected family="unix">
@@ -10768,14 +10609,9 @@ This requirement only applies to components where this is specific to the functi
             </affected>
             <description>Address space layout randomization (ASLR) makes it more difficult for an attacker to predict the location of attack code he or she has introduced into a process's address space during an attempt at exploitation. Additionally, ASLR also makes it more difficult for an attacker to know the location of existing code in order to repurpose it using return-oriented programming (ROP) techniques.</description>
           </metadata>
-          <criteria operator="AND">
-            <criterion comment="Check if /etc/sysctl.conf has kernel.randomize_va_space set to value other than 2" test_ref="oval:mil.disa.stig.rhel7:tst:9252102" />
-            <criterion comment="Check if any .conf file in /etc/sysctl.d has kernel.randomize_va_space set to value other than 2" test_ref="oval:mil.disa.stig.rhel7:tst:9252103" />
-            <criterion comment="Check if /sbin/sysctl kernel.randomize_va_space = 2" test_ref="oval:mil.disa.stig.rhel7:tst:9252104" />
-            <criteria operator="OR">
-              <criterion comment="Check /etc/sysctl.conf has kernel.randomize_va_space set to 2" test_ref="oval:mil.disa.stig.rhel7:tst:9252100" />
-              <criterion comment="Check if any .conf file in /etc/sysctl.d has kernel.randomize_va_space set to 2" test_ref="oval:mil.disa.stig.rhel7:tst:9252101" />
-            </criteria>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.rhel7:tst:9252100" />
+            <criterion test_ref="oval:mil.disa.stig.rhel7:tst:9252101" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel7:def:93703" version="2">
@@ -10916,8 +10752,90 @@ The ability to enable/disable a session lock is given to the user by default. Di
             <criterion comment="name_format in /etc/audisp/audispd.conf is set to hostname, fqd, or numeric" test_ref="oval:mil.disa.stig.rhel7:tst:9573300" />
           </criteria>
         </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7os:def:204406" version="1">
+          <metadata>
+            <title>RHEL-07-010119 - The Red Hat Enterprise Linux operating system must be configured so that when passwords are changed or new passwords are established, pwquality must be used.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux  7</platform>
+            </affected>
+            <description>Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:251714" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7os:def:204445" version="1">
+          <metadata>
+            <title>RHEL-07-020030 - The Red Hat Enterprise Linux operating system must be configured so that a file integrity tool verifies the baseline operating system configuration at least weekly.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux  7</platform>
+            </affected>
+            <description>Unauthorized changes to the baseline configuration could make the system vulnerable to various attacks or allow unauthorized access to the operating system. Changes to operating system configurations can have unintended side effects, some of which may be relevant to security.
+
+Detecting such changes and providing an automated response can help avoid unintended, negative consequences that could ultimately affect the security state of the operating system. The operating system's Information System Security Manager (ISSM)/Information System Security Officer (ISSO) and System Administrators (SAs) must be notified via email and/or monitoring system trap when there is an unauthorized modification of a configuration item.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:204445" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel7os:def:204576" version="1">
+          <metadata>
+            <title>RHEL-07-040000 - The Red Hat Enterprise Linux operating system must limit the number of concurrent sessions to 10 for all accounts and/or account types.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux  7</platform>
+            </affected>
+            <description>Operating system management includes the ability to control the number of users and user sessions that utilize an operating system. Limiting the number of allowed users and sessions per user is helpful in reducing the risks related to DoS attacks.
+
+This requirement addresses concurrent sessions for information system accounts and does not address concurrent sessions by single users via multiple system accounts. The maximum number of concurrent sessions should be defined based on mission needs and the operational environment for each system.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230346" />
+          </criteria>
+        </definition>
       </definitions>
       <tests>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="AIDE is configured to run daily with /etc/crontab" id="oval:mil.disa.stig.ind:tst:20444501" version="1" state_operator="OR">
+          <object object_ref="oval:mil.disa.stig.ind:obj:20444501" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20444500" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20444501" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20444502" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="AIDE is configured to run daily with /etc/cron.d" id="oval:mil.disa.stig.ind:tst:20444502" version="1" state_operator="OR">
+          <object object_ref="oval:mil.disa.stig.ind:obj:20444502" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20444500" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20444501" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20444502" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="AIDE is configured to run daily with /var/spool/cron/root" id="oval:mil.disa.stig.ind:tst:20444503" version="1" state_operator="OR">
+          <object object_ref="oval:mil.disa.stig.ind:obj:20444503" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20444500" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20444501" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20444502" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="AIDE is configured to run daily with cron.daily" id="oval:mil.disa.stig.ind:tst:20444504" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:20444504" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="AIDE is configured to run daily with cron.weekly" id="oval:mil.disa.stig.ind:tst:20444505" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:20444505" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="AIDE is configured to run daily with cron.hourly" id="oval:mil.disa.stig.ind:tst:20444506" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:20444506" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="limits.conf and limits.d/*.conf:maxlogins is set to 10 or less by default" id="oval:mil.disa.stig.ind:tst:23034600" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23034600" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:23034600" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="any_exist" comment="limits.conf and limits.d/*.conf:maxlogins is set to 10 or less for non-default domains" id="oval:mil.disa.stig.ind:tst:23034601" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23034603" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:23034600" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="/etc/pam.d/system-auth:retry not greater than 3 and not 0" id="oval:mil.disa.stig.ind:tst:25171400" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:25171400" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20000018" />
+        </textfilecontent54_test>
+        <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" comment="AIDE package is installed" id="oval:mil.disa.stig.linux:tst:20444500" version="1">
+          <object object_ref="oval:mil.disa.stig.linux:obj:20444500" />
+        </rpminfo_test>
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="redhat-release-client is version 7" id="oval:mil.disa.stig.rhel7:tst:17" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:52" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:53" />
@@ -10933,10 +10851,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="redhat-release-computenode is version 7" id="oval:mil.disa.stig.rhel7:tst:20" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:58" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:59" />
-        </rpminfo_test>
-        <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="redhat-release-computenode is version 7" id="oval:mil.fso.centos.centos7:tst:220" version="1">
-          <object object_ref="oval:mil.fso.centos.centos7:obj:258" />
-          <state state_ref="oval:mil.fso.centos.centos7:ste:259" />
         </rpminfo_test>
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="oval:mil.disa.stig.rhel7:tst:21" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:60" />
@@ -11025,19 +10939,15 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="none_exist" comment="NOPASSWD does not exist in /etc/sudoers.d" id="oval:mil.disa.stig.rhel7:tst:178" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2109" />
         </textfilecontent54_test>
-        <sysctl_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="kernel runtime parameter net.ipv4.conf.all.accept_redirects set to the appropriate value" id="oval:mil.disa.stig.rhel7:tst:320" version="1">
+        <sysctl_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="kernel runtime parameter net.ipv4.conf.all.accept_redirects set to the appropriate value" id="oval:mil.disa.stig.rhel7:tst:320" version="2">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2167" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2168" />
-        </sysctl_test>
-        <sysctl_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="kernel runtime parameter net.ipv4.conf.all.accept_source_route set to the appropriate value" id="oval:mil.disa.stig.rhel7:tst:321" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2169" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2170" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:2196" />
         </sysctl_test>
         <sysctl_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="kernel runtime parameter net.ipv4.conf.all.send_redirects set to 0" id="oval:mil.disa.stig.rhel7:tst:325" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2177" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:2178" />
         </sysctl_test>
-        <sysctl_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="kernel runtime parameter net.ipv4.conf.default.accept_redirects set to the appropriate value" id="oval:mil.disa.stig.rhel7:tst:326" version="1">
+        <sysctl_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="net.ipv4.conf.default.accept_redirects setting in kernel is set to 0" id="oval:mil.disa.stig.rhel7:tst:326" version="2">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2179" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:2180" />
         </sysctl_test>
@@ -11061,137 +10971,37 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2203" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:2204" />
         </sysctl_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv4.conf.all.accept_redirects static configuration" id="oval:mil.disa.stig.rhel7:tst:351" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2221" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2222" />
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="net.ipv4.conf.all.accept_redirects static configuration" id="oval:mil.disa.stig.rhel7:tst:351" version="2">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:20461500" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:2256" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.all.accept_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:352" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2223" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2222" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.all.accept_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:353" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2224" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2222" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.all.accept_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:354" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2225" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2222" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv4.conf.all.accept_source_route static configuration" id="oval:mil.disa.stig.rhel7:tst:355" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2226" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2227" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.all.accept_source_route static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:356" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2228" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2227" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.all.accept_source_route static configuration in /lib/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:357" version="2">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2229" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2227" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.all.accept_source_route static configuration in /usr/lib/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:358" version="2">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2230" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2227" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv4.conf.all.send_redirects static configuration" id="oval:mil.disa.stig.rhel7:tst:371" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2246" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.all.send_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:372" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2247" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.all.send_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:373" version="1">
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="net.ipv4.conf.all.send_redirects setting in acceptable directory is set to 0, and nothing else, and there are no conflicting settings in other files" id="oval:mil.disa.stig.rhel7:tst:371" version="3">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2248" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:26300" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.all.send_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:374" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2249" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv4.conf.default.accept_redirects static configuration" id="oval:mil.disa.stig.rhel7:tst:375" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2250" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2251" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.default.accept_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:376" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2252" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2251" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.default.accept_redirects static configuration in /run/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:377" version="2">
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="net.ipv4.conf.default.accept_redirects setting in a configuration file in an acceptable directory is set to 0, and nothing else, and no conflicting configurations are in the files" id="oval:mil.disa.stig.rhel7:tst:375" version="3">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2253" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:2251" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.default.accept_redirects static configuration in /usr/lib/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:378" version="2">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2254" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2251" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv4.conf.default.accept_source_route static configuration" id="oval:mil.disa.stig.rhel7:tst:379" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2255" />
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="net.ipv4.conf.default.accept_source_route static configuration" id="oval:mil.disa.stig.rhel7:tst:379" version="2">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:20461200" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:2256" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.default.accept_source_route static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:380" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2257" />
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="net.ipv4.conf.default.send_redirects static configuration" id="oval:mil.disa.stig.rhel7:tst:395" version="3">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:20461600" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:20461600" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="net.ipv4.icmp_echo_ignore_broadcasts static configuration" id="oval:mil.disa.stig.rhel7:tst:399" version="3">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:20461300" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:2280" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="net.ipv4.ip_forward static configuration" id="oval:mil.disa.stig.rhel7:tst:407" version="2">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:20462500" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:2256" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.default.accept_source_route static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:381" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2258" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2256" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.default.accept_source_route static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:382" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2259" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2256" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv4.conf.default.send_redirects static configuration" id="oval:mil.disa.stig.rhel7:tst:395" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2275" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.default.send_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:396" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2276" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.default.send_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:397" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2277" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.conf.default.send_redirects static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:398" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2278" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv4.icmp_echo_ignore_broadcasts static configuration" id="oval:mil.disa.stig.rhel7:tst:399" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2279" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2280" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.icmp_echo_ignore_broadcasts static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:400" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2281" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2280" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.icmp_echo_ignore_broadcasts static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:401" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2282" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2280" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.icmp_echo_ignore_broadcasts static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:402" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2283" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2280" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv4.ip_forward static configuration" id="oval:mil.disa.stig.rhel7:tst:407" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2289" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.ip_forward static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:408" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2290" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.ip_forward static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:409" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2291" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv4.ip_forward static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:410" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2292" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv6.conf.all.accept_source_route static configuration" id="oval:mil.disa.stig.rhel7:tst:423" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2308" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2309" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv6.conf.all.accept_source_route static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:424" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2310" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2309" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv6.conf.all.accept_source_route static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:425" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2311" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2309" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv6.conf.all.accept_source_route static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:426" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2312" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2309" />
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="net.ipv6.conf.all.accept_source_route static configuration" id="oval:mil.disa.stig.rhel7:tst:423" version="2">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:20463000" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:20463000" />
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="the value INACTIVE parameter should be set appropriately in /etc/default/useradd" id="oval:mil.disa.stig.rhel7:tst:444" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2333" />
@@ -11201,17 +11011,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="Check value of CREATE_HOME in /etc/login.defs" id="oval:mil.disa.stig.rhel7:tst:448" version="22">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2338" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:2338" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="the value maxlogins should be set appropriately in /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:450" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2341" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2340" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="the value maxlogins should be set appropriately in /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:451" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2342" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="the value maxlogins should be set appropriately in /etc/security/limits.conf" id="oval:mil.disa.stig.rhel7:tst:452" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2339" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2340" />
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="The value of PASS_MAX_DAYS should be set appropriately in /etc/login.defs" id="oval:mil.disa.stig.rhel7:tst:454" version="2">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:3729" />
@@ -11260,17 +11059,9 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="check the configuration of /etc/pam.d/system-auth" id="oval:mil.disa.stig.rhel7:tst:480" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2368" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="check the configuration of /etc/pam.d/system-auth" id="oval:mil.disa.stig.rhel7:tst:483" version="4">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2371" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2370" />
-        </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="check the configuration of /etc/security/pwquality.conf" id="oval:mil.disa.stig.rhel7:tst:485" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2372" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:2373" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="Test if remember attribute of pam_unix.so is set correctly in /etc/pam.d/system-auth" id="oval:mil.disa.stig.rhel7:tst:487" version="3">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2374" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2375" />
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="Test if remember attribute of pam_pwhistory.so is set correctly in /etc/pam.d/system-auth" id="oval:mil.disa.stig.rhel7:tst:488" version="3">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2376" />
@@ -11279,27 +11070,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="TMOUT in /etc/profile.d/*.sh" id="oval:mil.disa.stig.rhel7:tst:512" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2401" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:2400" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="run aide daily with /etc/crontab" id="oval:mil.disa.stig.rhel7:tst:527" version="2" state_operator="OR">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2412" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2412" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2413" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2414" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="run aide daily with /etc/cron.d" id="oval:mil.disa.stig.rhel7:tst:528" version="2" state_operator="OR">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2413" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2412" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2413" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2414" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="run aide daily with /var/spool/cron/root" id="oval:mil.disa.stig.rhel7:tst:529" version="2" state_operator="OR">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2414" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2412" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2413" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2414" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="run aide daily with cron.daily" id="oval:mil.disa.stig.rhel7:tst:530" version="4">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2415" />
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="audit auditctl" id="oval:mil.disa.stig.rhel7:tst:543" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2426" />
@@ -11950,9 +11720,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="none_exist" comment="make sure nullok is not used in /etc/pam.d/system-auth" id="oval:mil.disa.stig.rhel7:tst:1230" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2964" />
         </textfilecontent54_test>
-        <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" comment="package aide is installed" id="oval:mil.disa.stig.rhel7:tst:1249" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:2981" />
-        </rpminfo_test>
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" comment="package dconf is installed" id="oval:mil.disa.stig.rhel7:tst:1252" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2983" />
         </rpminfo_test>
@@ -12071,15 +11838,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="net.ipv6.conf.all.disable_ipv6 static configuration" id="oval:mil.disa.stig.rhel7:tst:1423" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:3095" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv6.conf.all.disable_ipv6 static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:1424" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:3096" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv6.conf.all.disable_ipv6 static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:1425" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:3097" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="net.ipv6.conf.all.disable_ipv6 static configuration in /etc/sysctl.d/*.conf" id="oval:mil.disa.stig.rhel7:tst:1426" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:3098" />
-        </textfilecontent54_test>
         <uname_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" comment="64 bit architecture" id="oval:mil.disa.stig.rhel7:tst:1429" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:3099" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:3100" />
@@ -12108,6 +11866,13 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" comment="/etc/system-fips exists" id="oval:mil.disa.stig.rhel7:tst:12603" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:12603" />
         </file_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" state_operator="OR" comment="RHEL 7 version is 7.0, 7.1, 7.2 or 7.3" id="oval:mil.disa.stig.rhel7:tst:15900" version="4">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:16900" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:8658500" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:8658501" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:8658502" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:8658503" />
+        </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="Supported RHEL7 minor version" id="oval:mil.disa.stig.rhel7:tst:16900" version="8">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:16900" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:16907" />
@@ -12140,9 +11905,13 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <object object_ref="oval:mil.disa.stig.rhel7:obj:17902" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:17900" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="Test if remember attribute of pam_unix.so is set correctly in /etc/pam.d/password-auth" id="oval:mil.disa.stig.rhel7:tst:48700" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:237400" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2375" />
+        <sysctl_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="kernel runtime parameter net.ipv4.conf.all.accept_source_route set to the appropriate value" id="oval:mil.disa.stig.rhel7:tst:25100" version="1">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:2169" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:25100" />
+        </sysctl_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="net.ipv4.conf.all.accept_source_route setting in acceptable directory is set to 0, and nothing else, and there are no conflicting settings in other files" id="oval:mil.disa.stig.rhel7:tst:25101" version="1">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:25103" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:25101" />
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="Test if remember attribute of pam_pwhistory.so is set correctly in /etc/pam.d/password-auth" id="oval:mil.disa.stig.rhel7:tst:48800" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:237600" />
@@ -12215,12 +11984,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <object object_ref="oval:mil.disa.stig.rhel7:obj:16900" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:8658500" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:8658501" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="run aide daily with cron.weekly" id="oval:mil.disa.stig.rhel7:tst:8659700" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:8659700" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="run aide daily with cron.hourly" id="oval:mil.disa.stig.rhel7:tst:8659701" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:8659701" />
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="kernel module usb-storage blacklisted in /etc/modprobe.d" id="oval:mil.disa.stig.rhel7:tst:8660700" version="2">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:8660700" />
@@ -12303,18 +12066,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="audit auditctl kmod" id="oval:mil.disa.stig.rhel7:tst:8681501" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:8681501" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="limits.d maxlogins in all domains configured correctly" id="oval:mil.disa.stig.rhel7:tst:8684100" version="2" check_existence="any_exist">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:450" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2340" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="limits.conf maxlogins in all domains configured correctly" id="oval:mil.disa.stig.rhel7:tst:8684101" version="2" check_existence="any_exist">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:451" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:2340" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="all values are integers" id="oval:mil.disa.stig.rhel7:tst:8684102" version="1" check_existence="at_least_one_exists">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:8684102" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:8684102" />
-        </textfilecontent54_test>
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="package openssh-server is removed" id="oval:mil.disa.stig.rhel7:tst:8687500" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:2994" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:8687500" />
@@ -12382,24 +12133,14 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <object object_ref="oval:mil.disa.stig.rhel7:obj:9251900" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:9251900" />
         </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="Check /etc/sysctl.conf has kernel.randomize_va_space set to 2" id="oval:mil.disa.stig.rhel7:tst:9252100" version="1">
+        <sysctl_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="kernel.randomize_va_space is set to 2 in kernel" check="all" id="oval:mil.disa.stig.rhel7:tst:9252100" version="2">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:9252100" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:9252100" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="Check if any .conf file in /etc/sysctl.d has kernel.randomize_va_space set to 2" id="oval:mil.disa.stig.rhel7:tst:9252101" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:9252101" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:9252100" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="none_exist" comment="Check /etc/sysctl.conf has kernel.randomize_va_space set to a value other than 2" id="oval:mil.disa.stig.rhel7:tst:9252102" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:9252102" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="none_exist" comment="Check if any .conf file in /etc/sysctl.d has kernel.randomize_va_space set to a value other than 2" id="oval:mil.disa.stig.rhel7:tst:9252103" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:9252103" />
-        </textfilecontent54_test>
-        <sysctl_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="Check if /sbin/sysctl kernel.randomize_va_space = 2" id="oval:mil.disa.stig.rhel7:tst:9252104" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel7:obj:9252104" />
-          <state state_ref="oval:mil.disa.stig.rhel7:ste:9252101" />
         </sysctl_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="kernel.randomize_va_space is set to 2 in the sysctl configuration files, and there are no conflicting settings in other files." check="all" check_existence="at_least_one_exists" id="oval:mil.disa.stig.rhel7:tst:9252101" version="3">
+          <object object_ref="oval:mil.disa.stig.rhel7:obj:9252103" />
+          <state state_ref="oval:mil.disa.stig.rhel7:ste:9252101" />
+        </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="idle-activation-enabled configuration is present" id="oval:mil.disa.stig.rhel7:tst:9370300" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:9370300" />
         </textfilecontent54_test>
@@ -12474,6 +12215,82 @@ The ability to enable/disable a session lock is given to the user by default. Di
         </textfilecontent54_test>
       </tests>
       <objects>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:20444501" version="1">
+          <filepath>/etc/crontab</filepath>
+          <pattern operation="pattern match">^[ \t]*([\S]+[ \t]+[\S]+[ \t]+\*[ \t]+\*[ \t]+[\S]+)[ \t]+root[ \t]+\/usr\/sbin\/aide[ \t]+\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:20444502" version="1">
+          <path operation="equals">/etc/cron.d</path>
+          <filename operation="pattern match">^.+$</filename>
+          <pattern operation="pattern match">^[ \t]*([\S]+[ \t]+[\S]+[ \t]+\*[ \t]+\*[ \t]+[\S]+)[ \t]+root[ \t]+\/usr\/sbin\/aide[ \t]+\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:20444503" version="1">
+          <filepath>/var/spool/cron/root</filepath>
+          <pattern operation="pattern match">^[ \t]*([\S]+[ \t]+[\S]+[ \t]+\*[ \t]+\*[ \t]+[\S]+)[ \t]+\/usr\/sbin\/aide[ \t]+\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:20444504" version="1">
+          <path operation="equals">/etc/cron.daily</path>
+          <filename operation="pattern match">^.+$</filename>
+          <pattern operation="pattern match">^[ \t]*/usr/sbin/aide[ \t]*\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:20444505" version="1">
+          <path operation="equals">/etc/cron.weekly</path>
+          <filename operation="pattern match">^.+$</filename>
+          <pattern operation="pattern match">^[ \t]*/usr/sbin/aide[ \t]*\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:20444506" version="1">
+          <path operation="equals">/etc/cron.hourly</path>
+          <filename operation="pattern match">^.+$</filename>
+          <pattern operation="pattern match">^[ \t]*/usr/sbin/aide[ \t]*\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all default maxlogins settings in /etc/security/limits.conf and /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.ind:obj:23034600" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.ind:obj:23034601</object_reference>
+            <object_reference>oval:mil.disa.stig.ind:obj:23034602</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="default maxlogins in /etc/security/limits.conf" id="oval:mil.disa.stig.ind:obj:23034601" version="1">
+          <filepath>/etc/security/limits.conf</filepath>
+          <pattern operation="pattern match">^\s*\*\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="default maxlogins in /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.ind:obj:23034602" version="1">
+          <path>/etc/security/limits.d</path>
+          <filename operation="pattern match">.*\.conf$</filename>
+          <pattern operation="pattern match">^\s*\*\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all non-default maxlogins settings in /etc/security/limits.conf and /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.ind:obj:23034603" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.ind:obj:23034604</object_reference>
+            <object_reference>oval:mil.disa.stig.ind:obj:23034605</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="non-default maxlogins in /etc/security/limits.conf" id="oval:mil.disa.stig.ind:obj:23034604" version="1">
+          <filepath>/etc/security/limits.conf</filepath>
+          <pattern operation="pattern match">^\s*[^#*\s]+\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="non-default maxlogins in /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.ind:obj:23034605" version="1">
+          <path>/etc/security/limits.d</path>
+          <filename operation="pattern match">.*\.conf$</filename>
+          <pattern operation="pattern match">^\s*[^#*\s]+\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:25171400" version="1" comment="in /etc/pam.d/system-auth check for pam_pwquality.so retry equals value">
+          <filepath>/etc/pam.d/system-auth</filepath>
+          <pattern operation="pattern match">^[ \t]*password[ \t]+(?:(?:required)|(?:requisite))[ \t]+pam_pwquality\.so(?:[ \t]+|(?:[ \t][^#\r\f\n]+[ \t]+))retry=([0-9]+)(?:\s|$)</pattern>
+          <instance datatype="int">1</instance>
+        </textfilecontent54_object>
+        <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.linux:obj:20444500" version="1">
+          <name>aide</name>
+        </rpminfo_object>
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:52" version="1">
           <name>redhat-release-client</name>
         </rpminfo_object>
@@ -12486,26 +12303,12 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:58" version="1">
           <name>redhat-release-computenode</name>
         </rpminfo_object>
-        <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:obj:258" version="1">
-          <name>centos-release</name>
-        </rpminfo_object>
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:60" version="1">
           <name>redhat-release-virtualization-host</name>
         </rpminfo_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:61" version="1">
           <filepath>/etc/redhat-release</filepath>
           <pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:450" version="6" comment="limits.d maxlogins in any domain">
-          <path>/etc/security/limits.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*[^#\s]+[\s]+(?:(?:hard)|(?:-))[\s]+maxlogins[\s]+([^#\s]+)\s*(?:#.*)?$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:451" version="7" comment="limits.conf maxlogins in any domain">
-          <filepath>/etc/security/limits.conf</filepath>
-          <pattern operation="pattern match">^[\s]*[^#\s]+[\s]+(?:(?:hard)|(?:-))[\s]+maxlogins[\s]+([^#\s]+)\s*(?:#.*)?$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="FAIL_DELAY value from /etc/login.defs" id="oval:mil.disa.stig.rhel7:obj:2055" version="2">
@@ -12634,205 +12437,62 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <pattern operation="pattern match">^\s*net\.ipv4\.conf\.all\.accept_redirects[\s]*=[\s]*(\d+)\s*$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2223" version="2">
-          <path>/etc/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.all\.accept_redirects[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2224" version="2">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.all\.accept_redirects[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2225" version="2">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.all\.accept_redirects[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2226" version="3">
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2246" version="4">
           <filepath>/etc/sysctl.conf</filepath>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.all\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
+          <pattern operation="pattern match">(?:^|\.*\n)\s*net\.ipv4\.conf\.all\.send_redirects\s*=\s*(\d+)\s*$</pattern>
+          <instance operation="greater than or equal" datatype="int">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2247" version="4">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:26300" var_check="at least one" />
+          <filename operation="pattern match">\.conf$</filename>
+          <pattern operation="pattern match">(?:^|\.*\n)\s*net\.ipv4\.conf\.all\.send_redirects\s*=\s*(\d+)\s*$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2228" version="3">
-          <path>/etc/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.all\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2248" version="4">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2246</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2247</object_reference>
+          </set>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2229" version="3">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.all\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2230" version="3">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.all\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2246" version="3">
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2250" version="4">
           <filepath>/etc/sysctl.conf</filepath>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.all\.send_redirects[\s]*=[\s]*0[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2247" version="3">
-          <path>/etc/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.all\.send_redirects[\s]*=[\s]*0[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2248" version="3">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.all\.send_redirects[\s]*=[\s]*0[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2249" version="3">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.all\.send_redirects[\s]*=[\s]*0[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2250" version="3">
-          <filepath>/etc/sysctl.conf</filepath>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.default\.accept_redirects[\s]*=[\s]*(\d+)\s*$</pattern>
+          <pattern operation="pattern match">(?:^|\.*\n)\s*net\.ipv4\.conf\.default\.accept_redirects\s*=\s*(\d+)\s*$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2252" version="3">
-          <path>/etc/sysctl.d</path>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2252" version="5">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:26600" var_check="at least one" />
           <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.default\.accept_redirects[\s]*=[\s]*(\d+)\s*$</pattern>
+          <pattern operation="pattern match">(?:^|\.*\n)\s*net\.ipv4\.conf\.default\.accept_redirects\s*=\s*(\d+)\s*$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2253" version="3">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.default\.accept_redirects[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2254" version="3">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.default\.accept_redirects[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2253" version="4">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2250</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2252</object_reference>
+          </set>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2255" version="2">
           <filepath>/etc/sysctl.conf</filepath>
           <pattern operation="pattern match">^\s*net\.ipv4\.conf\.default\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2257" version="2">
-          <path>/etc/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.default\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2258" version="2">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.default\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2259" version="2">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.default\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2275" version="2">
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2275" version="4">
           <filepath>/etc/sysctl.conf</filepath>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.default\.send_redirects[\s]*=[\s]*0[\s]*$</pattern>
-          <instance datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2276" version="2">
-          <path>/etc/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.default\.send_redirects[\s]*=[\s]*0[\s]*$</pattern>
-          <instance datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2277" version="2">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.default\.send_redirects[\s]*=[\s]*0[\s]*$</pattern>
-          <instance datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2278" version="2">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.default\.send_redirects[\s]*=[\s]*0[\s]*$</pattern>
-          <instance datatype="int">1</instance>
+          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.default\.send_redirects[\s]*=[\s]*(\d+)[\s]*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2279" version="3">
           <filepath>/etc/sysctl.conf</filepath>
           <pattern operation="pattern match">^\s*net\.ipv4\.icmp_echo_ignore_broadcasts[\s]*=[\s]*(\d+)\s*$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2281" version="3">
-          <path>/etc/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.icmp_echo_ignore_broadcasts[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2282" version="3">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.icmp_echo_ignore_broadcasts[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2283" version="3">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv4\.icmp_echo_ignore_broadcasts[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2289" version="3">
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2289" version="4">
           <filepath>/etc/sysctl.conf</filepath>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.ip_forward[\s]*=[\s]*0[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2290" version="3">
-          <path>/etc/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.ip_forward[\s]*=[\s]*0[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2291" version="3">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.ip_forward[\s]*=[\s]*0[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2292" version="3">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv4\.ip_forward[\s]*=[\s]*0[\s]*$</pattern>
+          <pattern operation="pattern match">^[\s]*net\.ipv4\.ip_forward[\s]*=[\s]*(\d+)[\s]*$</pattern>
           <instance operation="greater than or equal" datatype="int">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2308" version="2">
           <filepath>/etc/sysctl.conf</filepath>
-          <pattern operation="pattern match">^\s*net\.ipv6\.conf\.all\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2310" version="2">
-          <path>/etc/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv6\.conf\.all\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2311" version="2">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^\s*net\.ipv6\.conf\.all\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2312" version="2">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
           <pattern operation="pattern match">^\s*net\.ipv6\.conf\.all\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
@@ -12844,23 +12504,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2338" version="4">
           <filepath>/etc/login.defs</filepath>
           <pattern operation="pattern match">^\s*CREATE_HOME\s+(\S+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2339" version="5">
-          <filepath>/etc/security/limits.conf</filepath>
-          <pattern operation="pattern match">^[\s]*\*[\s]+(?:(?:hard)|(?:-))[\s]+maxlogins[\s]+([^#\s]+)\s*(?:#.*)?$</pattern>
-          <instance datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2341" version="5">
-          <path>/etc/security/limits.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*\*[\s]+(?:(?:hard)|(?:-))[\s]+maxlogins[\s]+([^#\s]+)\s*(?:#.*)?$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2342" version="1">
-          <path>/etc/security/limits.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*\*[\s]+(?:(?:hard)|(?:-))[\s]+maxlogins</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2347" version="1">
@@ -12913,20 +12556,10 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <pattern operation="pattern match">^\s*password\s+(?:(?:required)|(?:requisite))\s+pam_pwquality\.so.*$</pattern>
           <instance datatype="int">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2371" version="5" comment="in /etc/pam.d/system-auth check for pam_pwquality.so retry equals value">
-          <filepath>/etc/pam.d/system-auth</filepath>
-          <pattern operation="pattern match">^[ \t]*password[ \t]+(?:(?:required)|(?:requisite))[ \t]+pam_pwquality\.so(?:[ \t]+|(?:[ \t][^#\r\f\n]+[ \t]+))retry=([0-9]+)(?:\s|$)</pattern>
-          <instance datatype="int">1</instance>
-        </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2372" version="3">
           <filepath>/etc/security/pwquality.conf</filepath>
           <pattern operation="pattern match">^ucredit[\s]*=[\s]*(-?\d+)(?:[\s]|$)</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2374" version="8">
-          <filepath>/etc/pam.d/system-auth</filepath>
-          <pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so[^#\n\r]*remember=([0-9]*).*$</pattern>
-          <instance datatype="int">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2376" version="8">
           <filepath>/etc/pam.d/system-auth</filepath>
@@ -12938,28 +12571,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <filename operation="pattern match">^.*\.sh$</filename>
           <pattern operation="pattern match">^[\s]*declare[\s]+-xr[\s]+TMOUT[\s]*=[\s]*([\d]*)[\s]*$</pattern>
           <instance datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="run aide daily with /etc/crontab" id="oval:mil.disa.stig.rhel7:obj:2412" version="2">
-          <filepath>/etc/crontab</filepath>
-          <pattern operation="pattern match">^[ \t]*([\S]+[ \t]+[\S]+[ \t]+\*[ \t]+\*[ \t]+[\S]+)[ \t]+root[ \t]+\/usr\/sbin\/aide[ \t]+\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="run aide daily with /etc/cron.d" id="oval:mil.disa.stig.rhel7:obj:2413" version="3">
-          <path operation="equals">/etc/cron.d</path>
-          <filename operation="pattern match">^.+$</filename>
-          <pattern operation="pattern match">^[ \t]*([\S]+[ \t]+[\S]+[ \t]+\*[ \t]+\*[ \t]+[\S]+)[ \t]+root[ \t]+\/usr\/sbin\/aide[ \t]+\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="run aide daily with /var/spool/cron/root" id="oval:mil.disa.stig.rhel7:obj:2414" version="3">
-          <filepath>/var/spool/cron/root</filepath>
-          <pattern operation="pattern match">^[ \t]*([\S]+[ \t]+[\S]+[ \t]+\*[ \t]+\*[ \t]+[\S]+)[ \t]+\/usr\/sbin\/aide[ \t]+\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="run aide daily with cron.daily" id="oval:mil.disa.stig.rhel7:obj:2415" version="5">
-          <path operation="equals">/etc/cron.daily</path>
-          <filename operation="pattern match">^.+$</filename>
-          <pattern operation="pattern match">^[ \t]*/usr/sbin/aide[ \t]*\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:2426" version="2">
           <filepath>/usr/lib/systemd/system/auditd.service</filepath>
@@ -14126,9 +13737,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <pattern operation="pattern match">^[^#]*\s*nullok\s*</pattern>
           <instance datatype="int">1</instance>
         </textfilecontent54_object>
-        <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:2981" version="2" comment="Check for the package with the name of aide is installed">
-          <name>aide</name>
-        </rpminfo_object>
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:2983" version="1">
           <name>dconf</name>
         </rpminfo_object>
@@ -14275,24 +13883,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <pattern operation="pattern match">^[\s]*net\.ipv6\.conf\.all\.disable_ipv6[\s]*=[\s]*1[\s]*$</pattern>
           <instance operation="greater than or equal" datatype="int">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:3096" version="2">
-          <path>/etc/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv6\.conf\.all\.disable_ipv6[\s]*=[\s]*1[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:3097" version="2">
-          <path>/run/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv6\.conf\.all\.disable_ipv6[\s]*=[\s]*1[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:3098" version="2">
-          <path>/usr/lib/sysctl.d</path>
-          <filename operation="pattern match">^.*\.conf$</filename>
-          <pattern operation="pattern match">^[\s]*net\.ipv6\.conf\.all\.disable_ipv6[\s]*=[\s]*1[\s]*$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
         <uname_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="64 bit architecture" id="oval:mil.disa.stig.rhel7:obj:3099" version="1" />
         <uname_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="64 bit architecture" id="oval:mil.disa.stig.rhel7:obj:3101" version="1" />
         <uname_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="64 bit architecture" id="oval:mil.disa.stig.rhel7:obj:3105" version="1" />
@@ -14421,6 +14011,23 @@ The ability to enable/disable a session lock is given to the user by default. Di
             <object_reference>oval:mil.disa.stig.rhel7:obj:17901</object_reference>
           </set>
         </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="other sysctl configuration files" id="oval:mil.disa.stig.rhel7:obj:25101" version="2">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:25100" var_check="at least one" />
+          <filename operation="pattern match">\.conf$</filename>
+          <pattern operation="pattern match">(?:^|\.*\n)\s*net\.ipv4\.conf\.all\.accept_source_route\s*=\s*(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="/etc/sysctl.conf" id="oval:mil.disa.stig.rhel7:obj:25102" version="2">
+          <filepath>/etc/sysctl.conf</filepath>
+          <pattern operation="pattern match">(?:^|.*\n)\s*net\.ipv4\.conf\.all\.accept_source_route\s*=\s*(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all sysctl configuration files" id="oval:mil.disa.stig.rhel7:obj:25103" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:25101</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:25102</object_reference>
+          </set>
+        </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:68600" version="5" comment="augenrules audit /bin/mount commands">
           <path operation="equals">/etc/audit/rules.d</path>
           <filename operation="pattern match">.*\.rules$</filename>
@@ -14458,11 +14065,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <filename operation="pattern match">^.*\.conf$</filename>
           <pattern operation="pattern match">^[\s]*\[sssd\]([^\n]*\n+)+?[\s]*services.*pam.*$</pattern>
           <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:237400" version="1">
-          <filepath>/etc/pam.d/password-auth</filepath>
-          <pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so[^#\n\r]*remember=([0-9]*).*$</pattern>
-          <instance datatype="int">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:237600" version="1">
           <filepath>/etc/pam.d/password-auth</filepath>
@@ -14505,18 +14107,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <filepath datatype="string" operation="equals">/etc/shadow</filepath>
           <pattern operation="pattern match" var_ref="oval:mil.disa.stig.rhel7:var:8655502" var_check="at least one" />
           <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="run aide daily with cron.weekly" id="oval:mil.disa.stig.rhel7:obj:8659700" version="1">
-          <path operation="equals">/etc/cron.weekly</path>
-          <filename operation="pattern match">^.+$</filename>
-          <pattern operation="pattern match">^[ \t]*/usr/sbin/aide[ \t]*\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="run aide daily with cron.hourly" id="oval:mil.disa.stig.rhel7:obj:8659701" version="1">
-          <path operation="equals">/etc/cron.hourly</path>
-          <filename operation="pattern match">^.+$</filename>
-          <pattern operation="pattern match">^[ \t]*/usr/sbin/aide[ \t]*\-\-check(?:[\s]+|[\&gt;\|]|$)</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="kernel module usb-storage blacklisted in /etc/modprobe.d/*.conf" id="oval:mil.disa.stig.rhel7:obj:8660700" version="2">
           <path>/etc/modprobe.d</path>
@@ -14649,34 +14239,16 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <pattern operation="pattern match">^\-w[\s]+/etc/sudoers\.d/?[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)[-\w]+[\s]*$</pattern>
           <instance datatype="int">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:8681500" version="2">
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:8681500" version="3">
           <path operation="equals">/etc/audit/rules.d</path>
           <filename operation="pattern match">.*\.rules$</filename>
-          <pattern operation="pattern match">^[\s]*-w\s+\/usr\/bin\/kmod[\s]+((-F[\s]+perm=|-p\s+)([rwa]*x[rwa]*)[\s]+)?-F[\s]+auid!=(?:4294967295|-1|unset)[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</pattern>
+          <pattern operation="pattern match">^\s*-a\s+(always,exit|exit,always)\s+-F\s+path=\/usr\/bin\/kmod\s+(-F\s+perm=([rwa]*x[rwa]*)\s+)?-F\s+auid&gt;=1000\s+-F\s+auid!=(4294967295|-1|unset)(\s+(-k\s+|-F\s+key=)\S+)?\s*$</pattern>
           <instance datatype="int">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:8681501" version="2">
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:8681501" version="3">
           <filepath>/etc/audit/audit.rules</filepath>
-          <pattern operation="pattern match">^[\s]*-w\s+\/usr\/bin\/kmod[\s]+((-F[\s]+perm=|-p\s+)([rwa]*x[rwa]*)[\s]+)?-F[\s]+auid!=(?:4294967295|-1|unset)[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</pattern>
+          <pattern operation="pattern match">^\s*-a\s+(always,exit|exit,always)\s+-F\s+path=\/usr\/bin\/kmod\s+(-F\s+perm=([rwa]*x[rwa]*)\s+)?-F\s+auid&gt;=1000\s+-F\s+auid!=(4294967295|-1|unset)(\s+(-k\s+|-F\s+key=)\S+)?\s*$</pattern>
           <instance datatype="int">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:8684102" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
-            <object_reference>oval:mil.disa.stig.rhel7:obj:8684103</object_reference>
-            <object_reference>oval:mil.disa.stig.rhel7:obj:8684104</object_reference>
-          </set>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:8684103" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
-            <object_reference>oval:mil.disa.stig.rhel7:obj:450</object_reference>
-            <object_reference>oval:mil.disa.stig.rhel7:obj:451</object_reference>
-          </set>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:8684104" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
-            <object_reference>oval:mil.disa.stig.rhel7:obj:2339</object_reference>
-            <object_reference>oval:mil.disa.stig.rhel7:obj:2341</object_reference>
-          </set>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:8689900" version="2" comment="Checking the lines with pam_lastlog.so for the showfailed option">
           <path>/etc/pam.d</path>
@@ -14760,33 +14332,26 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <pattern datatype="string" operation="pattern match">^\s*ExecStart=([^\n#]+)$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:9252100" version="1" comment="Check what /etc/sysctl.conf has kernel.randomize_va_space is set to">
-          <filepath operation="equals">/etc/sysctl.conf</filepath>
-          <pattern operation="pattern match">^\s*kernel\.randomize_va_space\s*=\s*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:9252101" version="1" comment="Check what if any .conf file in /etc/sysctl.d has kernel.randomize_va_space is set to">
-          <behaviors max_depth="-1" recurse="symlinks and directories" recurse_direction="down" />
-          <path operation="equals">/etc/sysctl.d</path>
-          <filename operation="pattern match">^.+\.conf$</filename>
-          <pattern operation="pattern match">^\s*kernel\.randomize_va_space\s*=\s*(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:9252102" version="1" comment="Check /etc/sysctl.conf has kernel.randomize_va_space is  not set to 2">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="COMPLEMENT">
-            <object_reference>oval:mil.disa.stig.rhel7:obj:9252100</object_reference>
-            <filter>oval:mil.disa.stig.rhel7:ste:9252100</filter>
-          </set>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:9252103" version="1" comment="Check if any .conf file in /etc/sysctl.d has kernel.randomize_va_space is not set to 2">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="COMPLEMENT">
-            <object_reference>oval:mil.disa.stig.rhel7:obj:9252101</object_reference>
-            <filter>oval:mil.disa.stig.rhel7:ste:9252100</filter>
-          </set>
-        </textfilecontent54_object>
-        <sysctl_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:obj:9252104" version="1">
+        <sysctl_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:obj:9252100" version="2">
           <name>kernel.randomize_va_space</name>
         </sysctl_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:9252101" version="2">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:9252100" var_check="only one" />
+          <filename operation="pattern match">\.conf$</filename>
+          <pattern operation="pattern match">^\s*kernel\.randomize_va_space\s*=\s*(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:9252102" version="2">
+          <filepath>/etc/sysctl.conf</filepath>
+          <pattern operation="pattern match">^\s*kernel\.randomize_va_space\s*=\s*(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:9252103" version="2">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:9252101</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:9252102</object_reference>
+          </set>
+        </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:9370300" version="2">
           <behaviors recurse_direction="down" max_depth="1" multiline="true" />
           <path>/etc/dconf/db/</path>
@@ -14911,8 +14476,95 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <pattern operation="pattern match">(?i)^\s*name_format[ ]*=[ ]*([\w]+)\s*</pattern>
           <instance datatype="int">1</instance>
         </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:20461200" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2255</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:20461201</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:20461201" version="1">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:14400" var_check="at least one" />
+          <filename operation="pattern match">^.*\.conf$</filename>
+          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.default\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all sysctl configuration files" id="oval:mil.disa.stig.rhel7:obj:20461300" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2279</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:20461301</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="other sysctl configuration files" id="oval:mil.disa.stig.rhel7:obj:20461301" version="1">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:14400" var_check="at least one" />
+          <filename operation="pattern match">^.*\.conf$</filename>
+          <pattern operation="pattern match">(?:^|.*\n)\s*net.ipv4.icmp_echo_ignore_broadcasts\s*=\s*(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:20461500" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2221</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:20461501</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:20461501" version="1">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:14400" var_check="at least one" />
+          <filename operation="pattern match">^.*\.conf$</filename>
+          <pattern operation="pattern match">^\s*net\.ipv4\.conf\.all\.accept_redirects[\s]*=[\s]*(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all sysctl configuration files" id="oval:mil.disa.stig.rhel7:obj:20461600" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2275</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:20461601</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="other sysctl configuration files" id="oval:mil.disa.stig.rhel7:obj:20461601" version="1">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:14400" var_check="at least one" />
+          <filename operation="pattern match">^.*\.conf$</filename>
+          <pattern operation="pattern match">^[\s]*net\.ipv4\.conf\.default\.send_redirects[\s]*=[\s]*(\d+)[\s]*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:20462500" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2289</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:20462501</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:obj:20462501" version="1">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:14400" var_check="at least one" />
+          <filename operation="pattern match">^.*\.conf$</filename>
+          <pattern operation="pattern match">^[\s]*net\.ipv4\.ip_forward[\s]*=[\s]*(\d+)[\s]*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all sysctl configuration files" id="oval:mil.disa.stig.rhel7:obj:20463000" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.rhel7:obj:2308</object_reference>
+            <object_reference>oval:mil.disa.stig.rhel7:obj:20463001</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="other sysctl configuration files" id="oval:mil.disa.stig.rhel7:obj:20463001" version="1">
+          <path var_ref="oval:mil.disa.stig.rhel7:var:14400" var_check="at least one" />
+          <filename operation="pattern match">\.conf$</filename>
+          <pattern operation="pattern match">^\s*net\.ipv6\.conf\.all\.accept_source_route[\s]*=[\s]*(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
       </objects>
       <states>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:ste:20000018" version="1">
+          <subexpression datatype="string" operation="pattern match">^[123]$</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The days of the week must be set" id="oval:mil.disa.stig.ind:ste:20444500" version="1">
+          <subexpression datatype="string" operation="pattern match">((?:[0-5]?[0-9]|\*)[ \t]+(?:[01]?[0-9]|2[0-3]|\*)[ \t]+\*[ \t]+\*[ \t]+(?:[0-7]|sun|mon|tue|wed|thu|fri|sat))</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The hours in the day must be set" id="oval:mil.disa.stig.ind:ste:20444501" version="1">
+          <subexpression datatype="string" operation="pattern match">((?:[0-5]?[0-9]|\*)[ \t]+(?:[01]?[0-9]|2[0-3])[ \t]+\*[ \t]+\*[ \t]+(?:[0-7]|sun|mon|tue|wed|thu|fri|sat|\*))</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The minutes in an hour must be set" id="oval:mil.disa.stig.ind:ste:20444502" version="1">
+          <subexpression datatype="string" operation="pattern match">((?:[0-5]?[0-9])[ \t]+(?:[01]?[0-9]|2[0-3]|\*)[ \t]+\*[ \t]+\*[ \t]+(?:[0-7]|sun|mon|tue|wed|thu|fri|sat|\*))</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:ste:23034600" version="1">
+          <subexpression datatype="int" operation="less than or equal">10</subexpression>
+        </textfilecontent54_state>
         <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:ste:53" version="1">
           <version operation="pattern match">^7.*$</version>
         </rpminfo_state>
@@ -14923,9 +14575,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <version operation="pattern match">^7.*$</version>
         </rpminfo_state>
         <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:ste:59" version="1">
-          <version operation="pattern match">^7.*$</version>
-        </rpminfo_state>
-        <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:ste:259" version="1">
           <version operation="pattern match">^7.*$</version>
         </rpminfo_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:62" version="1">
@@ -14943,12 +14592,11 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2067" version="1">
           <user_id datatype="int">0</user_id>
         </file_state>
-        <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2069" version="5">
+        <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2069" version="6">
           <suid datatype="boolean">false</suid>
           <sgid datatype="boolean">false</sgid>
           <sticky datatype="boolean">false</sticky>
           <uexec datatype="boolean">false</uexec>
-          <gread datatype="boolean">false</gread>
           <gwrite datatype="boolean">false</gwrite>
           <gexec datatype="boolean">false</gexec>
           <oread datatype="boolean">false</oread>
@@ -14971,20 +14619,14 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="approved macs in the correct order" id="oval:mil.disa.stig.rhel7:ste:2104" version="2">
           <subexpression datatype="string" operation="pattern match">^hmac-sha2-512,hmac-sha2-256$</subexpression>
         </textfilecontent54_state>
-        <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2168" version="1">
-          <value datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3770" />
-        </sysctl_state>
-        <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2170" version="1">
-          <value datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3771" />
-        </sysctl_state>
         <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2178" version="1">
           <value datatype="int" operation="equals">0</value>
         </sysctl_state>
-        <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2180" version="1">
-          <value datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3775" />
+        <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2180" version="2">
+          <value datatype="int" operation="equals">0</value>
         </sysctl_state>
-        <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2182" version="1">
-          <value datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3776" />
+        <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2182" version="3">
+          <value datatype="int">0</value>
         </sysctl_state>
         <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2190" version="1">
           <value datatype="int" operation="equals">0</value>
@@ -14998,23 +14640,14 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:2204" version="1">
           <value datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3785" />
         </sysctl_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2222" version="1">
-          <subexpression datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3770" />
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2251" version="2">
+          <subexpression datatype="int" operation="equals">0</subexpression>
         </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2227" version="1">
-          <subexpression datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3771" />
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2256" version="3">
+          <subexpression datatype="int">0</subexpression>
         </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2251" version="1">
-          <subexpression datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3775" />
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2256" version="1">
-          <subexpression datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3776" />
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2280" version="1">
-          <subexpression datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3780" />
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2309" version="1">
-          <subexpression datatype="int" operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3785" />
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2280" version="2">
+          <subexpression datatype="int" operation="equals">1</subexpression>
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2334" version="2">
           <subexpression datatype="int" operation="less than or equal">35</subexpression>
@@ -15024,9 +14657,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2338" version="2">
           <subexpression datatype="string">yes</subexpression>
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2340" version="1">
-          <subexpression datatype="int" operation="less than or equal" var_ref="oval:mil.disa.stig.rhel7:var:3792" />
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2344" version="3">
           <subexpression datatype="int" operation="less than or equal" var_check="at least one" var_ref="oval:mil.disa.stig.rhel7:var:3793" />
@@ -15064,9 +14694,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <instance datatype="int">1</instance>
           <subexpression datatype="int" operation="less than or equal" var_ref="oval:mil.disa.stig.rhel7:var:3803" />
         </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2370" version="3" comment="Less than or equal to 3">
-          <subexpression datatype="string" operation="pattern match">^[123]$</subexpression>
-        </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2373" version="1">
           <instance datatype="int">1</instance>
           <subexpression datatype="int" operation="less than or equal" var_ref="oval:mil.disa.stig.rhel7:var:3805" />
@@ -15076,15 +14703,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2400" version="2">
           <subexpression datatype="int" operation="less than or equal">900</subexpression>
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The days of the week must be set" id="oval:mil.disa.stig.rhel7:ste:2412" version="2">
-          <subexpression datatype="string" operation="pattern match">((?:[0-5]?[0-9]|\*)[ \t]+(?:[01]?[0-9]|2[0-3]|\*)[ \t]+\*[ \t]+\*[ \t]+(?:[0-7]|sun|mon|tue|wed|thu|fri|sat))</subexpression>
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The hours in the day must be set" id="oval:mil.disa.stig.rhel7:ste:2413" version="2">
-          <subexpression datatype="string" operation="pattern match">((?:[0-5]?[0-9]|\*)[ \t]+(?:[01]?[0-9]|2[0-3])[ \t]+\*[ \t]+\*[ \t]+(?:[0-7]|sun|mon|tue|wed|thu|fri|sat|\*))</subexpression>
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The minutes in an hour must be set" id="oval:mil.disa.stig.rhel7:ste:2414" version="2">
-          <subexpression datatype="string" operation="pattern match">((?:[0-5]?[0-9])[ \t]+(?:[01]?[0-9]|2[0-3]|\*)[ \t]+\*[ \t]+\*[ \t]+(?:[0-7]|sun|mon|tue|wed|thu|fri|sat|\*))</subexpression>
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:2689" version="1">
           <subexpression operation="equals" var_ref="oval:mil.disa.stig.rhel7:var:3821" />
@@ -15149,6 +14767,15 @@ The ability to enable/disable a session lock is given to the user by default. Di
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:17900" version="1">
           <subexpression datatype="int" operation="greater than or equal">0</subexpression>
+        </textfilecontent54_state>
+        <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:25100" version="1">
+          <value datatype="int" operation="equals">0</value>
+        </sysctl_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:25101" version="1">
+          <subexpression datatype="int" operation="equals">0</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:26300" version="1">
+          <subexpression datatype="int" operation="equals">0</subexpression>
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:47000" version="1">
           <subexpression datatype="int" operation="greater than">0</subexpression>
@@ -15219,6 +14846,12 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:8658501" version="1" comment="RHEL 7.1">
           <subexpression>7.1</subexpression>
         </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:8658502" version="1">
+          <subexpression>7.2</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:8658503" version="1">
+          <subexpression>7.3</subexpression>
+        </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="/bin/true" id="oval:mil.disa.stig.rhel7:ste:8660700" version="1">
           <subexpression datatype="string" operation="equals">/bin/true</subexpression>
         </textfilecontent54_state>
@@ -15251,9 +14884,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:8671500" version="1" comment="space_left_action = email">
           <subexpression datatype="string" operation="pattern match">^[Ee][Mm][Aa][Ii][Ll]$</subexpression>
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:8684102" version="1">
-          <subexpression operation="pattern match">^\d+$</subexpression>
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:8686300" version="1">
           <subexpression datatype="string">no</subexpression>
@@ -15321,12 +14951,12 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:9251900" version="1" comment="the options assigned to ExecStart includes /usr/sbin/sulogin">
           <subexpression datatype="string" operation="pattern match">['"; ]*\/usr\/sbin\/sulogin['"; ]*</subexpression>
         </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:9252100" version="1" comment="The value was set to 2">
-          <subexpression datatype="string" operation="equals">2</subexpression>
-        </textfilecontent54_state>
-        <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:9252101" version="1">
+        <sysctl_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel7:ste:9252100" version="2">
           <value datatype="int" operation="equals">2</value>
         </sysctl_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:9252101" version="2">
+          <subexpression datatype="int" operation="equals">2</subexpression>
+        </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:9370300" version="1" comment="match paths for databases that have idle-activation-enabled locked">
           <path datatype="string" var_check="at least one" var_ref="oval:mil.disa.stig.rhel7:var:9370300" />
         </textfilecontent54_state>
@@ -15348,6 +14978,12 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:9573300" version="1" comment="The value is set to a case insensitive hostname, fqd, or numeric">
           <subexpression datatype="string" operation="pattern match">(?i)^hostname|fqd|numeric$</subexpression>
         </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:20461600" version="1">
+          <subexpression datatype="int" operation="equals">0</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:20463000" version="1">
+          <subexpression datatype="int" operation="equals">0</subexpression>
+        </textfilecontent54_state>
       </states>
       <variables>
         <external_variable comment="Expected fail_delay" datatype="int" id="oval:mil.disa.stig.rhel7:var:3761" version="1" />
@@ -15357,7 +14993,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <external_variable comment="External variable for net.ipv4.conf.default.accept_source_route" datatype="int" id="oval:mil.disa.stig.rhel7:var:3776" version="1" />
         <external_variable comment="External variable for net.ipv4.icmp_echo_ignore_broadcasts" datatype="int" id="oval:mil.disa.stig.rhel7:var:3780" version="1" />
         <external_variable comment="External variable for net.ipv6.conf.all.accept_source_route" datatype="int" id="oval:mil.disa.stig.rhel7:var:3785" version="1" />
-        <external_variable comment="maximum number of concurrent logins per user" datatype="int" id="oval:mil.disa.stig.rhel7:var:3792" version="1" />
         <external_variable comment="Maximum password age" datatype="int" id="oval:mil.disa.stig.rhel7:var:3793" version="1" />
         <external_variable comment="Minimum password age in days" datatype="int" id="oval:mil.disa.stig.rhel7:var:3794" version="1" />
         <external_variable comment="External variable for pam_pwquality dcredit" datatype="int" id="oval:mil.disa.stig.rhel7:var:3796" version="1" />
@@ -15380,6 +15015,34 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <constant_variable datatype="string" id="oval:mil.disa.stig.rhel7:var:12600" comment="grub.cfg locations" version="2">
           <value>/boot/grub2/grub.cfg</value>
           <value>/boot/efi/EFI/redhat/grub.cfg</value>
+        </constant_variable>
+        <constant_variable datatype="string" comment="other sysctl configuration file locations" id="oval:mil.disa.stig.rhel7:var:14400" version="1">
+          <value>/etc/sysctl.d</value>
+          <value>/run/sysctl.d</value>
+          <value>/lib/sysctl.d</value>
+          <value>/usr/lib/sysctl.d</value>
+          <value>/usr/local/lib/sysctl.d</value>
+        </constant_variable>
+        <constant_variable datatype="string" comment="other sysctl configuration file locations" id="oval:mil.disa.stig.rhel7:var:25100" version="1">
+          <value>/etc/sysctl.d</value>
+          <value>/run/sysctl.d</value>
+          <value>/lib/sysctl.d</value>
+          <value>/usr/lib/sysctl.d</value>
+          <value>/usr/local/lib/sysctl.d</value>
+        </constant_variable>
+        <constant_variable datatype="string" comment="other sysctl configuration file locations" id="oval:mil.disa.stig.rhel7:var:26300" version="1">
+          <value>/etc/sysctl.d</value>
+          <value>/run/sysctl.d</value>
+          <value>/lib/sysctl.d</value>
+          <value>/usr/lib/sysctl.d</value>
+          <value>/usr/local/lib/sysctl.d</value>
+        </constant_variable>
+        <constant_variable datatype="string" comment="other sysctl configuration file locations" id="oval:mil.disa.stig.rhel7:var:26600" version="1">
+          <value>/etc/sysctl.d</value>
+          <value>/run/sysctl.d</value>
+          <value>/lib/sysctl.d</value>
+          <value>/usr/lib/sysctl.d</value>
+          <value>/usr/local/lib/sysctl.d</value>
         </constant_variable>
         <local_variable id="oval:mil.disa.stig.rhel7:var:8655100" version="3" datatype="string" comment="system users">
           <object_component item_field="username" object_ref="oval:mil.disa.stig.rhel7:obj:8655101" />
@@ -15430,6 +15093,13 @@ The ability to enable/disable a session lock is given to the user by default. Di
             <literal_component>/locks</literal_component>
           </concat>
         </local_variable>
+        <constant_variable datatype="string" comment="Directories containing sysctl configuration files." id="oval:mil.disa.stig.rhel7:var:9252100" version="1">
+          <value>/etc/sysctl.d</value>
+          <value>/run/sysctl.d</value>
+          <value>/usr/local/lib/sysctl.d</value>
+          <value>/usr/lib/sysctl.d</value>
+          <value>/lib/sysctl.d</value>
+        </constant_variable>
         <local_variable id="oval:mil.disa.stig.rhel7:var:9370300" version="1" datatype="string" comment="paths for databases that have idle-activation-enabled locked">
           <regex_capture pattern="^(.*)/locks$">
             <object_component object_ref="oval:mil.disa.stig.rhel7:obj:9370302" item_field="path" />
@@ -15444,12 +15114,12 @@ The ability to enable/disable a session lock is given to the user by default. Di
       </variables>
     </oval_definitions>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_RHEL_7_V3R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2022-06-28T15:26:15">
+  <component id="scap_mil.disa.stig_comp_U_RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2023-03-28T17:40:59">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-06-28T15:26:15</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:40:58</oval:timestamp>
       </generator>
       <definitions>
         <definition class="inventory" id="oval:mil.disa.stig.rhel7:def:1" version="2">
@@ -15468,7 +15138,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
             <criterion comment="RHEL 7 Workstation is installed" test_ref="oval:mil.disa.stig.rhel7:tst:18" />
             <criterion comment="RHEL 7 Server is installed" test_ref="oval:mil.disa.stig.rhel7:tst:19" />
             <criterion comment="RHEL 7 Compute Node is installed" test_ref="oval:mil.disa.stig.rhel7:tst:20" />
-            <criterion comment="CentOS 7 is installed" test_ref="oval:mil.fso.centos.centos7:tst:220" />
             <criteria comment="Red Hat Enterpise Virtualization Host is installed" operator="AND">
               <criterion comment="redhat-release-virtualization-host RPM package is installed" test_ref="oval:mil.disa.stig.rhel7:tst:21" />
               <criterion comment="Red Hat Enterpise Virtualization Host is based on RHEL 7" test_ref="oval:mil.disa.stig.rhel7:tst:22" />
@@ -15493,10 +15162,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <object object_ref="oval:mil.disa.stig.rhel7:obj:58" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:59" />
         </rpminfo_test>
-        <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="oval:mil.fso.centos.centos7:tst:220" version="1">
-          <object object_ref="oval:mil.fso.centos.centos7:obj:258" />
-          <state state_ref="oval:mil.fso.centos.centos7:ste:259" />
-        </rpminfo_test>
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="oval:mil.disa.stig.rhel7:tst:21" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:60" />
         </rpminfo_test>
@@ -15518,9 +15183,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:58" version="1">
           <name>redhat-release-computenode</name>
         </rpminfo_object>
-        <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:obj:258" version="1">
-          <name>centos-release</name>
-        </rpminfo_object>
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:60" version="1">
           <name>redhat-release-virtualization-host</name>
         </rpminfo_object>
@@ -15541,9 +15203,6 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <version operation="pattern match">^7.*$</version>
         </rpminfo_state>
         <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:ste:59" version="1">
-          <version operation="pattern match">^7.*$</version>
-        </rpminfo_state>
-        <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:ste:259" version="1">
           <version operation="pattern match">^7.*$</version>
         </rpminfo_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:62" version="1">

--- a/scap/content/guides/disa/stig-el7-scap_1-2.xml
+++ b/scap/content/guides/disa/stig-el7-scap_1-2.xml
@@ -7387,7 +7387,8 @@ Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ 
             <criterion comment="RHEL 7 Client is installed" test_ref="oval:mil.disa.stig.rhel7:tst:17" />
             <criterion comment="RHEL 7 Workstation is installed" test_ref="oval:mil.disa.stig.rhel7:tst:18" />
             <criterion comment="RHEL 7 Server is installed" test_ref="oval:mil.disa.stig.rhel7:tst:19" />
-            <criterion comment="RHEL 7 Compute Node is installed" test_ref="oval:mil.disa.stig.rhel7:tst:20" />
+            <criterion comment="RHEL 7 Compute Node is installed" test_ref="oval:mil.disa.stig.rhel7:tst:20" />           
+            <criterion comment="CentOS Enterprise Linux 7 is installed" test_ref="oval:mil.fso.centos.centos7:tst:220" />
             <criteria comment="Red Hat Enterpise Virtualization Host is installed" operator="AND">
               <criterion comment="redhat-release-virtualization-host RPM package is installed" test_ref="oval:mil.disa.stig.rhel7:tst:21" />
               <criterion comment="Red Hat Enterpise Virtualization Host is based on RHEL 7" test_ref="oval:mil.disa.stig.rhel7:tst:22" />
@@ -10852,6 +10853,10 @@ This requirement addresses concurrent sessions for information system accounts a
           <object object_ref="oval:mil.disa.stig.rhel7:obj:58" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:59" />
         </rpminfo_test>
+        <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="oval:mil.fso.centos.centos7:tst:220" version="1">
+          <object object_ref="oval:mil.fso.centos.centos7:obj:258" />
+          <state state_ref="oval:mil.fso.centos.centos7:ste:259" />
+        </rpminfo_test>                
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="oval:mil.disa.stig.rhel7:tst:21" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:60" />
         </rpminfo_test>
@@ -12303,6 +12308,9 @@ This requirement addresses concurrent sessions for information system accounts a
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:58" version="1">
           <name>redhat-release-computenode</name>
         </rpminfo_object>
+        <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:obj:258" version="1">
+          <name>centos-release</name>
+        </rpminfo_object>                
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:60" version="1">
           <name>redhat-release-virtualization-host</name>
         </rpminfo_object>
@@ -14577,6 +14585,9 @@ This requirement addresses concurrent sessions for information system accounts a
         <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:ste:59" version="1">
           <version operation="pattern match">^7.*$</version>
         </rpminfo_state>
+        <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:ste:259" version="1">
+          <version operation="pattern match">^7.*$</version>
+        </rpminfo_state>               
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:62" version="1">
           <subexpression operation="pattern match">7</subexpression>
         </textfilecontent54_state>
@@ -15138,6 +15149,7 @@ This requirement addresses concurrent sessions for information system accounts a
             <criterion comment="RHEL 7 Workstation is installed" test_ref="oval:mil.disa.stig.rhel7:tst:18" />
             <criterion comment="RHEL 7 Server is installed" test_ref="oval:mil.disa.stig.rhel7:tst:19" />
             <criterion comment="RHEL 7 Compute Node is installed" test_ref="oval:mil.disa.stig.rhel7:tst:20" />
+            <criterion comment="CentOS 7 is installed" test_ref="oval:mil.fso.centos.centos7:tst:220" />           
             <criteria comment="Red Hat Enterpise Virtualization Host is installed" operator="AND">
               <criterion comment="redhat-release-virtualization-host RPM package is installed" test_ref="oval:mil.disa.stig.rhel7:tst:21" />
               <criterion comment="Red Hat Enterpise Virtualization Host is based on RHEL 7" test_ref="oval:mil.disa.stig.rhel7:tst:22" />
@@ -15162,6 +15174,10 @@ This requirement addresses concurrent sessions for information system accounts a
           <object object_ref="oval:mil.disa.stig.rhel7:obj:58" />
           <state state_ref="oval:mil.disa.stig.rhel7:ste:59" />
         </rpminfo_test>
+        <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="oval:mil.fso.centos.centos7:tst:220" version="1">
+          <object object_ref="oval:mil.fso.centos.centos7:obj:258" />
+          <state state_ref="oval:mil.fso.centos.centos7:ste:259" />
+        </rpminfo_test>              
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="oval:mil.disa.stig.rhel7:tst:21" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:60" />
         </rpminfo_test>
@@ -15183,6 +15199,9 @@ This requirement addresses concurrent sessions for information system accounts a
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:58" version="1">
           <name>redhat-release-computenode</name>
         </rpminfo_object>
+        <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:obj:258" version="1">
+          <name>centos-release</name>
+        </rpminfo_object>                
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:60" version="1">
           <name>redhat-release-virtualization-host</name>
         </rpminfo_object>
@@ -15205,6 +15224,9 @@ This requirement addresses concurrent sessions for information system accounts a
         <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:ste:59" version="1">
           <version operation="pattern match">^7.*$</version>
         </rpminfo_state>
+        <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:ste:259" version="1">
+          <version operation="pattern match">^7.*$</version>
+        </rpminfo_state>              
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:62" version="1">
           <subexpression operation="pattern match">7</subexpression>
         </textfilecontent54_state>

--- a/scap/content/guides/disa/stig-el7-scap_1-2.xml
+++ b/scap/content/guides/disa/stig-el7-scap_1-2.xml
@@ -2014,14 +2014,14 @@ Satisfies: SRG-OS-000375-GPOS-00161,SRG-OS-000375-GPOS-00162&lt;/VulnDiscussion&
 
 Note: If the system does not have GNOME installed, this requirement is Not Applicable.
 
-Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command: 
+Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command:
 
 Note: The example is using the database local for the system, so if the system is using another database in "/etc/dconf/profile/user", the file should be created under the appropriate subdirectory.
 
 # touch /etc/dconf/db/local.d/00-defaults
 
 Edit "[org/gnome/login-screen]" and add or update the following line:
-enable-smartcard-authentication=true   
+enable-smartcard-authentication=true
 
 Update the system databases:
 # dconf update</xccdf:fixtext>
@@ -2099,7 +2099,7 @@ The session lock is implemented at the point where session activity can be deter
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
           <xccdf:fixtext fixref="F-4523r880772_fix">Configure the operating system to prevent a user from overriding a screensaver lock after a 15-minute period of inactivity for graphical user interfaces.
 
-Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command: 
+Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command:
 
 Note: The example below is using the database "local" for the system, so if the system is using another database in "/etc/dconf/profile/user", the file should be created under the appropriate subdirectory.
 
@@ -2136,7 +2136,7 @@ The session lock is implemented at the point where session activity can be deter
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
           <xccdf:fixtext fixref="F-4526r880781_fix">Configure the operating system to initiate a session lock after a 15-minute period of inactivity for graphical user interfaces.
 
-Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command: 
+Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command:
 
      # touch /etc/dconf/db/local.d/00-screensaver
 
@@ -2180,7 +2180,7 @@ The ability to enable/disable a session lock is given to the user by default. Di
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
           <xccdf:fixtext fixref="F-4527r880784_fix">Configure the operating system to prevent a user from overriding a screensaver lock after a 15-minute period of inactivity for graphical user interfaces.
 
-Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command: 
+Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command:
 
 Note: The example below is using the database "local" for the system, so if the system is using another database in "/etc/dconf/profile/user", the file should be created under the appropriate subdirectory.
 
@@ -2217,7 +2217,7 @@ The session lock is implemented at the point where session activity can be deter
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
           <xccdf:fixtext fixref="F-4528r880787_fix">Configure the operating system to initiate a session lock for graphical user interfaces when a screensaver is activated.
 
-Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command: 
+Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command:
 
      # touch /etc/dconf/db/local.d/00-screensaver
 
@@ -2351,7 +2351,7 @@ Password complexity is one factor of several that determines how long it takes t
           <xccdf:ident system="http://cyber.mil/cci">CCI-000193</xccdf:ident>
           <xccdf:fixtext fixref="F-4532r88417_fix">Configure the system to require at least one lower-case character when creating or changing a password.
 
-Add or modify the following line 
+Add or modify the following line
 in "/etc/security/pwquality.conf":
 
 lcredit = -1</xccdf:fixtext>
@@ -2636,7 +2636,7 @@ ENCRYPT_METHOD SHA512</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000196</xccdf:ident>
           <xccdf:fixtext fixref="F-4541r88444_fix">Configure the operating system to store only SHA512 encrypted representations of passwords.
 
-Add or update the following line in "/etc/libuser.conf" in the [defaults] section: 
+Add or update the following line in "/etc/libuser.conf" in the [defaults] section:
 
 crypt_style = sha512</xccdf:fixtext>
           <xccdf:fix id="F-4541r88444_fix" />
@@ -2780,7 +2780,7 @@ PASS_MAX_DAYS     60</xccdf:fixtext>
 Add the following line in "/etc/pam.d/system-auth" and "/etc/pam.d/password-auth" (or modify the line to have the required value):
 
      password     requisite     pam_pwhistory.so use_authtok remember=5 retry=3
-   
+
 Note: Per requirement RHEL-07-010199, RHEL 7 must be configured to not overwrite custom authentication configuration settings while using the authconfig utility, otherwise manual changes to the listed files will be overwritten whenever the authconfig utility is used.</xccdf:fixtext>
           <xccdf:fix id="F-4546r880835_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -2917,7 +2917,7 @@ DoD recommendation is 35 days, but a lower value is acceptable. The value "-1" w
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204429r861003_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010340</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that users must provide a password for privilege escalation.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization.
 
 When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate.
 
@@ -2956,7 +2956,7 @@ Remove any occurrences of "NOPASSWD" tags in the file.</xccdf:fixtext>
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204430r853885_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010350</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that users must re-authenticate for privilege escalation.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization.
 
 When operating systems provide the capability to escalate a functional capability, it is critical the user reauthenticate.
 
@@ -3196,7 +3196,7 @@ ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block d
           <xccdf:fixtext fixref="F-4562r744094_fix">Configure the system to encrypt the boot password for the grub superusers account with the grub2-setpassword command, which creates/overwrites the /boot/grub2/user.cfg file.
 
 Generate an encrypted grub2 password for the grub superusers account with the following command:
-  
+
 $ sudo grub2-setpassword
 Enter password:
 Confirm password:</xccdf:fixtext>
@@ -3316,9 +3316,9 @@ Detecting such changes and providing an automated response can help avoid uninte
           <xccdf:ident system="http://cyber.mil/legacy">SV-86597</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-71973</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001744</xccdf:ident>
-          <xccdf:fixtext fixref="F-36304r902697_fix">Configure the file integrity tool to run automatically on the system at least weekly. 
+          <xccdf:fixtext fixref="F-36304r902697_fix">Configure the file integrity tool to run automatically on the system at least weekly.
 
-The following example output is generic. It will set cron to run AIDE daily, but other file integrity tools may be used:  
+The following example output is generic. It will set cron to run AIDE daily, but other file integrity tools may be used:
 
      # more /etc/cron.daily/aide
      #!/bin/bash
@@ -3465,7 +3465,7 @@ Add the following line to the created file:
 
 install dccp /bin/true
 
-Ensure that the DCCP module is blacklisted: 
+Ensure that the DCCP module is blacklisted:
 
 # vi /etc/modprobe.d/blacklist.conf
 
@@ -3643,7 +3643,7 @@ Red Hat offers the Extended Update Support (EUS) Add-On to a Red Hat Enterprise 
           <xccdf:ident system="http://cyber.mil/legacy">SV-86629</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72005</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4586r88579_fix">Change the UID of any account on the system, other than root, that has a UID of "0". 
+          <xccdf:fixtext fixref="F-4586r88579_fix">Change the UID of any account on the system, other than root, that has a UID of "0".
 
 If the account is associated with system commands or applications, the UID should be changed to one greater than "0" but less than "1000". Otherwise, assign a UID of greater than "1000" that has not already been assigned.</xccdf:fixtext>
           <xccdf:fix id="F-4586r88579_fix" />
@@ -3702,7 +3702,7 @@ In addition, if a local interactive user has a home directory defined that does 
 
 Note: The example will be for the user smithj, who has a home directory of "/home/smithj", a UID of "smithj", and a Group Identifier (GID) of "users" assigned in "/etc/passwd".
 
-# mkdir /home/smithj 
+# mkdir /home/smithj
 # chown smithj /home/smithj
 # chgrp users /home/smithj
 # chmod 0750 /home/smithj</xccdf:fixtext>
@@ -3938,7 +3938,7 @@ The only authorized public directories are those temporary directories supplied 
           <xccdf:fixtext fixref="F-36309r602637_fix">Start the "tmp.mount" service with the following command:
 
 # systemctl enable tmp.mount
-   
+
 OR
 
 Edit the "/etc/fstab" file and ensure the "/tmp" directory is defined in the fstab with a device and mount point.</xccdf:fixtext>
@@ -3975,7 +3975,7 @@ Satisfies: SRG-OS-000033-GPOS-00014, SRG-OS-000185-GPOS-00079, SRG-OS-000396-GPO
 
 To enable strict FIPS compliance, the fips=1 kernel option needs to be added to the kernel command line during system installation so key generation is done with FIPS-approved algorithms and continuous monitoring tests in place.
 
-Configure the operating system to implement DoD-approved encryption by following the steps below: 
+Configure the operating system to implement DoD-approved encryption by following the steps below:
 
 The fips=1 kernel option needs to be added to the kernel command line during system installation so that key generation is done with FIPS-approved algorithms and continuous monitoring tests in place. Users should also ensure that the system has plenty of entropy during the installation process by moving the mouse around, or if no mouse is available, ensuring that many keystrokes are typed. The recommended amount of keystrokes is 256 and more. Less than 256 keystrokes may generate a non-unique key.
 
@@ -4397,8 +4397,8 @@ network_failure_action = syslog</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001855</xccdf:ident>
           <xccdf:fixtext fixref="F-4638r88735_fix">Configure the operating system to immediately notify the SA and ISSO (at a minimum) when the threshold for the repository maximum audit record storage capacity is reached.
 
-Uncomment or edit the "space_left_action" keyword in "/etc/audit/auditd.conf" and set it to "email". 
- 
+Uncomment or edit the "space_left_action" keyword in "/etc/audit/auditd.conf" and set it to "email".
+
 space_left_action = email</xccdf:fixtext>
           <xccdf:fix id="F-4638r88735_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4426,8 +4426,8 @@ space_left_action = email</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001855</xccdf:ident>
           <xccdf:fixtext fixref="F-4639r88738_fix">Configure the operating system to immediately notify the SA and ISSO (at a minimum) when the threshold for the repository maximum audit record storage capacity is reached.
 
-Uncomment or edit the "action_mail_acct" keyword in "/etc/audit/auditd.conf" and set it to root and any other accounts associated with security personnel. 
- 
+Uncomment or edit the "action_mail_acct" keyword in "/etc/audit/auditd.conf" and set it to root and any other accounts associated with security personnel.
+
 action_mail_acct = root</xccdf:fixtext>
           <xccdf:fix id="F-4639r88738_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -4812,9 +4812,9 @@ Satisfies: SRG-OS-000392-GPOS-00172, SRG-OS-000470-GPOS-00214, SRG-OS-000473-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000126</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4664r88813_fix">Configure the operating system to generate audit records when unsuccessful account access events occur. 
+          <xccdf:fixtext fixref="F-4664r88813_fix">Configure the operating system to generate audit records when unsuccessful account access events occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -w /var/run/faillock -p wa -k logins
 
@@ -4849,9 +4849,9 @@ Satisfies: SRG-OS-000392-GPOS-00172, SRG-OS-000470-GPOS-00214, SRG-OS-000473-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000126</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4665r88816_fix">Configure the operating system to generate audit records when successful account access events occur. 
+          <xccdf:fixtext fixref="F-4665r88816_fix">Configure the operating system to generate audit records when successful account access events occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -w /var/log/lastlog -p wa -k logins
 
@@ -5086,9 +5086,9 @@ Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
           <xccdf:fixtext fixref="F-4671r861040_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "su" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
--a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change 
+-a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4671r861040_fix" />
@@ -5126,9 +5126,9 @@ Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
           <xccdf:fixtext fixref="F-4672r861043_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "sudo" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
--a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change 
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-4672r861043_fix" />
@@ -5206,7 +5206,7 @@ Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
           <xccdf:fixtext fixref="F-4674r861046_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "newgrp" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
@@ -5246,7 +5246,7 @@ Satisfies: SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
           <xccdf:fixtext fixref="F-4675r861049_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "chsh" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
 
@@ -5324,7 +5324,7 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
           <xccdf:fixtext fixref="F-4677r861055_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "umount" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-mount
 
@@ -5362,7 +5362,7 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
           <xccdf:fixtext fixref="F-4678r861058_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "postdrop" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-postfix
 
@@ -5398,9 +5398,9 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">V-72177</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4679r861061_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "postqueue" command occur. 
+          <xccdf:fixtext fixref="F-4679r861061_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "postqueue" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-postfix
 
@@ -5437,9 +5437,9 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4680r861064_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "ssh-keysign" command occur. 
+          <xccdf:fixtext fixref="F-4680r861064_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "ssh-keysign" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-ssh
 
@@ -5476,9 +5476,9 @@ Satisfies: SRG-OS-000042-GPOS-00020, SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPO
           <xccdf:ident system="http://cyber.mil/cci">CCI-000135</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002884</xccdf:ident>
-          <xccdf:fixtext fixref="F-4681r861067_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "crontab" command occur. 
+          <xccdf:fixtext fixref="F-4681r861067_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "crontab" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-cron
 
@@ -5509,9 +5509,9 @@ When a user logs on, the auid is set to the uid of the account that is being aut
           <xccdf:ident system="http://cyber.mil/legacy">V-72185</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86809</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:fixtext fixref="F-4682r833165_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "pam_timestamp_check" command occur. 
+          <xccdf:fixtext fixref="F-4682r833165_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "pam_timestamp_check" command occur.
 
-Add or update the following rule in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-pam
 
@@ -5528,7 +5528,7 @@ The audit daemon must be restarted for the changes to take effect.</xccdf:fixtex
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204559r833169_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030819</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the create_module syscall.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
 Audit records can be generated from various components within the information system (e.g., module or policy filter).
 
@@ -5564,7 +5564,7 @@ The audit daemon must be restarted for the changes to take effect.</xccdf:fixtex
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204560r833172_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030820</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the init_module and finit_module syscalls.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
 Audit records can be generated from various components within the information system (e.g., module or policy filter).
 
@@ -5582,7 +5582,7 @@ Satisfies: SRG-OS-000471-GPOS-00216, SRG-OS-000477-GPOS-00222&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">V-72187</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86811</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:fixtext fixref="F-4684r833171_fix">Configure the operating system to generate audit records upon successful/unsuccessful attempts to use the "init_module" and "finit_module" syscalls. 
+          <xccdf:fixtext fixref="F-4684r833171_fix">Configure the operating system to generate audit records upon successful/unsuccessful attempts to use the "init_module" and "finit_module" syscalls.
 
 Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 
@@ -5603,7 +5603,7 @@ The audit daemon must be restarted for the changes to take effect.</xccdf:fixtex
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204562r833175_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030830</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the delete_module syscall.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
 Audit records can be generated from various components within the information system (e.g., module or policy filter).
 
@@ -5619,9 +5619,9 @@ Satisfies: SRG-OS-000471-GPOS-00216, SRG-OS-000477-GPOS-00222&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">V-72189</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86813</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:fixtext fixref="F-4686r833174_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "delete_module" syscall occur. 
+          <xccdf:fixtext fixref="F-4686r833174_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "delete_module" syscall occur.
 
-Add or update the following rules in "/etc/audit/rules.d/audit.rules": 
+Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F arch=b32 -S delete_module -F auid&gt;=1000 -F auid!=unset -k module-change
 
@@ -5640,7 +5640,7 @@ The audit daemon must be restarted for the changes to take effect.</xccdf:fixtex
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204563r858498_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-030840</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must audit all uses of the kmod command.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
 Audit records can be generated from various components within the information system (e.g., module or policy filter).
 
@@ -5657,7 +5657,7 @@ Satisfies: SRG-OS-000471-GPOS-00216, SRG-OS-000477-GPOS-00222&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-86815</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72191</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:fixtext fixref="F-4687r858497_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "kmod" command occur. 
+          <xccdf:fixtext fixref="F-4687r858497_fix">Configure the operating system to generate audit records when successful/unsuccessful attempts to use the "kmod" command occur.
 
 Add or update the following rule in "/etc/audit/rules.d/audit.rules":
 
@@ -5970,7 +5970,7 @@ The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204579r861070_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040160</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that all network connections associated with a communication session are terminated at the end of the session or after 15 minutes of inactivity from the user at a command prompt, except to fulfill documented and validated mission requirements.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle session will also free up resources committed by the managed network element. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle session will also free up resources committed by the managed network element.
 
 Terminating network connections associated with communications sessions includes, for example, de-allocating associated TCP/IP address/port pairs at the operating system level and de-allocating networking assignments at the application level if multiple application sessions are using a single operating system-level network connection. This does not mean that the operating system terminates all sessions or network access; it only ends the inactive session and releases the resources associated with that session.
 
@@ -6037,9 +6037,9 @@ Issue the following command to make the changes take effect:
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-204585r853989_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-040300</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must be configured so that all networked systems have SSH installed.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered.
 
-This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. 
+This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification.
 
 Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, logical means (cryptography) do not have to be employed, and vice versa.
 
@@ -6374,7 +6374,7 @@ The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">V-72255</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86879</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4720r88981_fix">Note: SSH public key files may be found in other directories on the system depending on the installation. 
+          <xccdf:fixtext fixref="F-4720r88981_fix">Note: SSH public key files may be found in other directories on the system depending on the installation.
 
 Change the mode of public host key files under "/etc/ssh" to "0644" with the following command:
 
@@ -6433,7 +6433,7 @@ Change the mode of public host key files under "/etc/ssh" to "0644" with the fol
           <xccdf:ident system="http://cyber.mil/cci">CCI-001812</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001813</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001814</xccdf:ident>
-          <xccdf:fixtext fixref="F-4722r88987_fix">Uncomment the "GSSAPIAuthentication" keyword in "/etc/ssh/sshd_config" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor) and set the value to "no": 
+          <xccdf:fixtext fixref="F-4722r88987_fix">Uncomment the "GSSAPIAuthentication" keyword in "/etc/ssh/sshd_config" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor) and set the value to "no":
 
 GSSAPIAuthentication no
 
@@ -6584,7 +6584,7 @@ The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86899</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72275</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000052</xccdf:ident>
-          <xccdf:fixtext fixref="F-4729r89008_fix">Configure the operating system to provide users with feedback on when account accesses last occurred by setting the required configuration options in "/etc/pam.d/postlogin". 
+          <xccdf:fixtext fixref="F-4729r89008_fix">Configure the operating system to provide users with feedback on when account accesses last occurred by setting the required configuration options in "/etc/pam.d/postlogin".
 
 Add the following line to the top of "/etc/pam.d/postlogin":
 
@@ -6667,10 +6667,10 @@ session required pam_lastlog.so showfailed</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
           <xccdf:fixtext fixref="F-4733r880796_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-     net.ipv4.conf.all.accept_source_route = 0   
+     net.ipv4.conf.all.accept_source_route = 0
 
 Issue the following command to make the changes take effect:
- 
+
      # sysctl -system</xccdf:fixtext>
           <xccdf:fix id="F-4733r880796_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -6699,10 +6699,10 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
           <xccdf:fixtext fixref="F-4736r880805_fix">Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-     net.ipv4.conf.default.accept_source_route = 0   
+     net.ipv4.conf.default.accept_source_route = 0
 
 Issue the following command to make the changes take effect:
- 
+
      # sysctl --system</xccdf:fixtext>
           <xccdf:fix id="F-4736r880805_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
@@ -6733,7 +6733,7 @@ Issue the following command to make the changes take effect:
 
      net.ipv4.icmp_echo_ignore_broadcasts = 1
 
-Issue the following command to make the changes take effect: 
+Issue the following command to make the changes take effect:
 
      # sysctl --system</xccdf:fixtext>
           <xccdf:fix id="F-4737r880808_fix" />
@@ -6763,7 +6763,7 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
           <xccdf:fixtext fixref="F-4738r880811_fix">Set the system to not accept IPv4 ICMP redirect messages by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-     net.ipv4.conf.default.accept_redirects = 0   
+     net.ipv4.conf.default.accept_redirects = 0
 
 Issue the following command to make the changes take effect:
 
@@ -6795,7 +6795,7 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
           <xccdf:fixtext fixref="F-4739r880814_fix">Set the system to ignore IPv4 ICMP redirect messages by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
-     net.ipv4.conf.all.accept_redirects = 0   
+     net.ipv4.conf.all.accept_redirects = 0
 
 Issue the following command to make the changes take effect:
 
@@ -6825,7 +6825,7 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/legacy">V-72291</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86915</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4740r880817_fix">Configure the system to not allow interfaces to perform IPv4 ICMP redirects by default. 
+          <xccdf:fixtext fixref="F-4740r880817_fix">Configure the system to not allow interfaces to perform IPv4 ICMP redirects by default.
 
 Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
@@ -6858,7 +6858,7 @@ Issue the following command to make the changes take effect:
           <xccdf:ident system="http://cyber.mil/legacy">V-72293</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-86917</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-4741r880820_fix">Configure the system to not allow interfaces to perform IPv4 ICMP redirects. 
+          <xccdf:fixtext fixref="F-4741r880820_fix">Configure the system to not allow interfaces to perform IPv4 ICMP redirects.
 
 Set the system to the required kernel parameter by adding the following line to "/etc/sysctl.conf" or a configuration file in the /etc/sysctl.d/ directory (or modify the line to have the required value):
 
@@ -7268,7 +7268,7 @@ ALL     ALL=(ALL:ALL) ALL</xccdf:fixtext>
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237634r880755_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010342</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must use the invoking user's password for privilege escalation when using "sudo".</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;The sudoers security policy requires that users authenticate themselves before they can use sudo. When sudoers requires authentication, it validates the invoking user's credentials. If the rootpw, targetpw, or runaspw flags are defined and not disabled, by default the operating system will prompt the invoking user for the "root" user password. 
+          <xccdf:description>&lt;VulnDiscussion&gt;The sudoers security policy requires that users authenticate themselves before they can use sudo. When sudoers requires authentication, it validates the invoking user's credentials. If the rootpw, targetpw, or runaspw flags are defined and not disabled, by default the operating system will prompt the invoking user for the "root" user password.
 For more information on each of the listed configurations, reference the sudoers(5) manual page.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Red Hat Enterprise Linux 7</dc:title>
@@ -7283,7 +7283,7 @@ For more information on each of the listed configurations, reference the sudoers
      Defaults !rootpw
      Defaults !runaspw
 
-Remove any configurations that conflict with the above from the following locations: 
+Remove any configurations that conflict with the above from the following locations:
      /etc/sudoers
      /etc/sudoers.d/</xccdf:fixtext>
           <xccdf:fix id="F-40816r880754_fix" />
@@ -7298,7 +7298,7 @@ Remove any configurations that conflict with the above from the following locati
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237635r861075_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-07-010343</xccdf:version>
           <xccdf:title>The Red Hat Enterprise Linux operating system must require re-authentication when using the "sudo" command.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization.
 
 When operating systems provide the capability to escalate a functional capability, it is critical the organization requires the user to re-authenticate when using the "sudo" command.
 
@@ -7387,7 +7387,7 @@ Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ 
             <criterion comment="RHEL 7 Client is installed" test_ref="oval:mil.disa.stig.rhel7:tst:17" />
             <criterion comment="RHEL 7 Workstation is installed" test_ref="oval:mil.disa.stig.rhel7:tst:18" />
             <criterion comment="RHEL 7 Server is installed" test_ref="oval:mil.disa.stig.rhel7:tst:19" />
-            <criterion comment="RHEL 7 Compute Node is installed" test_ref="oval:mil.disa.stig.rhel7:tst:20" />           
+            <criterion comment="RHEL 7 Compute Node is installed" test_ref="oval:mil.disa.stig.rhel7:tst:20" />
             <criterion comment="CentOS Enterprise Linux 7 is installed" test_ref="oval:mil.fso.centos.centos7:tst:220" />
             <criteria comment="Red Hat Enterpise Virtualization Host is installed" operator="AND">
               <criterion comment="redhat-release-virtualization-host RPM package is installed" test_ref="oval:mil.disa.stig.rhel7:tst:21" />
@@ -7417,7 +7417,7 @@ Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ 
               <platform>Red Hat Enterprise Linux 7</platform>
             </affected>
             <reference ref_id="CCE-80346-0" source="http://cce.mitre.org" />
-            <description>The clean_requirements_on_remove option should be used to ensure that old 
+            <description>The clean_requirements_on_remove option should be used to ensure that old
       versions of software components are removed after updating.</description>
             <reference ref_id="clean_components_post_updating" source="ssg" />
           </metadata>
@@ -7432,7 +7432,7 @@ Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ 
               <platform>Red Hat Enterprise Linux 7</platform>
             </affected>
             <reference ref_id="CCE-80347-8" source="http://cce.mitre.org" />
-            <description>The localpkg_gpgcheck option should be used to ensure that checking 
+            <description>The localpkg_gpgcheck option should be used to ensure that checking
       of an RPM package's signature always occurs prior to its
       installation.</description>
             <reference ref_id="ensure_gpgcheck_local_packages" source="ssg" />
@@ -7751,7 +7751,7 @@ By specifying a hash algorithm list with the order of hashes being in a "stronge
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 7</platform>
             </affected>
-            <description>The sudoers security policy requires that users authenticate themselves before they can use sudo. When sudoers requires authentication, it validates the invoking user's credentials. If the rootpw, targetpw, or runaspw flags are defined and not disabled, by default the operating system will prompt the invoking user for the "root" user password. 
+            <description>The sudoers security policy requires that users authenticate themselves before they can use sudo. When sudoers requires authentication, it validates the invoking user's credentials. If the rootpw, targetpw, or runaspw flags are defined and not disabled, by default the operating system will prompt the invoking user for the "root" user password.
 For more information on each of the listed configurations, reference the sudoers(5) manual page.</description>
           </metadata>
           <criteria operator="AND">
@@ -7775,7 +7775,7 @@ For more information on each of the listed configurations, reference the sudoers
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 7</platform>
             </affected>
-            <description>Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
+            <description>Without re-authentication, users may access resources or perform tasks for which they do not have authorization.
 
 When operating systems provide the capability to escalate a functional capability, it is critical the organization requires the user to re-authenticate when using the "sudo" command.
 
@@ -8350,7 +8350,7 @@ Password complexity is one factor of several that determines how long it takes t
             <affected family="unix">
               <platform>multi_platform_rhel</platform>
             </affected>
-            <description>Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle session will also free up resources committed by the managed network element. 
+            <description>Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle session will also free up resources committed by the managed network element.
 
 Terminating network connections associated with communications sessions includes, for example, de-allocating associated TCP/IP address/port pairs at the operating system level and de-allocating networking assignments at the application level if multiple application sessions are using a single operating system-level network connection. This does not mean that the operating system terminates all sessions or network access; it only ends the inactive session and releases the resources associated with that session.</description>
             <reference ref_id="accounts_tmout" source="ssg" />
@@ -8681,7 +8681,7 @@ The system call rules are loaded into a matching engine that intercepts each sys
             </affected>
             <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-80414-6" />
             <reference ref_id="audit_rules_kernel_module_loading_init" source="ssg" />
-            <description>Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+            <description>Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
 Audit records can be generated from various components within the information system (e.g., module or policy filter).
 The system call rules are loaded into a matching engine that intercepts each syscall that all programs on the system makes. Therefore, it is very important to only use syscall rules when you have to since these affect performance. The more rules, the bigger the performance hit. You can help the performance, though, by combining syscalls into one rule whenever possible.</description>
@@ -8829,7 +8829,7 @@ The system call rules are loaded into a matching engine that intercepts each sys
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 7</platform>
             </affected>
-            <description>Misuse of privileged functions, either intentionally or unintentionally by authorized users, or by unauthorized external entities that have compromised information system accounts, is a serious and ongoing concern and can have a significant adverse impacts on orginizations.  
+            <description>Misuse of privileged functions, either intentionally or unintentionally by authorized users, or by unauthorized external entities that have compromised information system accounts, is a serious and ongoing concern and can have a significant adverse impacts on orginizations.
 		Auditing the use of privileged functions is one way to detect such misuse and identify the risk from insider threats and the advanced persistent threat.</description>
             <reference ref_id="audit_rules_privileged_commands" source="ssg" />
           </metadata>
@@ -10856,7 +10856,7 @@ This requirement addresses concurrent sessions for information system accounts a
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="oval:mil.fso.centos.centos7:tst:220" version="1">
           <object object_ref="oval:mil.fso.centos.centos7:obj:258" />
           <state state_ref="oval:mil.fso.centos.centos7:ste:259" />
-        </rpminfo_test>                
+        </rpminfo_test>
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="oval:mil.disa.stig.rhel7:tst:21" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:60" />
         </rpminfo_test>
@@ -12310,7 +12310,7 @@ This requirement addresses concurrent sessions for information system accounts a
         </rpminfo_object>
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:obj:258" version="1">
           <name>centos-release</name>
-        </rpminfo_object>                
+        </rpminfo_object>
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:60" version="1">
           <name>redhat-release-virtualization-host</name>
         </rpminfo_object>
@@ -14587,7 +14587,7 @@ This requirement addresses concurrent sessions for information system accounts a
         </rpminfo_state>
         <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:ste:259" version="1">
           <version operation="pattern match">^7.*$</version>
-        </rpminfo_state>               
+        </rpminfo_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:62" version="1">
           <subexpression operation="pattern match">7</subexpression>
         </textfilecontent54_state>
@@ -15149,7 +15149,7 @@ This requirement addresses concurrent sessions for information system accounts a
             <criterion comment="RHEL 7 Workstation is installed" test_ref="oval:mil.disa.stig.rhel7:tst:18" />
             <criterion comment="RHEL 7 Server is installed" test_ref="oval:mil.disa.stig.rhel7:tst:19" />
             <criterion comment="RHEL 7 Compute Node is installed" test_ref="oval:mil.disa.stig.rhel7:tst:20" />
-            <criterion comment="CentOS 7 is installed" test_ref="oval:mil.fso.centos.centos7:tst:220" />           
+            <criterion comment="CentOS 7 is installed" test_ref="oval:mil.fso.centos.centos7:tst:220" />
             <criteria comment="Red Hat Enterpise Virtualization Host is installed" operator="AND">
               <criterion comment="redhat-release-virtualization-host RPM package is installed" test_ref="oval:mil.disa.stig.rhel7:tst:21" />
               <criterion comment="Red Hat Enterpise Virtualization Host is based on RHEL 7" test_ref="oval:mil.disa.stig.rhel7:tst:22" />
@@ -15177,7 +15177,7 @@ This requirement addresses concurrent sessions for information system accounts a
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="at_least_one_exists" comment="centos-release is version 7" id="oval:mil.fso.centos.centos7:tst:220" version="1">
           <object object_ref="oval:mil.fso.centos.centos7:obj:258" />
           <state state_ref="oval:mil.fso.centos.centos7:ste:259" />
-        </rpminfo_test>              
+        </rpminfo_test>
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="only_one_exists" comment="redhat-release-virtualization-host RPM package is installed" id="oval:mil.disa.stig.rhel7:tst:21" version="1">
           <object object_ref="oval:mil.disa.stig.rhel7:obj:60" />
         </rpminfo_test>
@@ -15201,7 +15201,7 @@ This requirement addresses concurrent sessions for information system accounts a
         </rpminfo_object>
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:obj:258" version="1">
           <name>centos-release</name>
-        </rpminfo_object>                
+        </rpminfo_object>
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel7:obj:60" version="1">
           <name>redhat-release-virtualization-host</name>
         </rpminfo_object>
@@ -15226,7 +15226,7 @@ This requirement addresses concurrent sessions for information system accounts a
         </rpminfo_state>
         <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.fso.centos.centos7:ste:259" version="1">
           <version operation="pattern match">^7.*$</version>
-        </rpminfo_state>              
+        </rpminfo_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel7:ste:62" version="1">
           <subexpression operation="pattern match">7</subexpression>
         </textfilecontent54_state>

--- a/scap/content/guides/disa/stig-el8-scap_1-2.xml
+++ b/scap/content/guides/disa/stig-el8-scap_1-2.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#unix http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/unix-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
-  <data-stream id="scap_mil.disa.stig_datastream_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2022-06-28T15:27:20">
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/linux-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#unix http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/unix-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
+  <data-stream id="scap_mil.disa.stig_datastream_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2023-03-28T17:41:02">
     <dictionaries>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+          <cat:uri name="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
         </cat:catalog>
       </component-ref>
     </dictionaries>
     <checklists>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-xccdf.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-xccdf.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          <cat:uri name="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
         </cat:catalog>
       </component-ref>
     </checklists>
     <checks>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
     </checks>
   </data-stream>
-  <component id="scap_mil.disa.stig_comp_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2022-06-28T15:27:20">
+  <component id="scap_mil.disa.stig_comp_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2023-03-28T17:41:02">
     <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0">
       <cpe-item name="cpe:/o:redhat:enterprise_linux:8">
         <title xml:lang="en-us">Red Hat Enterprise Linux 8</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.rhel8:def:1</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.rhel8:def:1</check>
       </cpe-item>
     </cpe-list>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2022-06-28T15:27:20">
+  <component id="scap_mil.disa.stig_comp_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2023-03-28T17:41:02">
     <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_RHEL_8_STIG" xml:lang="en" style="SCAP_1.2">
-      <xccdf:status date="2022-06-15">accepted</xccdf:status>
-      <xccdf:title>Red Hat Enterprise Linux 8 Security Technical Implementation Guide</xccdf:title>
-      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
+      <xccdf:status date="2023-03-08">accepted</xccdf:status>
+      <xccdf:title>Red Hat Enterprise Linux 8 STIG SCAP Benchmark</xccdf:title>
+      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
       <xccdf:notice id="terms-of-use" xml:lang="en" />
       <xccdf:front-matter xml:lang="en" />
       <xccdf:rear-matter xml:lang="en" />
@@ -40,11 +40,19 @@
         <dc:publisher>DISA</dc:publisher>
         <dc:source>STIG.DOD.MIL</dc:source>
       </xccdf:reference>
-      <xccdf:plain-text id="release-info">Release: 1.6 Benchmark Date: 27 Jul 2022</xccdf:plain-text>
-      <xccdf:plain-text id="generator">3.3.0.27375</xccdf:plain-text>
+      <xccdf:plain-text id="release-info">Release: 1.9 Benchmark Date: 27 Apr 2023</xccdf:plain-text>
+      <xccdf:plain-text id="generator">3.4.0.34222</xccdf:plain-text>
       <xccdf:plain-text id="conventionsVersion">1.10.0</xccdf:plain-text>
+      <cpe:platform-specification>
+        <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_RHEL_8-3_or_Lower">
+          <title>RHEL 8.3 or Lower</title>
+          <logical-test negate="false" operator="AND">
+            <check-fact-ref id-ref="oval:mil.disa.stig.linux:def:100008" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </logical-test>
+        </platform>
+      </cpe:platform-specification>
       <xccdf:platform idref="cpe:/o:redhat:enterprise_linux:8" />
-      <xccdf:version update="http://iase.disa.mil/stigs">001.006</xccdf:version>
+      <xccdf:version update="http://iase.disa.mil/stigs">001.009</xccdf:version>
       <xccdf:metadata>
         <dc:creator>DISA</dc:creator>
         <dc:publisher>DISA</dc:publisher>
@@ -96,7 +104,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230286" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230287" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230288" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-230289" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230290" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230291" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230292" selected="true" />
@@ -285,6 +292,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244554" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-251706" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-251714" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-1_Public">
         <xccdf:title>I - Mission Critical Public</xccdf:title>
@@ -331,7 +339,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230286" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230287" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230288" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-230289" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230290" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230291" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230292" selected="true" />
@@ -520,6 +527,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244554" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-251706" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-251714" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-1_Sensitive">
         <xccdf:title>I - Mission Critical Sensitive</xccdf:title>
@@ -566,7 +574,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230286" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230287" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230288" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-230289" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230290" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230291" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230292" selected="true" />
@@ -755,6 +762,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244554" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-251706" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-251714" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-2_Classified">
         <xccdf:title>II - Mission Support Classified</xccdf:title>
@@ -801,7 +809,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230286" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230287" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230288" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-230289" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230290" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230291" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230292" selected="true" />
@@ -990,6 +997,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244554" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-251706" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-251714" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-2_Public">
         <xccdf:title>II - Mission Support Public</xccdf:title>
@@ -1036,7 +1044,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230286" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230287" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230288" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-230289" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230290" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230291" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230292" selected="true" />
@@ -1225,6 +1232,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244554" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-251706" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-251714" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-2_Sensitive">
         <xccdf:title>II - Mission Support Sensitive</xccdf:title>
@@ -1271,7 +1279,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230286" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230287" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230288" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-230289" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230290" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230291" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230292" selected="true" />
@@ -1460,6 +1467,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244554" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-251706" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-251714" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-3_Classified">
         <xccdf:title>III - Administrative Classified</xccdf:title>
@@ -1506,7 +1514,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230286" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230287" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230288" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-230289" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230290" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230291" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230292" selected="true" />
@@ -1695,6 +1702,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244554" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-251706" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-251714" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-3_Public">
         <xccdf:title>III - Administrative Public</xccdf:title>
@@ -1741,7 +1749,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230286" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230287" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230288" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-230289" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230290" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230291" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230292" selected="true" />
@@ -1930,6 +1937,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244554" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-251706" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-251714" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-3_Sensitive">
         <xccdf:title>III - Administrative Sensitive</xccdf:title>
@@ -1976,7 +1984,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230286" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230287" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230288" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-230289" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230290" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230291" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-230292" selected="true" />
@@ -2165,19 +2172,20 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-244554" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-251706" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-251714" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_CAT_I_Only">
         <xccdf:title>CAT I Only</xccdf:title>
         <xccdf:description>This profile only includes rules that are Severity Category I.</xccdf:description>
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230231r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230232r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230233r809273_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230231r877397_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230232r877397_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230233r880705_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230236r743928_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230237r809276_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230238r646862_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230239r646864_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230241r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230244r743934_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230244r858697_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230245r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230246r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230247r627750_rule" selected="false" />
@@ -2185,44 +2193,43 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230249r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230250r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230253r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230255r809382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230255r877394_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230257r792862_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230258r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230259r792864_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230266r833290_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230267r833292_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230268r833294_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230269r833296_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230270r833298_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230271r833301_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230272r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230273r743943_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230280r833303_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230281r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230282r627750_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230266r877463_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230267r858751_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230268r858754_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230269r858756_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230270r858758_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230271r854026_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230272r854027_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230273r854028_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230280r858767_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230281r854034_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230282r854035_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230286r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230287r743951_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230288r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230289r743954_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230290r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230291r743957_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230292r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230293r627750_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230287r880714_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230288r858701_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230290r858705_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230291r858707_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230292r902718_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230293r902720_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230294r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230295r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230296r627750_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230296r858711_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230298r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230300r743959_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230301r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230306r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230307r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230308r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230311r833305_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230311r858769_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230313r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230314r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230315r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230324r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230330r646870_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230330r877377_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230332r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230333r743966_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230334r627750_rule" selected="false" />
@@ -2235,39 +2242,39 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230343r743981_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230344r646874_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230345r743984_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230346r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230348r743987_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230349r833388_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230346r877399_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230348r902725_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230349r880737_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230350r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230356r809379_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230357r833313_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230358r833315_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230359r833317_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230360r833319_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230361r833321_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230362r833323_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230363r833325_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230356r902728_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230357r858771_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230358r858773_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230359r858775_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230360r858777_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230361r858779_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230362r858781_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230363r858783_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230364r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230365r627750_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230365r858727_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230366r646878_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230367r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230368r810414_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230369r833327_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230368r902759_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230369r858785_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230370r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230373r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230375r833329_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230377r833331_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230375r858787_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230377r858789_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230378r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230382r627750_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230382r858717_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230383r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230386r627750_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230386r854037_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230388r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230390r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230392r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230393r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230394r627750_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230394r877390_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230395r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230396r627750_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230396r902733_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230397r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230398r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230399r627750_rule" selected="false" />
@@ -2324,8 +2331,8 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230474r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230477r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230478r744011_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230480r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230483r744014_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230480r877390_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230483r877389_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230485r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230486r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230488r627750_rule" selected="false" />
@@ -2338,60 +2345,62 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230499r792924_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230503r809319_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230507r833336_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230508r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230509r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230510r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230511r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230512r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230513r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230514r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230515r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230516r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230517r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230518r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230519r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230520r792927_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230521r792930_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230522r792933_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230526r744032_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230527r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230535r833340_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230536r833342_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230537r833344_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230538r833346_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230539r838722_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230540r833349_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230541r833351_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230542r833353_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230543r833355_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230544r833357_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230545r833359_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230546r833361_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230547r833363_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230548r833365_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230549r833367_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230508r854049_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230509r854050_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230510r854051_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230511r854052_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230512r854053_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230513r854054_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230514r854055_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230515r854056_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230516r854057_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230517r854058_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230518r854059_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230519r854060_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230520r854061_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230521r854062_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230522r854063_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230526r854067_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230527r877398_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230535r858793_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230536r858795_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230537r858797_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230538r858801_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230539r861085_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230540r858810_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230541r858812_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230542r858814_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230543r858816_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230544r858820_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230545r858822_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230546r858824_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230547r858826_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230548r858828_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230549r858830_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230550r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230555r627750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230556r627750_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230555r858721_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230556r858723_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230557r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230559r646887_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230560r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-230561r627750_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237640r646890_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237641r646893_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237642r833369_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237643r838720_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-244554r833381_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237642r880727_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-237643r861088_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-244554r858832_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-251714r902743_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230221">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230221r743913_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230221r858734_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010000</xccdf:version>
           <xccdf:title>RHEL 8 must be a vendor-supported release.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;An operating system release is considered "supported" if the vendor continues to provide security patches for the product. With an unsupported release, it will not be possible to resolve security issues discovered in the system software.
 
-Red Hat offers the Extended Update Support (EUS) ad-on to a Red Hat Enterprise Linux subscription, for a fee, for those customers who wish to standardize on a specific minor release for an extended period. The RHEL 8 minor releases eligible for EUS are 8.1, 8.2, 8.4, 8.6, and 8.8. Each RHEL 8 EUS stream is available for 24 months from the availability of the minor release. RHEL 8.10 will be the final minor release overall. For more details on the Red Hat Enterprise Linux Life Cycle  visit https://access.redhat.com/support/policy/updates/errata.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+Red Hat offers the Extended Update Support (EUS) add-on to a Red Hat Enterprise Linux subscription, for a fee, for those customers who wish to standardize on a specific minor release for an extended period. The RHEL 8 minor releases eligible for EUS are 8.1, 8.2, 8.4, 8.6, and 8.8. Each RHEL 8 EUS stream is available for 24 months from the availability of the minor release. RHEL 8.10 will be the final minor release overall. For more details on the Red Hat Enterprise Linux Life Cycle  visit https://access.redhat.com/support/policy/updates/errata/.
+Note: The life-cycle time spans and dates are subject to adjustment.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Red Hat Enterprise Linux 8</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -2403,19 +2412,19 @@ Red Hat offers the Extended Update Support (EUS) ad-on to a Red Hat Enterprise L
           <xccdf:fixtext fixref="F-32865r567410_fix">Upgrade to a supported version of RHEL 8.</xccdf:fixtext>
           <xccdf:fix id="F-32865r567410_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:100" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:100" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230223">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230223r792855_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230223r877398_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010020</xccdf:version>
           <xccdf:title>RHEL 8 must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect data requiring data-at-rest protections in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of weak or untested encryption algorithms undermines the purposes of using encryption to protect data. The operating system must implement cryptographic modules adhering to the higher standards approved by the Federal Government since this provides assurance they have been tested and validated.
 
-RHEL 8 utilizes GRUB 2 as the default bootloader. Note that GRUB 2 command-line parameters are defined in the "kernelopts" variable of the /boot/grub2/grubenv file for all kernel boot entries.  The command "fips-mode-setup" modifies the "kernelopts" variable, which in turn updates all kernel boot entries. 
+RHEL 8 utilizes GRUB 2 as the default bootloader. Note that GRUB 2 command-line parameters are defined in the "kernelopts" variable of the /boot/grub2/grubenv file for all kernel boot entries.  The command "fips-mode-setup" modifies the "kernelopts" variable, which in turn updates all kernel boot entries.
 
 The fips=1 kernel option needs to be added to the kernel command line during system installation so that key generation is done with FIPS-approved algorithms and continuous monitoring tests in place. Users must also ensure the system has plenty of entropy during the installation process by moving the mouse around, or if no mouse is available, ensuring that many keystrokes are typed. The recommended amount of keystrokes is 256 and more. Less than 256 keystrokes may generate a non-unique key.
 
@@ -2439,14 +2448,14 @@ $ sudo fips-mode-setup --enable
 Reboot the system for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-32867r567416_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:101" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:101" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230231">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230231r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230231r877397_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010110</xccdf:version>
           <xccdf:title>RHEL 8 must encrypt all stored passwords with a FIPS 140-2 approved cryptographic hashing algorithm.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised.
@@ -2462,21 +2471,21 @@ FIPS 140-2 is the current standard for validating that mechanisms used to access
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000196</xccdf:ident>
-          <xccdf:fixtext fixref="F-32875r567440_fix">Configure RHEL 8 to encrypt all stored passwords. 
+          <xccdf:fixtext fixref="F-32875r567440_fix">Configure RHEL 8 to encrypt all stored passwords.
 
 Edit/Modify the following line in the "/etc/login.defs" file and set "[ENCRYPT_METHOD]" to SHA512.
 
 ENCRYPT_METHOD SHA512</xccdf:fixtext>
           <xccdf:fix id="F-32875r567440_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:103" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:103" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230232">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230232r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230232r877397_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010120</xccdf:version>
           <xccdf:title>RHEL 8 must employ FIPS 140-2 approved cryptographic hashing algorithms for all stored passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The system must use a strong hashing algorithm to store the password.
@@ -2493,14 +2502,14 @@ Passwords need to be protected at all times, and encryption is the standard meth
           <xccdf:fixtext fixref="F-32876r567443_fix">Lock all interactive user accounts not using SHA-512 hashing until the passwords can be regenerated with SHA-512.</xccdf:fixtext>
           <xccdf:fix id="F-32876r567443_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:104" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:104" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230233">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230233r809273_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230233r880705_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010130</xccdf:version>
           <xccdf:title>The RHEL 8 shadow password suite must be configured to use a sufficient number of hashing rounds.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The system must use a strong hashing algorithm to store the password. The system must use a sufficient number of hashing rounds to ensure the required level of entropy.
@@ -2521,7 +2530,7 @@ Edit/modify the following line in the "/etc/login.defs" file and set "SHA_CRYPT_
 SHA_CRYPT_MIN_ROUNDS 5000</xccdf:fixtext>
           <xccdf:fix id="F-32877r809272_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:105" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:105" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2549,7 +2558,7 @@ Enter password:
 Confirm password:</xccdf:fixtext>
           <xccdf:fix id="F-32878r743921_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:106" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:106" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2577,7 +2586,7 @@ Enter password:
 Confirm password:</xccdf:fixtext>
           <xccdf:fix id="F-32879r743924_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:107" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:107" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2601,7 +2610,7 @@ Confirm password:</xccdf:fixtext>
 ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue</xccdf:fixtext>
           <xccdf:fix id="F-32880r743927_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:108" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:108" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2613,7 +2622,7 @@ ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue</xccdf:fixtext>
           <xccdf:title>The RHEL 8 pam_unix.so module must be configured in the password-auth file to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unapproved mechanisms that are used for authentication to the cryptographic module are not verified and therefore cannot be relied upon to provide confidentiality or integrity, and DoD data may be compromised.
 
-RHEL 8 systems utilizing encryption are required to use FIPS-compliant mechanisms for authenticating to cryptographic modules. 
+RHEL 8 systems utilizing encryption are required to use FIPS-compliant mechanisms for authenticating to cryptographic modules.
 
 FIPS 140-2 is the current standard for validating that mechanisms used to access cryptographic modules utilize authentication that meets DoD requirements. This allows for Security Levels 1, 2, 3, or 4 for use on a general-purpose computing system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -2631,7 +2640,7 @@ Edit/modify the following line in the "/etc/pam.d/password-auth" file to include
 password sufficient pam_unix.so sha512</xccdf:fixtext>
           <xccdf:fix id="F-32881r809275_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:109" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:109" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2661,7 +2670,7 @@ FIPS 140-2 is the current standard for validating that mechanisms used to access
 Remove any files with the .keytab extension from the operating system.</xccdf:fixtext>
           <xccdf:fix id="F-32882r567461_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:110" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:110" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2691,7 +2700,7 @@ FIPS 140-2 is the current standard for validating that mechanisms used to access
 $ sudo yum remove krb5-workstation</xccdf:fixtext>
           <xccdf:fix id="F-32883r567464_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:111" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:111" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2717,14 +2726,14 @@ Policycoreutils contains the policy core utilities that are required for basic o
 $ sudo yum install policycoreutils</xccdf:fixtext>
           <xccdf:fix id="F-32885r567470_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:112" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:112" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230244">
         <xccdf:title>SRG-OS-000163-GPOS-00072</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230244r743934_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230244r858697_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010200</xccdf:version>
           <xccdf:title>RHEL 8 must be configured so that all network connections associated with SSH traffic are terminated at the end of the session or after 10 minutes of inactivity, except to fulfill documented and validated mission requirements.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Terminating an idle SSH session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle SSH session will also free up resources committed by the managed network element.
@@ -2742,18 +2751,18 @@ Satisfies: SRG-OS-000163-GPOS-00072, SRG-OS-000126-GPOS-00066, SRG-OS-000279-GPO
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001133</xccdf:ident>
-          <xccdf:fixtext fixref="F-32888r743933_fix">Configure RHEL 8 to automatically terminate all network connections associated with SSH traffic at the end of a session or after 10 minutes of inactivity.
+          <xccdf:fixtext fixref="F-32888r858696_fix">Configure RHEL 8 to automatically terminate all network connections associated with SSH traffic at the end of a session or after 10 minutes of inactivity.
 
 Modify or append the following lines in the "/etc/ssh/sshd_config" file:
 
-ClientAliveCountMax 0
+ClientAliveCountMax 1
 
 In order for the changes to take effect, the SSH daemon must be restarted.
 
 $ sudo systemctl restart sshd.service</xccdf:fixtext>
-          <xccdf:fix id="F-32888r743933_fix" />
+          <xccdf:fix id="F-32888r858696_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:115" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:230244" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2779,7 +2788,7 @@ The structure and content of error messages must be carefully considered by the 
 $ sudo chmod 0640 /var/log/messages</xccdf:fixtext>
           <xccdf:fix id="F-32889r567482_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:116" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:116" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2805,7 +2814,7 @@ The structure and content of error messages must be carefully considered by the 
 $ sudo chown root /var/log/messages</xccdf:fixtext>
           <xccdf:fix id="F-32890r567485_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:117" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:117" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2831,7 +2840,7 @@ The structure and content of error messages must be carefully considered by the 
 $ sudo chgrp root /var/log/messages</xccdf:fixtext>
           <xccdf:fix id="F-32891r567488_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:118" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:118" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2857,7 +2866,7 @@ The structure and content of error messages must be carefully considered by the 
 $ sudo chmod 0755 /var/log</xccdf:fixtext>
           <xccdf:fix id="F-32892r567491_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:119" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:119" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2883,7 +2892,7 @@ The structure and content of error messages must be carefully considered by the 
 $ sudo chown root /var/log</xccdf:fixtext>
           <xccdf:fix id="F-32893r567494_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:120" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:120" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2909,7 +2918,7 @@ The structure and content of error messages must be carefully considered by the 
 $ sudo chgrp root /var/log</xccdf:fixtext>
           <xccdf:fix id="F-32894r567497_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:121" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:121" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2939,14 +2948,14 @@ SSH_USE_STRONG_RNG=32
 The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-32897r567506_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:122" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:122" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230255">
         <xccdf:title>SRG-OS-000250-GPOS-00093</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230255r809382_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230255r877394_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010294</xccdf:version>
           <xccdf:title>The RHEL 8 operating system must implement DoD-approved TLS encryption in the OpenSSL package.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without cryptographic integrity protections, information can be altered by unauthorized users without detection.
@@ -2977,7 +2986,7 @@ DTLS.MinProtocol = DTLSv1.2
 A reboot is required for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-32899r809381_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:123" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:123" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3005,7 +3014,7 @@ Run the following command, replacing "[FILE]" with any system command with a mod
 $ sudo chmod 755 [FILE]</xccdf:fixtext>
           <xccdf:fix id="F-32901r792861_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:124" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:230257" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3033,7 +3042,7 @@ Run the following command, replacing "[FILE]" with any system command file not o
 $ sudo chown root [FILE]</xccdf:fixtext>
           <xccdf:fix id="F-32902r567521_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:125" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:125" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3061,14 +3070,14 @@ Run the following command, replacing "[FILE]" with any system command file not g
 $ sudo chgrp root [FILE]</xccdf:fixtext>
           <xccdf:fix id="F-32903r567524_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:126" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:126" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230264">
         <xccdf:title>SRG-OS-000366-GPOS-00153</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230264r627750_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230264r880711_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010370</xccdf:version>
           <xccdf:title>RHEL 8 must prevent the installation of software, patches, service packs, device drivers, or operating system components from a repository without verification they have been digitally signed using a certificate that is issued by a Certificate Authority (CA) that is recognized and approved by the organization.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor.
@@ -3084,19 +3093,19 @@ Verifying the authenticity of the software prior to installation validates the i
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001749</xccdf:ident>
-          <xccdf:fixtext fixref="F-32908r567539_fix">Configure the operating system to verify the signature of packages from a repository prior to install by setting the following option in the "/etc/yum.repos.d/[your_repo_name].repo" file:
+          <xccdf:fixtext fixref="F-32908r880710_fix">Configure the operating system to verify the signature of packages from a repository prior to install by setting the following option in the "/etc/yum.repos.d/[your_repo_name].repo" file:
 
-gpgcheck=1</xccdf:fixtext>
-          <xccdf:fix id="F-32908r567539_fix" />
+     gpgcheck=1</xccdf:fixtext>
+          <xccdf:fix id="F-32908r880710_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:130" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:130" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230265">
         <xccdf:title>SRG-OS-000366-GPOS-00153</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230265r627750_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230265r877463_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010371</xccdf:version>
           <xccdf:title>RHEL 8 must prevent the installation of software, patches, service packs, device drivers, or operating system components of local packages without verification they have been digitally signed using a certificate that is issued by a Certificate Authority (CA) that is recognized and approved by the organization.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor.
@@ -3119,14 +3128,14 @@ Set the "localpkg_gpgcheck" option to "True" in the "/etc/dnf/dnf.conf" file:
 localpkg_gpgcheck=True</xccdf:fixtext>
           <xccdf:fix id="F-32909r567542_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:131" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:131" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230266">
         <xccdf:title>SRG-OS-000366-GPOS-00153</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230266r833290_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230266r877463_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010372</xccdf:version>
           <xccdf:title>RHEL 8 must prevent the loading of a new kernel for later execution.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor.
@@ -3148,25 +3157,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001749</xccdf:ident>
-          <xccdf:fixtext fixref="F-32910r818815_fix">Configure the operating system to disable kernel image loading.
+          <xccdf:fixtext fixref="F-32910r858747_fix">Configure the operating system to disable kernel image loading.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 kernel.kexec_load_disabled = 1
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-32910r818815_fix" />
+          <xccdf:fix id="F-32910r858747_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:132" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:132" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230267">
         <xccdf:title>SRG-OS-000312-GPOS-00122</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230267r833292_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230267r858751_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010373</xccdf:version>
           <xccdf:title>RHEL 8 must enable kernel parameters to enforce discretionary access control on symlinks.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Discretionary Access Control (DAC) is based on the notion that individual users are "owners" of objects and therefore have discretion over who should be authorized to access the object and in which mode (e.g., read or write). Ownership is usually acquired as a consequence of creating the object or via specified ownership assignment. DAC allows the owner to determine who will have access to objects they control. An example of DAC includes user-controlled file permissions.
@@ -3192,25 +3209,33 @@ Satisfies: SRG-OS-000312-GPOS-00122, SRG-OS-000312-GPOS-00123, SRG-OS-000312-GPO
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002165</xccdf:ident>
-          <xccdf:fixtext fixref="F-32911r818818_fix">Configure the operating system to enable DAC on symlinks.
+          <xccdf:fixtext fixref="F-32911r858750_fix">Configure the operating system to enable DAC on symlinks.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 fs.protected_symlinks = 1
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-32911r818818_fix" />
+          <xccdf:fix id="F-32911r858750_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:133" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:133" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230268">
         <xccdf:title>SRG-OS-000312-GPOS-00122</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230268r833294_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230268r858754_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010374</xccdf:version>
           <xccdf:title>RHEL 8 must enable kernel parameters to enforce discretionary access control on hardlinks.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Discretionary Access Control (DAC) is based on the notion that individual users are "owners" of objects and therefore have discretion over who should be authorized to access the object and in which mode (e.g., read or write). Ownership is usually acquired as a consequence of creating the object or via specified ownership assignment. DAC allows the owner to determine who will have access to objects they control. An example of DAC includes user-controlled file permissions.
@@ -3236,25 +3261,33 @@ Satisfies: SRG-OS-000312-GPOS-00122, SRG-OS-000312-GPOS-00123, SRG-OS-000312-GPO
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002165</xccdf:ident>
-          <xccdf:fixtext fixref="F-32912r818821_fix">Configure the operating system to enable DAC on hardlinks.
+          <xccdf:fixtext fixref="F-32912r858753_fix">Configure the operating system to enable DAC on hardlinks.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 fs.protected_hardlinks = 1
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-32912r818821_fix" />
+          <xccdf:fix id="F-32912r858753_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:134" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:134" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230269">
         <xccdf:title>SRG-OS-000138-GPOS-00069</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230269r833296_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230269r858756_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010375</xccdf:version>
           <xccdf:title>RHEL 8 must restrict access to the kernel message buffer.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Preventing unauthorized information transfers mitigates the risk of information, including encrypted representations of information, produced by the actions of prior users/roles (or the actions of processes acting on behalf of prior users/roles) from being available to any current users/roles (or current processes) that obtain access to shared system resources (e.g., registers, main memory, hard disks) after those resources have been released back to information systems. The control of information in shared resources is also commonly referred to as object reuse and residual information protection.
@@ -3280,25 +3313,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001090</xccdf:ident>
-          <xccdf:fixtext fixref="F-32913r818824_fix">Configure the operating system to restrict access to the kernel message buffer.
+          <xccdf:fixtext fixref="F-32913r858755_fix">Configure the operating system to restrict access to the kernel message buffer.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 kernel.dmesg_restrict = 1
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-32913r818824_fix" />
+          <xccdf:fix id="F-32913r858755_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:135" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:135" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230270">
         <xccdf:title>SRG-OS-000138-GPOS-00069</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230270r833298_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230270r858758_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010376</xccdf:version>
           <xccdf:title>RHEL 8 must prevent kernel profiling by unprivileged users.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Preventing unauthorized information transfers mitigates the risk of information, including encrypted representations of information, produced by the actions of prior users/roles (or the actions of processes acting on behalf of prior users/roles) from being available to any current users/roles (or current processes) that obtain access to shared system resources (e.g., registers, main memory, hard disks) after those resources have been released back to information systems. The control of information in shared resources is also commonly referred to as object reuse and residual information protection.
@@ -3324,25 +3365,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001090</xccdf:ident>
-          <xccdf:fixtext fixref="F-32914r818827_fix">Configure the operating system to prevent kernel profiling by unprivileged users.
+          <xccdf:fixtext fixref="F-32914r858757_fix">Configure the operating system to prevent kernel profiling by unprivileged users.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 kernel.perf_event_paranoid = 2
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-32914r818827_fix" />
+          <xccdf:fix id="F-32914r858757_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:136" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:136" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230271">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230271r833301_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230271r854026_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010380</xccdf:version>
           <xccdf:title>RHEL 8 must require users to provide a password for privilege escalation.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without reauthentication, users may access resources or perform tasks for which they do not have authorization.
@@ -3358,27 +3407,17 @@ Satisfies: SRG-OS-000373-GPOS-00156, SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPO
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002038</xccdf:ident>
-          <xccdf:fixtext fixref="F-32915r833300_fix">Configure the operating system to require users to supply a password for privilege escalation.
-
-Check the configuration of the "/etc/sudoers" file with the following command:
-$ sudo visudo
-
-Remove any occurrences of "NOPASSWD" tags in the file.
-
-Check the configuration of the /etc/sudoers.d/* files with the following command:
-$ sudo grep -ir nopasswd /etc/sudoers.d
-
-Remove any occurrences of "NOPASSWD" tags in the file.</xccdf:fixtext>
-          <xccdf:fix id="F-32915r833300_fix" />
+          <xccdf:fixtext fixref="F-32915r854025_fix">Remove any occurrence of "NOPASSWD" found in "/etc/sudoers" file or files in the "/etc/sudoers.d" directory.</xccdf:fixtext>
+          <xccdf:fix id="F-32915r854025_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:137" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:137" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230272">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230272r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230272r854027_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010381</xccdf:version>
           <xccdf:title>RHEL 8 must require users to reauthenticate for privilege escalation.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without reauthentication, users may access resources or perform tasks for which they do not have authorization.
@@ -3397,14 +3436,14 @@ Satisfies: SRG-OS-000373-GPOS-00156, SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPO
           <xccdf:fixtext fixref="F-32916r567563_fix">Remove any occurrence of "!authenticate" found in "/etc/sudoers" file or files in the "/etc/sudoers.d" directory.</xccdf:fixtext>
           <xccdf:fix id="F-32916r567563_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:138" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:138" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230273">
         <xccdf:title>SRG-OS-000375-GPOS-00160</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230273r743943_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230273r854028_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010390</xccdf:version>
           <xccdf:title>RHEL 8 must have the packages required for multifactor authentication installed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Using an authentication device, such as a DoD Common Access Card (CAC) or token that is separate from the information system, ensures that even if the information system is compromised, credentials stored on the authentication device will not be affected.
@@ -3429,14 +3468,14 @@ This requirement only applies to components where this is specific to the functi
 $ sudo yum install openssl-pkcs11</xccdf:fixtext>
           <xccdf:fix id="F-32917r743942_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:139" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:139" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230280">
         <xccdf:title>SRG-OS-000433-GPOS-00193</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230280r833303_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230280r858767_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010430</xccdf:version>
           <xccdf:title>RHEL 8 must implement address space layout randomization (ASLR) to protect its memory from unauthorized code execution.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Some adversaries launch attacks with the intent of executing code in non-executable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can be either hardware-enforced or software-enforced with hardware providing the greater strength of mechanism.
@@ -3458,25 +3497,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002824</xccdf:ident>
-          <xccdf:fixtext fixref="F-32924r818830_fix">Configure the operating system to implement virtual address space randomization.
+          <xccdf:fixtext fixref="F-32924r858766_fix">Configure the operating system to implement virtual address space randomization.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 kernel.randomize_va_space=2
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Issue the following command to make the changes take effect:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-32924r818830_fix" />
+          <xccdf:fix id="F-32924r858766_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:144" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:144" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230281">
         <xccdf:title>SRG-OS-000437-GPOS-00194</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230281r627750_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230281r854034_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010440</xccdf:version>
           <xccdf:title>YUM must remove all software components after updated versions have been installed on RHEL 8.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Previous versions of software components that are not removed from the information system after updates have been installed may be exploited by adversaries. Some information technology products may remove older versions of software automatically from the information system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3495,14 +3542,14 @@ Set the "clean_requirements_on_remove" option to "True" in the "/etc/dnf/dnf.con
 clean_requirements_on_remove=True</xccdf:fixtext>
           <xccdf:fix id="F-32925r567590_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:145" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:145" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230282">
         <xccdf:title>SRG-OS-000445-GPOS-00199</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230282r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230282r854035_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010450</xccdf:version>
           <xccdf:title>RHEL 8 must enable the SELinux targeted policy.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without verification of the security functions, security functions may not operate correctly and the failure may go unnoticed. Security function is defined as the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Security functionality includes, but is not limited to, establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters.
@@ -3525,7 +3572,7 @@ SELINUXTYPE=targeted
 A reboot is required for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-32926r567593_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:146" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:146" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3549,7 +3596,7 @@ A reboot is required for the changes to take effect.</xccdf:fixtext>
 $ sudo rm /etc/ssh/shosts.equiv</xccdf:fixtext>
           <xccdf:fix id="F-32927r567596_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:147" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:147" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3573,7 +3620,7 @@ $ sudo rm /etc/ssh/shosts.equiv</xccdf:fixtext>
 $ sudo rm /[path]/[to]/[file]/.shosts</xccdf:fixtext>
           <xccdf:fix id="F-32928r567599_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:148" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:148" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3601,16 +3648,16 @@ The SSH daemon must be restarted for the changes to take effect. To restart the 
 $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fix id="F-32930r567605_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:149" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:149" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230287">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230287r743951_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230287r880714_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010490</xccdf:version>
-          <xccdf:title>The RHEL 8 SSH private host key files must have mode 0600 or less permissive.</xccdf:title>
+          <xccdf:title>The RHEL 8 SSH private host key files must have mode 0640 or less permissive.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If an unauthorized user obtains the private SSH host key file, the host could be impersonated.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Red Hat Enterprise Linux 8</dc:title>
@@ -3620,23 +3667,23 @@ $ sudo systemctl restart sshd.service</xccdf:fixtext>
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-32931r743950_fix">Configure the mode of SSH private host key files under "/etc/ssh" to "0600" with the following command:
+          <xccdf:fixtext fixref="F-32931r880713_fix">Configure the mode of SSH private host key files under "/etc/ssh" to "0640" with the following command:
 
-$ sudo chmod 0600 /etc/ssh/ssh_host*key
+     $ sudo chmod 0640 /etc/ssh/ssh_host*key
 
 The SSH daemon must be restarted for the changes to take effect. To restart the SSH daemon, run the following command:
 
-$ sudo systemctl restart sshd.service</xccdf:fixtext>
-          <xccdf:fix id="F-32931r743950_fix" />
+     $ sudo systemctl restart sshd.service</xccdf:fixtext>
+          <xccdf:fix id="F-32931r880713_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:150" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:150" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230288">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230288r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230288r858701_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010500</xccdf:version>
           <xccdf:title>The RHEL 8 SSH daemon must perform strict mode checking of home directory configuration files.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If other users have access to modify user-specific SSH configuration files, they may be able to log on to the system as another user.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3657,40 +3704,14 @@ The SSH daemon must be restarted for the changes to take effect. To restart the 
 $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fix id="F-32932r567611_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:151" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-230289">
-        <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230289r743954_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010510</xccdf:version>
-          <xccdf:title>The RHEL 8 SSH daemon must not allow compression or must only allow compression after successful authentication.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;If compression is allowed in an SSH connection prior to authentication, vulnerabilities in the compression software could result in compromise of the system from an unauthenticated connection, potentially with root privileges.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Red Hat Enterprise Linux 8</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Red Hat Enterprise Linux 8</dc:subject>
-            <dc:identifier>2921</dc:identifier>
-          </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-32933r743953_fix">Uncomment the "Compression" keyword in "/etc/ssh/sshd_config" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor) on the system and set the value to "delayed" or "no":
-
-Compression no
-
-The SSH service must be restarted for changes to take effect.</xccdf:fixtext>
-          <xccdf:fix id="F-32933r743953_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:152" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:151" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230290">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230290r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230290r858705_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010520</xccdf:version>
           <xccdf:title>The RHEL 8 SSH daemon must not allow authentication using known host’s authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring this setting for the SSH daemon provides additional assurance that remote logon via SSH will require a password, even in the event of misconfiguration elsewhere.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3713,14 +3734,14 @@ The SSH daemon must be restarted for the changes to take effect. To restart the 
 $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fix id="F-32934r567617_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:153" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:153" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230291">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230291r743957_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230291r858707_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010521</xccdf:version>
           <xccdf:title>The RHEL 8 SSH daemon must not allow Kerberos authentication, except to fulfill documented and validated mission requirements.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring these settings for the SSH daemon provides additional assurance that remote logon via SSH will not use unused methods of authentication, even in the event of misconfiguration elsewhere.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3743,14 +3764,14 @@ The SSH daemon must be restarted for the changes to take effect. To restart the 
 $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fix id="F-32935r743956_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:154" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:154" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230292">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230292r627750_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230292r902718_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010540</xccdf:version>
           <xccdf:title>RHEL 8 must use a separate file system for /var.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The use of separate file systems for different paths can protect the system from failures resulting from a file system becoming full or failing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3765,14 +3786,14 @@ $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fixtext fixref="F-32936r567623_fix">Migrate the "/var" path onto a separate file system.</xccdf:fixtext>
           <xccdf:fix id="F-32936r567623_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:155" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:230292" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230293">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230293r627750_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230293r902720_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010541</xccdf:version>
           <xccdf:title>RHEL 8 must use a separate file system for /var/log.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The use of separate file systems for different paths can protect the system from failures resulting from a file system becoming full or failing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3787,7 +3808,7 @@ $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fixtext fixref="F-32937r567626_fix">Migrate the "/var/log" path onto a separate file system.</xccdf:fixtext>
           <xccdf:fix id="F-32937r567626_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:156" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:230293" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3809,7 +3830,7 @@ $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fixtext fixref="F-32938r567629_fix">Migrate the system audit data path onto a separate file system.</xccdf:fixtext>
           <xccdf:fix id="F-32938r567629_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:157" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:157" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3831,14 +3852,14 @@ $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fixtext fixref="F-32939r567632_fix">Migrate the "/tmp" directory onto a separate file system/partition.</xccdf:fixtext>
           <xccdf:fix id="F-32939r567632_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:158" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:158" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230296">
         <xccdf:title>SRG-OS-000109-GPOS-00056</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230296r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230296r858711_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010550</xccdf:version>
           <xccdf:title>RHEL 8 must not permit direct logons to the root account using remote access via SSH.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Even though the communications channel may be encrypted, an additional layer of security is gained by extending the policy of not logging on directly as root. In addition, logging on with a user-specific account provides individual accountability of actions performed on the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3861,7 +3882,7 @@ The SSH daemon must be restarted for the changes to take effect. To restart the 
 $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fix id="F-32940r567635_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:159" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:159" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3889,7 +3910,7 @@ $ sudo systemctl start rsyslog.service
 $ sudo systemctl enable rsyslog.service</xccdf:fixtext>
           <xccdf:fix id="F-32942r567641_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:161" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:161" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3911,7 +3932,7 @@ $ sudo systemctl enable rsyslog.service</xccdf:fixtext>
           <xccdf:fixtext fixref="F-32944r567647_fix">Configure the "/etc/fstab" to use the "nosuid" option on the /boot directory.</xccdf:fixtext>
           <xccdf:fix id="F-32944r567647_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:162" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:162" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3933,7 +3954,7 @@ $ sudo systemctl enable rsyslog.service</xccdf:fixtext>
           <xccdf:fixtext fixref="F-32945r567650_fix">Configure the "/etc/fstab" to use the "nodev" option on all non-root local partitions.</xccdf:fixtext>
           <xccdf:fix id="F-32945r567650_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:163" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:163" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3955,7 +3976,7 @@ $ sudo systemctl enable rsyslog.service</xccdf:fixtext>
           <xccdf:fixtext fixref="F-32950r567665_fix">Configure the "/etc/fstab" to use the "noexec" option on file systems that are being imported via NFS.</xccdf:fixtext>
           <xccdf:fix id="F-32950r567665_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:165" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:165" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3977,7 +3998,7 @@ $ sudo systemctl enable rsyslog.service</xccdf:fixtext>
           <xccdf:fixtext fixref="F-32951r567668_fix">Configure the "/etc/fstab" to use the "nodev" option on file systems that are being imported via NFS.</xccdf:fixtext>
           <xccdf:fix id="F-32951r567668_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:166" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:166" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3999,14 +4020,14 @@ $ sudo systemctl enable rsyslog.service</xccdf:fixtext>
           <xccdf:fixtext fixref="F-32952r567671_fix">Configure the "/etc/fstab" to use the "nosuid" option on file systems that are being imported via NFS.</xccdf:fixtext>
           <xccdf:fix id="F-32952r567671_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:167" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:167" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230311">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230311r833305_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230311r858769_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010671</xccdf:version>
           <xccdf:title>RHEL 8 must disable the kernel.core_pattern.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
@@ -4026,18 +4047,26 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-32955r818833_fix">Configure RHEL 8 to disable storing core dumps.
+          <xccdf:fixtext fixref="F-32955r858768_fix">Configure RHEL 8 to disable storing core dumps.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 kernel.core_pattern = |/bin/false
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 The system configuration files need to be reloaded for the changes to take effect. To reload the contents of the files, run the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-32955r818833_fix" />
+          <xccdf:fix id="F-32955r858768_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:168" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:168" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4065,7 +4094,7 @@ Add the following line to the top of the /etc/security/limits.conf or in a ".con
 * hard core 0</xccdf:fixtext>
           <xccdf:fix id="F-32957r619861_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:169" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:169" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4093,7 +4122,7 @@ Add or modify the following line in /etc/systemd/coredump.conf:
 Storage=none</xccdf:fixtext>
           <xccdf:fix id="F-32958r567689_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:170" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:170" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4121,7 +4150,7 @@ Add or modify the following line in /etc/systemd/coredump.conf:
 ProcessSizeMax=0</xccdf:fixtext>
           <xccdf:fix id="F-32959r567692_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:171" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:171" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4145,14 +4174,14 @@ ProcessSizeMax=0</xccdf:fixtext>
 CREATE_HOME yes</xccdf:fixtext>
           <xccdf:fix id="F-32968r567719_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:177" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:177" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230330">
         <xccdf:title>SRG-OS-000480-GPOS-00229</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230330r646870_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230330r877377_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010830</xccdf:version>
           <xccdf:title>RHEL 8 must not allow users to override SSH environment variables.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;SSH environment options potentially allow users to bypass access restriction in some configurations.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4175,7 +4204,7 @@ The SSH daemon must be restarted for the changes to take effect. To restart the 
 $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fix id="F-32974r567737_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:179" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:179" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4213,7 +4242,7 @@ The "sssd" service must be restarted for the changes to take effect. To restart 
 $ sudo systemctl restart sssd.service</xccdf:fixtext>
           <xccdf:fix id="F-32976r567743_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:180" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:180" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4245,7 +4274,7 @@ Add/Modify the "/etc/security/faillock.conf" file to match the following line:
 deny = 3</xccdf:fixtext>
           <xccdf:fix id="F-32977r743965_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:181" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:181" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4283,7 +4312,7 @@ The "sssd" service must be restarted for the changes to take effect. To restart 
 $ sudo systemctl restart sssd.service</xccdf:fixtext>
           <xccdf:fix id="F-32978r567749_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:182" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:182" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4315,7 +4344,7 @@ Add/Modify the "/etc/security/faillock.conf" file to match the following line:
 fail_interval = 900</xccdf:fixtext>
           <xccdf:fix id="F-32979r743968_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:183" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:183" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4353,7 +4382,7 @@ The "sssd" service must be restarted for the changes to take effect. To restart 
 $ sudo systemctl restart sssd.service</xccdf:fixtext>
           <xccdf:fix id="F-32980r567755_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:184" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:184" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4385,7 +4414,7 @@ Add/Modify the "/etc/security/faillock.conf" file to match the following line:
 unlock_time = 0</xccdf:fixtext>
           <xccdf:fix id="F-32981r743971_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:185" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:185" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4423,7 +4452,7 @@ The "sssd" service must be restarted for the changes to take effect. To restart 
 $ sudo systemctl restart sssd.service</xccdf:fixtext>
           <xccdf:fix id="F-32984r567767_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:186" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:186" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4455,7 +4484,7 @@ Add/Modify the "/etc/security/faillock.conf" file to match the following line:
 silent</xccdf:fixtext>
           <xccdf:fix id="F-32985r743977_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:187" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:187" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4495,7 +4524,7 @@ The "sssd" service must be restarted for the changes to take effect. To restart 
 $ sudo systemctl restart sssd.service</xccdf:fixtext>
           <xccdf:fix id="F-32986r567773_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:188" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:188" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4527,7 +4556,7 @@ Add/Modify the "/etc/security/faillock.conf" file to match the following line:
 audit</xccdf:fixtext>
           <xccdf:fix id="F-32987r743980_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:189" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:189" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4567,7 +4596,7 @@ The "sssd" service must be restarted for the changes to take effect. To restart 
 $ sudo systemctl restart sssd.service</xccdf:fixtext>
           <xccdf:fix id="F-32988r567779_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:190" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:190" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4599,14 +4628,14 @@ Add/Modify the "/etc/security/faillock.conf" file to match the following line:
 even_deny_root</xccdf:fixtext>
           <xccdf:fix id="F-32989r743983_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:191" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:191" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230346">
         <xccdf:title>SRG-OS-000027-GPOS-00008</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230346r627750_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230346r877399_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020024</xccdf:version>
           <xccdf:title>RHEL 8 must limit the number of concurrent sessions to ten for all accounts and/or account types.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Operating system management includes the ability to control the number of users and user sessions that utilize an operating system. Limiting the number of allowed users and sessions per user is helpful in reducing the risks related to DoS attacks.
@@ -4627,14 +4656,14 @@ Add the following line to the top of the /etc/security/limits.conf or in a ".con
 * hard maxlogins 10</xccdf:fixtext>
           <xccdf:fix id="F-32990r619863_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:192" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:230346" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230348">
         <xccdf:title>SRG-OS-000028-GPOS-00009</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230348r743987_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230348r902725_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020040</xccdf:version>
           <xccdf:title>RHEL 8 must enable a user session lock until that user re-establishes access using established identification and authentication procedures for command line sessions.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
@@ -4652,21 +4681,26 @@ Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000030-GPOS-00011&lt;/VulnDiscussion
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000056</xccdf:ident>
-          <xccdf:fixtext fixref="F-32992r743986_fix">Configure the operating system to enable a user to initiate a session lock via tmux.
+          <xccdf:fixtext fixref="F-32992r880719_fix">Configure the operating system to enable a user to manually initiate a session lock via tmux. This configuration binds the uppercase letter "X" to manually initiate a session lock after the prefix key "Ctrl + b" has been sent. The complete key sequence is thus "Ctrl + b" then "Shift + x" to lock tmux.
 
-Create a global configuration file "/etc/tmux.conf" and add the following line:
+Create a global configuration file "/etc/tmux.conf" and add the following lines:
 
-set -g lock-command vlock</xccdf:fixtext>
-          <xccdf:fix id="F-32992r743986_fix" />
+     set -g lock-command vlock
+     bind X lock-session
+
+Reload tmux configuration to take effect. This can be performed in tmux while it is running:
+
+     $ tmux source-file /etc/tmux.conf</xccdf:fixtext>
+          <xccdf:fix id="F-32992r880719_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:193" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:230348" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230349">
         <xccdf:title>SRG-OS-000028-GPOS-00009</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230349r833388_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230349r880737_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020041</xccdf:version>
           <xccdf:title>RHEL 8 must ensure session control is automatically started at shell initialization.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
@@ -4684,18 +4718,18 @@ Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000030-GPOS-00011&lt;/VulnDiscussion
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000056</xccdf:ident>
-          <xccdf:fixtext fixref="F-32993r833310_fix">Configure the operating system to initialize the tmux terminal multiplexer as each shell is called by adding the following lines to a custom.sh shell script in the /etc/profile.d/ directory:
+          <xccdf:fixtext fixref="F-32993r880735_fix">Configure the operating system to initialize the tmux terminal multiplexer as each shell is called by adding the following lines to a custom.sh shell script in the /etc/profile.d/ directory:
 
 if [ "$PS1" ]; then
 parent=$(ps -o ppid= -p $$)
 name=$(ps -o comm= -p $parent)
-case "$name" in (sshd|login) exec tmux ;; esac
+case "$name" in (sshd|login) tmux ;; esac
 fi
 
 This setting will take effect at next logon.</xccdf:fixtext>
-          <xccdf:fix id="F-32993r833310_fix" />
+          <xccdf:fix id="F-32993r880735_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:194" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:194" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4723,14 +4757,14 @@ Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000030-GPOS-00011&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-32994r567797_fix">Configure the operating system to prevent users from disabling the tmux terminal multiplexer by editing the "/etc/shells" configuration file to remove any instances of tmux.</xccdf:fixtext>
           <xccdf:fix id="F-32994r567797_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:195" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:195" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230356">
         <xccdf:title>SRG-OS-000069-GPOS-00037</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230356r809379_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230356r902728_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020100</xccdf:version>
           <xccdf:title>RHEL 8 must ensure the password complexity module is enabled in the password-auth file.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.
@@ -4746,21 +4780,21 @@ RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. This 
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33000r809286_fix">Configure the operating system to use "pwquality" to enforce password complexity rules.
+          <xccdf:fixtext fixref="F-33000r902727_fix">Configure the operating system to use "pwquality" to enforce password complexity rules.
 
 Add the following line to the "/etc/pam.d/password-auth" file (or modify the line to have the required value):
 
-password required pam_pwquality.so</xccdf:fixtext>
-          <xccdf:fix id="F-33000r809286_fix" />
+     password requisite pam_pwquality.so</xccdf:fixtext>
+          <xccdf:fix id="F-33000r902727_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:196" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:230356" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230357">
         <xccdf:title>SRG-OS-000069-GPOS-00037</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230357r833313_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230357r858771_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020110</xccdf:version>
           <xccdf:title>RHEL 8 must enforce password complexity by requiring that at least one uppercase character be used.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
@@ -4776,21 +4810,23 @@ RHEL 8 utilizes pwquality as a mechanism to enforce password complexity. Note th
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000192</xccdf:ident>
-          <xccdf:fixtext fixref="F-33001r567818_fix">Configure the operating system to enforce password complexity by requiring that at least one uppercase character be used by setting the "ucredit" option.
+          <xccdf:fixtext fixref="F-33001r858770_fix">Configure the operating system to enforce password complexity by requiring that at least one uppercase character be used by setting the "ucredit" option.
 
 Add the following line to /etc/security/pwquality.conf (or modify the line to have the required value):
 
-ucredit = -1</xccdf:fixtext>
-          <xccdf:fix id="F-33001r567818_fix" />
+ucredit = -1
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33001r858770_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:197" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:197" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230358">
         <xccdf:title>SRG-OS-000070-GPOS-00038</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230358r833315_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230358r858773_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020120</xccdf:version>
           <xccdf:title>RHEL 8 must enforce password complexity by requiring that at least one lower-case character be used.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
@@ -4806,21 +4842,23 @@ RHEL 8 utilizes pwquality as a mechanism to enforce password complexity. Note th
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000193</xccdf:ident>
-          <xccdf:fixtext fixref="F-33002r567821_fix">Configure the operating system to enforce password complexity by requiring that at least one lower-case character be used by setting the "lcredit" option.
+          <xccdf:fixtext fixref="F-33002r858772_fix">Configure the operating system to enforce password complexity by requiring that at least one lower-case character be used by setting the "lcredit" option.
 
 Add the following line to /etc/security/pwquality.conf (or modify the line to have the required value):
 
-lcredit = -1</xccdf:fixtext>
-          <xccdf:fix id="F-33002r567821_fix" />
+lcredit = -1
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33002r858772_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:198" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:198" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230359">
         <xccdf:title>SRG-OS-000071-GPOS-00039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230359r833317_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230359r858775_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020130</xccdf:version>
           <xccdf:title>RHEL 8 must enforce password complexity by requiring that at least one numeric character be used.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
@@ -4836,21 +4874,23 @@ RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. Note 
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000194</xccdf:ident>
-          <xccdf:fixtext fixref="F-33003r567824_fix">Configure the operating system to enforce password complexity by requiring that at least one numeric character be used by setting the "dcredit" option.
+          <xccdf:fixtext fixref="F-33003r858774_fix">Configure the operating system to enforce password complexity by requiring that at least one numeric character be used by setting the "dcredit" option.
 
 Add the following line to /etc/security/pwquality.conf (or modify the line to have the required value):
 
-dcredit = -1</xccdf:fixtext>
-          <xccdf:fix id="F-33003r567824_fix" />
+dcredit = -1
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33003r858774_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:199" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:199" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230360">
         <xccdf:title>SRG-OS-000072-GPOS-00040</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230360r833319_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230360r858777_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020140</xccdf:version>
           <xccdf:title>RHEL 8 must require the maximum number of repeating characters of the same character class be limited to four when passwords are changed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
@@ -4866,21 +4906,23 @@ RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. The "
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000195</xccdf:ident>
-          <xccdf:fixtext fixref="F-33004r567827_fix">Configure the operating system to require the change of the number of repeating characters of the same character class when passwords are changed by setting the "maxclassrepeat" option.
+          <xccdf:fixtext fixref="F-33004r858776_fix">Configure the operating system to require the change of the number of repeating characters of the same character class when passwords are changed by setting the "maxclassrepeat" option.
 
 Add the following line to "/etc/security/pwquality.conf" conf (or modify the line to have the required value):
 
-maxclassrepeat = 4</xccdf:fixtext>
-          <xccdf:fix id="F-33004r567827_fix" />
+maxclassrepeat = 4
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33004r858776_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:200" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:200" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230361">
         <xccdf:title>SRG-OS-000072-GPOS-00040</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230361r833321_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230361r858779_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020150</xccdf:version>
           <xccdf:title>RHEL 8 must require the maximum number of repeating characters be limited to three when passwords are changed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
@@ -4896,21 +4938,23 @@ RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. The "
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000195</xccdf:ident>
-          <xccdf:fixtext fixref="F-33005r567830_fix">Configure the operating system to require the change of the number of repeating consecutive characters when passwords are changed by setting the "maxrepeat" option.
+          <xccdf:fixtext fixref="F-33005r858778_fix">Configure the operating system to require the change of the number of repeating consecutive characters when passwords are changed by setting the "maxrepeat" option.
 
 Add the following line to "/etc/security/pwquality.conf conf" (or modify the line to have the required value):
 
-maxrepeat = 3</xccdf:fixtext>
-          <xccdf:fix id="F-33005r567830_fix" />
+maxrepeat = 3
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33005r858778_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:201" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:201" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230362">
         <xccdf:title>SRG-OS-000072-GPOS-00040</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230362r833323_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230362r858781_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020160</xccdf:version>
           <xccdf:title>RHEL 8 must require the change of at least four character classes when passwords are changed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
@@ -4926,21 +4970,23 @@ RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. The "
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000195</xccdf:ident>
-          <xccdf:fixtext fixref="F-33006r567833_fix">Configure the operating system to require the change of at least four character classes when passwords are changed by setting the "minclass" option.
+          <xccdf:fixtext fixref="F-33006r858780_fix">Configure the operating system to require the change of at least four character classes when passwords are changed by setting the "minclass" option.
 
 Add the following line to "/etc/security/pwquality.conf conf" (or modify the line to have the required value):
 
-minclass = 4</xccdf:fixtext>
-          <xccdf:fix id="F-33006r567833_fix" />
+minclass = 4
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33006r858780_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:202" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:202" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230363">
         <xccdf:title>SRG-OS-000072-GPOS-00040</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230363r833325_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230363r858783_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020170</xccdf:version>
           <xccdf:title>RHEL 8 must require the change of at least 8 characters when passwords are changed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
@@ -4956,14 +5002,16 @@ RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. The "
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000195</xccdf:ident>
-          <xccdf:fixtext fixref="F-33007r567836_fix">Configure the operating system to require the change of at least eight of the total number of characters when passwords are changed by setting the "difok" option.
+          <xccdf:fixtext fixref="F-33007r858782_fix">Configure the operating system to require the change of at least eight of the total number of characters when passwords are changed by setting the "difok" option.
 
 Add the following line to "/etc/security/pwquality.conf" (or modify the line to have the required value):
 
-difok = 8</xccdf:fixtext>
-          <xccdf:fix id="F-33007r567836_fix" />
+difok = 8
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33007r858782_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:203" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:203" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4987,16 +5035,16 @@ difok = 8</xccdf:fixtext>
 $ sudo chage -m 1 [user]</xccdf:fixtext>
           <xccdf:fix id="F-33008r567839_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:204" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:204" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230365">
         <xccdf:title>SRG-OS-000075-GPOS-00043</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230365r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230365r858727_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020190</xccdf:version>
-          <xccdf:title>RHEL 8 passwords for new users or password changes must have a 24 hours/1 day minimum password lifetime restriction in /etc/logins.def.</xccdf:title>
+          <xccdf:title>RHEL 8 passwords for new users or password changes must have a 24 hours/1 day minimum password lifetime restriction in /etc/login.defs.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Enforcing a minimum password lifetime helps to prevent repeated password changes to defeat the password reuse or history enforcement requirement. If users are allowed to immediately and continually change their password, the password could be repeatedly changed in a short period of time to defeat the organization's policy regarding password reuse.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Red Hat Enterprise Linux 8</dc:title>
@@ -5013,7 +5061,7 @@ Add the following line in "/etc/login.defs" (or modify the line to have the requ
 PASS_MIN_DAYS 1</xccdf:fixtext>
           <xccdf:fix id="F-33009r567842_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:205" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:205" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5039,7 +5087,7 @@ Add, or modify the following line in the "/etc/login.defs" file:
 PASS_MAX_DAYS 60</xccdf:fixtext>
           <xccdf:fix id="F-33010r567845_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:206" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:206" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5063,14 +5111,14 @@ PASS_MAX_DAYS 60</xccdf:fixtext>
 $ sudo chage -M 60 [user]</xccdf:fixtext>
           <xccdf:fix id="F-33011r567848_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:207" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:207" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230368">
         <xccdf:title>SRG-OS-000077-GPOS-00045</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230368r810414_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230368r902759_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020220</xccdf:version>
           <xccdf:title>RHEL 8 must be configured in the password-auth file to prohibit password reuse for a minimum of five generations.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. If the information system or application allows the user to reuse their password consecutively when that password has exceeded its defined lifetime, the end result is a password that is not changed per policy requirements.
@@ -5088,21 +5136,21 @@ Note that manual changes to the listed files may be overwritten by the "authsele
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000200</xccdf:ident>
-          <xccdf:fixtext fixref="F-33012r809291_fix">Configure the operating system in the password-auth file to prohibit password reuse for a minimum of five generations.
+          <xccdf:fixtext fixref="F-33012r902757_fix">Configure the operating system in the password-auth file to prohibit password reuse for a minimum of five generations.
 
 Add the following line in "/etc/pam.d/password-auth" (or modify the line to have the required value):
 
-password required pam_pwhistory.so use_authtok remember=5 retry=3</xccdf:fixtext>
-          <xccdf:fix id="F-33012r809291_fix" />
+     password requisite pam_pwhistory.so use_authtok remember=5 retry=3</xccdf:fixtext>
+          <xccdf:fix id="F-33012r902757_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:208" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:230368" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230369">
         <xccdf:title>SRG-OS-000078-GPOS-00046</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230369r833327_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230369r858785_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020230</xccdf:version>
           <xccdf:title>RHEL 8 passwords must have a minimum of 15 characters.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The shorter the password, the lower the number of possible combinations that need to be tested before the password is compromised.
@@ -5122,14 +5170,16 @@ The DoD minimum password requirement is 15 characters.&lt;/VulnDiscussion&gt;&lt
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000205</xccdf:ident>
-          <xccdf:fixtext fixref="F-33013r567854_fix">Configure operating system to enforce a minimum 15-character password length.
+          <xccdf:fixtext fixref="F-33013r858784_fix">Configure operating system to enforce a minimum 15-character password length.
 
 Add the following line to "/etc/security/pwquality.conf" (or modify the line to have the required value):
 
-minlen = 15</xccdf:fixtext>
-          <xccdf:fix id="F-33013r567854_fix" />
+minlen = 15
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33013r858784_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:209" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:209" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5159,7 +5209,7 @@ Add, or modify the following line in the "/etc/login.defs" file:
 PASS_MIN_LEN 15</xccdf:fixtext>
           <xccdf:fix id="F-33014r567857_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:210" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:210" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5180,7 +5230,7 @@ RHEL 8 needs to track periods of inactivity and disable application identifiers 
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000795</xccdf:ident>
-          <xccdf:fixtext fixref="F-33017r567866_fix">Configure RHEL 8 to disable account identifiers after 35 days of inactivity after the password expiration. 
+          <xccdf:fixtext fixref="F-33017r567866_fix">Configure RHEL 8 to disable account identifiers after 35 days of inactivity after the password expiration.
 
 Run the following command to change the configuration for useradd:
 
@@ -5189,14 +5239,14 @@ $ sudo useradd -D -f 35
 DoD recommendation is 35 days, but a lower value is acceptable. The value "-1" will disable this feature, and "0" will disable the account immediately after the password expires.</xccdf:fixtext>
           <xccdf:fix id="F-33017r567866_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:211" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:211" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230375">
         <xccdf:title>SRG-OS-000266-GPOS-00101</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230375r833329_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230375r858787_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020280</xccdf:version>
           <xccdf:title>All RHEL 8 passwords must contain at least one special character.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
@@ -5212,21 +5262,23 @@ RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. Note 
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001619</xccdf:ident>
-          <xccdf:fixtext fixref="F-33019r567872_fix">Configure the operating system to enforce password complexity by requiring that at least one special character be used by setting the "ocredit" option.
+          <xccdf:fixtext fixref="F-33019r858786_fix">Configure the operating system to enforce password complexity by requiring that at least one special character be used by setting the "ocredit" option.
 
 Add the following line to /etc/security/pwquality.conf (or modify the line to have the required value):
 
-ocredit = -1</xccdf:fixtext>
-          <xccdf:fix id="F-33019r567872_fix" />
+ocredit = -1
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33019r858786_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:212" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:212" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230377">
         <xccdf:title>SRG-OS-000480-GPOS-00225</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230377r833331_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230377r858789_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020300</xccdf:version>
           <xccdf:title>RHEL 8 must prevent the use of dictionary words for passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If RHEL 8 allows the user to select passwords based on dictionary words, this increases the chances of password compromise by increasing the opportunity for successful guesses, and brute-force attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5238,14 +5290,16 @@ ocredit = -1</xccdf:fixtext>
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33021r567878_fix">Configure RHEL 8 to prevent the use of dictionary words for passwords.
+          <xccdf:fixtext fixref="F-33021r858788_fix">Configure RHEL 8 to prevent the use of dictionary words for passwords.
 
 Add or update the following line in the "/etc/security/pwquality.conf" file or a configuration file in the /etc/pwquality.conf.d/ directory to contain the "dictcheck" parameter:
 
-dictcheck=1</xccdf:fixtext>
-          <xccdf:fix id="F-33021r567878_fix" />
+dictcheck=1
+
+Remove any configurations that conflict with the above value.</xccdf:fixtext>
+          <xccdf:fix id="F-33021r858788_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:214" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:214" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5273,14 +5327,14 @@ Modify the "/etc/login.defs" file to set the "FAIL_DELAY" parameter to "4" or gr
 FAIL_DELAY 4</xccdf:fixtext>
           <xccdf:fix id="F-33022r567881_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:215" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:215" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230380">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230380r743993_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230380r858715_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020330</xccdf:version>
           <xccdf:title>RHEL 8 must not allow accounts configured with blank or null passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If an account has an empty password, anyone could log on and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5301,14 +5355,14 @@ The SSH daemon must be restarted for the changes to take effect. To restart the 
 $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fix id="F-33024r743992_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:216" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:216" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230382">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230382r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230382r858717_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020350</xccdf:version>
           <xccdf:title>RHEL 8 must display the date and time of the last successful account logon upon an SSH logon.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Providing users with feedback on when account accesses via SSH last occurred facilitates user recognition and reporting of unauthorized account use.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5319,7 +5373,7 @@ $ sudo systemctl restart sshd.service</xccdf:fixtext>
             <dc:subject>Red Hat Enterprise Linux 8</dc:subject>
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-000052</xccdf:ident>
           <xccdf:fixtext fixref="F-33026r567893_fix">Configure SSH to provide users with feedback on when account accesses last occurred by setting the required configuration options in "/etc/pam.d/sshd" or in the "sshd_config" file used by the system ("/etc/ssh/sshd_config" will be used in the example) (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor).
 
 Modify the "PrintLastLog" line in "/etc/ssh/sshd_config" to match the following:
@@ -5329,7 +5383,7 @@ PrintLastLog yes
 The SSH service must be restarted for changes to "sshd_config" to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33026r567893_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:218" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:218" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5355,14 +5409,14 @@ Add or edit the line for the "UMASK" parameter in "/etc/login.defs" file to "077
 UMASK 077</xccdf:fixtext>
           <xccdf:fix id="F-33027r567896_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:219" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:219" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230386">
         <xccdf:title>SRG-OS-000326-GPOS-00126</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230386r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230386r854037_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-030000</xccdf:version>
           <xccdf:title>The RHEL 8 audit system must be configured to audit the execution of privileged functions and prevent all software from executing at higher privilege levels than users executing the software.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Misuse of privileged functions, either intentionally or unintentionally by authorized users, or by unauthorized external entities that have compromised information system accounts, is a serious and ongoing concern and can have significant adverse impacts on organizations. Auditing the use of privileged functions is one way to detect such misuse and identify the risk from insider threats and the advanced persistent threat.
@@ -5380,16 +5434,16 @@ Satisfies: SRG-OS-000326-GPOS-00126, SRG-OS-000327-GPOS-00127&lt;/VulnDiscussion
 
 Add or update the following file system rules to "/etc/audit/rules.d/audit.rules":
 
--a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k execpriv 
+-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k execpriv
 -a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k execpriv
 
--a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k execpriv 
--a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k execpriv 
+-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k execpriv
+-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k execpriv
 
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33030r567905_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:220" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:220" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5412,14 +5466,14 @@ This requirement applies to each audit data storage repository (i.e., distinct i
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000139</xccdf:ident>
-          <xccdf:fixtext fixref="F-33032r567911_fix">Configure "auditd" service to notify the SA and ISSO in the event of an audit processing failure. 
+          <xccdf:fixtext fixref="F-33032r567911_fix">Configure "auditd" service to notify the SA and ISSO in the event of an audit processing failure.
 
 Edit the following line in "/etc/audit/auditd.conf" to ensure that administrators are notified via email for those situations:
 
 action_mail_acct = root</xccdf:fixtext>
           <xccdf:fix id="F-33032r567911_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:222" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:222" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5451,7 +5505,7 @@ disk_error_action = HALT
 If availability has been determined to be more important, and this decision is documented with the ISSO, configure the operating system to notify system administration staff and ISSO staff in the event of an audit processing failure by setting the "disk_error_action" to "SYSLOG".</xccdf:fixtext>
           <xccdf:fix id="F-33034r567917_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:223" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:223" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5463,7 +5517,7 @@ If availability has been determined to be more important, and this decision is d
           <xccdf:title>The RHEL 8 audit system must take appropriate action when the audit storage volume is full.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is critical that when RHEL 8 is at risk of failing to process audit logs as required, it takes action to mitigate the failure. Audit processing failures include software/hardware errors; failures in the audit capturing mechanisms; and audit storage capacity being reached or exceeded. Responses to audit failure depend upon the nature of the failure mode.
 
-When availability is an overriding concern, other approved actions in response to an audit failure are as follows: 
+When availability is an overriding concern, other approved actions in response to an audit failure are as follows:
 
 1) If the failure was caused by the lack of audit record storage capacity, RHEL 8 must continue generating audit records if possible (automatically restarting the audit service if necessary) and overwriting the oldest audit records in a first-in-first-out manner.
 
@@ -5485,7 +5539,7 @@ disk_full_action = HALT
 If availability has been determined to be more important, and this decision is documented with the ISSO, configure the operating system to notify system administration staff and ISSO staff in the event of an audit processing failure by setting the "disk_full_action" to "SYSLOG".</xccdf:fixtext>
           <xccdf:fix id="F-33036r567923_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:225" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:225" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5513,14 +5567,14 @@ Add or update the following line in "/etc/audit/auditd.conf" file:
 local_events = yes</xccdf:fixtext>
           <xccdf:fix id="F-33037r567926_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:226" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:226" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230394">
         <xccdf:title>SRG-OS-000342-GPOS-00133</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230394r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230394r877390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-030062</xccdf:version>
           <xccdf:title>RHEL 8 must label all off-loaded audit logs before sending them to the central log server.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without establishing what type of events occurred, the source of events, where events occurred, and the outcome of events, it would be difficult to establish, correlate, and investigate the events leading up to an outage or attack.
@@ -5545,7 +5599,7 @@ name_format = hostname
 The audit daemon must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33038r567929_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:227" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:227" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5575,14 +5629,14 @@ log_format = ENRICHED
 The audit daemon must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33039r567932_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:228" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:228" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230396">
         <xccdf:title>SRG-OS-000057-GPOS-00027</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230396r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230396r902733_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-030070</xccdf:version>
           <xccdf:title>RHEL 8 audit logs must have a mode of 0600 or less permissive to prevent unauthorized read access.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the RHEL 8 system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
@@ -5598,12 +5652,12 @@ Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPO
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000162</xccdf:ident>
-          <xccdf:fixtext fixref="F-33040r567935_fix">Configure the audit log to be protected from unauthorized read access by configuring the log group in the /etc/audit/auditd.conf file:
+          <xccdf:fixtext fixref="F-33040r902732_fix">Configure the audit log to be protected from unauthorized read access by setting the correct permissive mode with the following command:
 
-log_group = root</xccdf:fixtext>
-          <xccdf:fix id="F-33040r567935_fix" />
+$ sudo chmod 0600 /var/log/audit/audit.log</xccdf:fixtext>
+          <xccdf:fix id="F-33040r902732_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:229" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:230396" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5633,7 +5687,7 @@ $ sudo chown root [audit_log_file]
 Replace "[audit_log_file]" to the correct audit log path, by default this location is "/var/log/audit/audit.log".</xccdf:fixtext>
           <xccdf:fix id="F-33041r567938_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:230" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:230" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5661,7 +5715,7 @@ Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPO
 log_group = root</xccdf:fixtext>
           <xccdf:fix id="F-33042r567941_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:231" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:231" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5691,7 +5745,7 @@ $ sudo chown root [audit_log_directory]
 Replace "[audit_log_directory]" with the correct audit log directory path, by default this location is usually "/var/log/audit".</xccdf:fixtext>
           <xccdf:fix id="F-33043r567944_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:232" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:232" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5721,7 +5775,7 @@ $ sudo chgrp root [audit_log_directory]
 Replace "[audit_log_directory]" with the correct audit log directory path, by default this location is usually "/var/log/audit".</xccdf:fixtext>
           <xccdf:fix id="F-33044r567947_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:233" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:233" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5751,7 +5805,7 @@ $ sudo chmod 0700 [audit_log_directory]
 Replace "[audit_log_directory]" to the correct audit log directory path, by default this location is "/var/log/audit".</xccdf:fixtext>
           <xccdf:fix id="F-33045r567950_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:234" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:234" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5783,7 +5837,7 @@ Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPO
 Note: Once set, the system must be rebooted for auditing to be changed.  It is recommended to add this option as the last step in securing the system.</xccdf:fixtext>
           <xccdf:fix id="F-33046r567953_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:235" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:235" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5813,7 +5867,7 @@ Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPO
 --loginuid-immutable</xccdf:fixtext>
           <xccdf:fix id="F-33047r567956_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:236" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:236" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5845,7 +5899,7 @@ Add or update the following file system rule to "/etc/audit/rules.d/audit.rules"
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33048r567959_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:237" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:237" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5877,7 +5931,7 @@ Add or update the following file system rule to "/etc/audit/rules.d/audit.rules"
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33049r567962_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:238" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:238" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5909,7 +5963,7 @@ Add or update the following file system rule to "/etc/audit/rules.d/audit.rules"
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33050r567965_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:239" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:239" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5941,7 +5995,7 @@ Add or update the following file system rule to "/etc/audit/rules.d/audit.rules"
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33051r567968_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:240" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:240" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5973,7 +6027,7 @@ Add or update the following file system rule to "/etc/audit/rules.d/audit.rules"
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33052r567971_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:241" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:241" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6005,7 +6059,7 @@ Add or update the following file system rule to "/etc/audit/rules.d/audit.rules"
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33053r567974_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:242" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:242" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6037,7 +6091,7 @@ Add or update the following file system rule to "/etc/audit/rules.d/audit.rules"
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33054r567977_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:243" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:243" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6069,7 +6123,7 @@ Install the audit service (if the audit service is not already installed) with t
 $ sudo yum install audit</xccdf:fixtext>
           <xccdf:fix id="F-33055r646880_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:244" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:244" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6101,7 +6155,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33056r567983_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:245" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:245" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6113,7 +6167,7 @@ The audit daemon must be restarted for the changes to take effect.</xccdf:fixtex
           <xccdf:title>The RHEL 8 audit system must be configured to audit any usage of the setxattr, fsetxattr, lsetxattr, removexattr, fremovexattr, and lremovexattr system calls.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
-Audit records can be generated from various components within the information system (e.g., module or policy filter). 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
 
 "Setxattr" is a system call used to set an extended attribute value.
 "Fsetxattr" is a system call used to set an extended attribute value. This is used to set extended attributes on a file.
@@ -6146,7 +6200,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33057r809294_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:246" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:246" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6178,7 +6232,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33062r568001_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:251" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:251" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6210,7 +6264,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33063r568004_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:252" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:252" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6242,7 +6296,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33065r568010_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:254" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:254" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6274,7 +6328,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33066r568013_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:255" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:255" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6306,7 +6360,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33067r568016_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:256" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:256" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6338,7 +6392,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33068r568019_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:257" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:257" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6371,7 +6425,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33069r568022_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:258" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:258" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6403,7 +6457,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33070r568025_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:259" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:259" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6435,7 +6489,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33071r568028_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:260" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:260" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6467,7 +6521,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33072r568031_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:261" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:261" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6499,7 +6553,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33073r568034_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:262" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:262" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6531,7 +6585,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33074r568037_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:263" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:263" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6563,7 +6617,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33075r568040_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:264" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:264" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6595,7 +6649,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33076r568043_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:265" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:265" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6627,7 +6681,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33077r568046_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:266" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:266" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6659,7 +6713,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33078r744001_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:267" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:267" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6691,7 +6745,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33079r568052_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:268" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:268" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6723,7 +6777,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33080r568055_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:269" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:269" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6755,7 +6809,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33081r568058_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:270" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:270" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6790,7 +6844,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33082r810448_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:271" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:271" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6830,7 +6884,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33083r809301_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:272" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:272" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6862,7 +6916,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33088r568079_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:277" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:277" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6895,7 +6949,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33090r568085_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:279" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:279" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6927,7 +6981,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33091r568088_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:280" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:280" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6959,7 +7013,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33092r568091_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:281" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:281" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6971,7 +7025,7 @@ The audit daemon must be restarted for the changes to take effect.</xccdf:fixtex
           <xccdf:title>Successful/unsuccessful uses of the truncate, ftruncate, creat, open, openat, and open_by_handle_at system calls in RHEL 8 must generate an audit record.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
-Audit records can be generated from various components within the information system (e.g., module or policy filter). The "truncate" and "ftruncate" functions are used to truncate a file to a specified length. 
+Audit records can be generated from various components within the information system (e.g., module or policy filter). The "truncate" and "ftruncate" functions are used to truncate a file to a specified length.
 
 The "creat" system call is used to open and possibly create a file or device.
 The "open" system call opens a file specified by a pathname. If the specified file does not exist, it may optionally be created by "open".
@@ -7002,7 +7056,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33093r809304_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:282" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:282" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7041,7 +7095,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33099r809307_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:288" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:288" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7071,7 +7125,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000169</xccdf:ident>
-          <xccdf:fixtext fixref="F-33100r809310_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chmod", "fchmod", and "fchmodat" syscalls by adding or updating the following line to "/etc/audit/rules.d/audit.rules": 
+          <xccdf:fixtext fixref="F-33100r809310_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chmod", "fchmod", and "fchmodat" syscalls by adding or updating the following line to "/etc/audit/rules.d/audit.rules":
 
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=unset -k perm_mod
 -a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=unset -k perm_mod
@@ -7079,7 +7133,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33100r809310_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:289" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:289" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7111,7 +7165,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33106r568133_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:295" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:295" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7143,7 +7197,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33107r568136_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:296" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:296" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7175,7 +7229,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33108r568139_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:297" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:297" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7197,7 +7251,7 @@ DoD has defined the list of events for which RHEL 8 will provide an audit record
 
 2) Access actions, such as successful and unsuccessful logon attempts, privileged activities or other system-level access, starting and ending time for user access to the system, concurrent logons from different workstations, successful and unsuccessful accesses to objects, all program initiations, and all direct access to the information system;
 
-3) All account creations, modifications, disabling, and terminations; and 
+3) All account creations, modifications, disabling, and terminations; and
 
 4) All kernel module load, unload, and restart actions.
 
@@ -7217,7 +7271,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33109r568142_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:298" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:298" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7239,7 +7293,7 @@ DoD has defined the list of events for which RHEL 8 will provide an audit record
 
 2) Access actions, such as successful and unsuccessful logon attempts, privileged activities or other system-level access, starting and ending time for user access to the system, concurrent logons from different workstations, successful and unsuccessful accesses to objects, all program initiations, and all direct access to the information system;
 
-3) All account creations, modifications, disabling, and terminations; and 
+3) All account creations, modifications, disabling, and terminations; and
 
 4) All kernel module load, unload, and restart actions.
 
@@ -7259,7 +7313,7 @@ Satisfies: SRG-OS-000062-GPOS-00031, SRG-OS-000037-GPOS-00015, SRG-OS-000042-GPO
 The audit daemon must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33111r568148_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:299" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:299" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7285,7 +7339,7 @@ $ sudo chmod 0640 /etc/audit/rules.d/[customrulesfile].rules
 $ sudo chmod 0640 /etc/audit/auditd.conf</xccdf:fixtext>
           <xccdf:fix id="F-33115r568160_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:303" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:303" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7315,7 +7369,7 @@ $ sudo chmod 0755 [audit_tool]
 Replace "[audit_tool]" with the audit tool that does not have the correct permissive mode.</xccdf:fixtext>
           <xccdf:fix id="F-33116r568163_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:304" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:304" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7347,7 +7401,7 @@ $ sudo chown root [audit_tool]
 Replace "[audit_tool]" with each audit tool not owned by "root".</xccdf:fixtext>
           <xccdf:fix id="F-33117r568166_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:305" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:305" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7379,7 +7433,7 @@ $ sudo chgrp root [audit_tool]
 Replace "[audit_tool]" with each audit tool not group-owned by "root".</xccdf:fixtext>
           <xccdf:fix id="F-33118r568169_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:306" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:306" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7414,7 +7468,7 @@ Note that a port number was given as there is no standard port for RELP.&lt;/Vul
 $ sudo yum install rsyslog</xccdf:fixtext>
           <xccdf:fix id="F-33121r568178_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:412" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:412" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7449,14 +7503,14 @@ Note that a port number was given as there is no standard port for RELP.&lt;/Vul
 $ sudo yum install rsyslog-gnutls</xccdf:fixtext>
           <xccdf:fix id="F-33122r744010_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:307" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:307" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230480">
         <xccdf:title>SRG-OS-000342-GPOS-00133</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230480r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230480r877390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-030700</xccdf:version>
           <xccdf:title>RHEL 8 must take appropriate action when the internal event queue is full.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
@@ -7481,14 +7535,14 @@ overflow_action = syslog
 The audit daemon must be restarted for changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33124r568187_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:308" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:308" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230483">
         <xccdf:title>SRG-OS-000343-GPOS-00134</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230483r744014_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230483r877389_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-030730</xccdf:version>
           <xccdf:title>RHEL 8 must take action when allocated audit record storage volume reaches 75 percent of the repository maximum audit record storage capacity.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If security personnel are not notified immediately when storage volume reaches 75 percent utilization, they are unable to plan for audit record storage capacity expansion.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7507,7 +7561,7 @@ space_left = 25%
 Note: Option names and values in the auditd.conf file are case insensitive.</xccdf:fixtext>
           <xccdf:fix id="F-33127r744013_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:309" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:309" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7537,7 +7591,7 @@ Note that USNO offers authenticated NTP service to DoD and U.S. Government agenc
 port 0</xccdf:fixtext>
           <xccdf:fix id="F-33129r568202_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:310" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:310" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7567,7 +7621,7 @@ Note that USNO offers authenticated NTP service to DoD and U.S. Government agenc
 cmdport 0</xccdf:fixtext>
           <xccdf:fix id="F-33130r568205_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:311" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:311" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7601,7 +7655,7 @@ If a privileged user were to log on using this service, the privileged user pass
 $ sudo yum remove telnet-server</xccdf:fixtext>
           <xccdf:fix id="F-33131r568208_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:312" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:312" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7631,7 +7685,7 @@ Verify the operating system is configured to disable non-essential capabilities.
 $ sudo yum remove abrt*</xccdf:fixtext>
           <xccdf:fix id="F-33132r568211_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:313" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:313" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7661,7 +7715,7 @@ Verify the operating system is configured to disable non-essential capabilities.
 $ sudo yum remove sendmail</xccdf:fixtext>
           <xccdf:fix id="F-33133r568214_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:314" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:314" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7693,7 +7747,7 @@ Satisfies: SRG-OS-000095-GPOS-00049, SRG-OS-000074-GPOS-00042&lt;/VulnDiscussion
 $ sudo yum remove rsh-server</xccdf:fixtext>
           <xccdf:fix id="F-33136r568223_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:317" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:317" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7726,7 +7780,7 @@ blacklist atm
 Reboot the system for the settings to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33138r792910_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:318" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:318" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7759,7 +7813,7 @@ blacklist can
 Reboot the system for the settings to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33139r792913_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:319" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:319" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7792,7 +7846,7 @@ blacklist sctp
 Reboot the system for the settings to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33140r792916_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:320" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:320" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7825,7 +7879,7 @@ blacklist tipc
 Reboot the system for the settings to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33141r792919_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:321" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:321" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7858,7 +7912,7 @@ blacklist cramfs
 Reboot the system for the settings to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33142r568241_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:322" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:322" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7889,7 +7943,7 @@ blacklist firewire-core
 Reboot the system for the settings to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33143r568244_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:323" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:323" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7920,7 +7974,7 @@ blacklist usb-storage
 Reboot the system for the settings to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33147r809318_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:325" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:325" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7949,25 +8003,25 @@ Build or modify the "/etc/modprobe.d/bluetooth.conf" file with the following lin
 
 install bluetooth /bin/true
 
-Disable the ability to use the Bluetooth kernel module. 
- 
-$ sudo vi /etc/modprobe.d/blacklist.conf 
- 
-Add or update the line: 
- 
+Disable the ability to use the Bluetooth kernel module.
+
+$ sudo vi /etc/modprobe.d/blacklist.conf
+
+Add or update the line:
+
 blacklist bluetooth
 
 Reboot the system for the settings to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-33151r833335_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:326" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:326" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230508">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230508r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230508r854049_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040120</xccdf:version>
           <xccdf:title>RHEL 8 must mount /dev/shm with the nodev option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -7990,14 +8044,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 tmpfs /dev/shm tmpfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33152r568271_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:327" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:327" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230509">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230509r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230509r854050_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040121</xccdf:version>
           <xccdf:title>RHEL 8 must mount /dev/shm with the nosuid option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8018,14 +8072,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 tmpfs /dev/shm tmpfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33153r568274_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:328" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:328" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230510">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230510r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230510r854051_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040122</xccdf:version>
           <xccdf:title>RHEL 8 must mount /dev/shm with the noexec option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8048,14 +8102,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 tmpfs /dev/shm tmpfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33154r568277_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:329" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:329" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230511">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230511r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230511r854052_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040123</xccdf:version>
           <xccdf:title>RHEL 8 must mount /tmp with the nodev option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8078,14 +8132,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-tmp /tmp xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33155r568280_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:330" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:330" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230512">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230512r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230512r854053_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040124</xccdf:version>
           <xccdf:title>RHEL 8 must mount /tmp with the nosuid option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8106,14 +8160,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-tmp /tmp xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33156r568283_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:331" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:331" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230513">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230513r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230513r854054_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040125</xccdf:version>
           <xccdf:title>RHEL 8 must mount /tmp with the noexec option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8136,14 +8190,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-tmp /tmp xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33157r568286_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:332" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:332" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230514">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230514r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230514r854055_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040126</xccdf:version>
           <xccdf:title>RHEL 8 must mount /var/log with the nodev option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8166,14 +8220,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-var-log /var/log xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33158r568289_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:333" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:333" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230515">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230515r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230515r854056_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040127</xccdf:version>
           <xccdf:title>RHEL 8 must mount /var/log with the nosuid option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8196,14 +8250,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-var-log /var/log xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33159r568292_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:334" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:334" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230516">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230516r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230516r854057_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040128</xccdf:version>
           <xccdf:title>RHEL 8 must mount /var/log with the noexec option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8226,14 +8280,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-var-log /var/log xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33160r568295_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:335" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:335" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230517">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230517r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230517r854058_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040129</xccdf:version>
           <xccdf:title>RHEL 8 must mount /var/log/audit with the nodev option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8256,14 +8310,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-var-log-audit /var/log/audit xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33161r568298_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:336" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:336" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230518">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230518r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230518r854059_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040130</xccdf:version>
           <xccdf:title>RHEL 8 must mount /var/log/audit with the nosuid option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8286,14 +8340,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-var-log-audit /var/log/audit xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33162r568301_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:337" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:337" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230519">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230519r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230519r854060_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040131</xccdf:version>
           <xccdf:title>RHEL 8 must mount /var/log/audit with the noexec option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8316,14 +8370,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-var-log-audit /var/log/audit xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33163r568304_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:338" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:338" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230520">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230520r792927_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230520r854061_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040132</xccdf:version>
           <xccdf:title>RHEL 8 must mount /var/tmp with the nodev option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8346,14 +8400,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-var-tmp /var/tmp xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33164r792926_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:339" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:339" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230521">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230521r792930_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230521r854062_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040133</xccdf:version>
           <xccdf:title>RHEL 8 must mount /var/tmp with the nosuid option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8376,14 +8430,14 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-var-tmp /var/tmp xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33165r792929_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:340" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:340" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230522">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230522r792933_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230522r854063_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040134</xccdf:version>
           <xccdf:title>RHEL 8 must mount /var/tmp with the noexec option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The organization must identify authorized software programs and permit execution of authorized software. The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting.
@@ -8406,19 +8460,19 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
 /dev/mapper/rhel-var-tmp /var/tmp xfs defaults,nodev,nosuid,noexec 0 0</xccdf:fixtext>
           <xccdf:fix id="F-33166r792932_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:341" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:341" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230526">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230526r744032_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230526r854067_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040160</xccdf:version>
           <xccdf:title>All RHEL 8 networked systems must have and implement SSH to protect the confidentiality and integrity of transmitted and received information, as well as information during preparation for transmission.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered.
 
-This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. 
+This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification.
 
 Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa.
 
@@ -8436,19 +8490,19 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188, SRG-OS-000425-GPO
 $ sudo systemctl enable sshd.service</xccdf:fixtext>
           <xccdf:fix id="F-33170r744031_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:342" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:342" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230527">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230527r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230527r877398_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040161</xccdf:version>
           <xccdf:title>RHEL 8 must force a frequent session key renegotiation for SSH connections to the server.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered.
 
-This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. 
+This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification.
 
 Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa.
 
@@ -8472,7 +8526,7 @@ Restart the SSH daemon for the settings to take effect.
 $ sudo systemctl restart sshd.service</xccdf:fixtext>
           <xccdf:fix id="F-33171r568328_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:343" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:343" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8500,7 +8554,7 @@ Reload the daemon for this change to take effect.
 $ sudo systemctl daemon-reload</xccdf:fixtext>
           <xccdf:fix id="F-33175r619890_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:345" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:345" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8524,7 +8578,7 @@ $ sudo systemctl daemon-reload</xccdf:fixtext>
 $ sudo yum remove tftp-server</xccdf:fixtext>
           <xccdf:fix id="F-33177r568346_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:346" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:346" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8543,19 +8597,19 @@ $ sudo yum remove tftp-server</xccdf:fixtext>
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33178r568349_fix">Change the UID of any account on the system, other than root, that has a UID of "0". 
+          <xccdf:fixtext fixref="F-33178r568349_fix">Change the UID of any account on the system, other than root, that has a UID of "0".
 
 If the account is associated with system commands or applications, the UID should be changed to one greater than "0" but less than "1000". Otherwise, assign a UID of greater than "1000" that has not already been assigned.</xccdf:fixtext>
           <xccdf:fix id="F-33178r568349_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:347" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:347" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230535">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230535r833340_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230535r858793_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040210</xccdf:version>
           <xccdf:title>RHEL 8 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect messages from being accepted.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages modify the host's route table and are unauthenticated. An illicit ICMP redirect message could result in a man-in-the-middle attack.
@@ -8575,25 +8629,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33179r818847_fix">Configure RHEL 8 to prevent IPv6 ICMP redirect messages from being accepted.
+          <xccdf:fixtext fixref="F-33179r858792_fix">Configure RHEL 8 to prevent IPv6 ICMP redirect messages from being accepted.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv6.conf.default.accept_redirects = 0
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33179r818847_fix" />
+          <xccdf:fix id="F-33179r858792_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:348" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:348" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230536">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230536r833342_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230536r858795_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040220</xccdf:version>
           <xccdf:title>RHEL 8 must not send Internet Control Message Protocol (ICMP) redirects.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages contain information from the system's route table, possibly revealing portions of the network topology.
@@ -8615,25 +8677,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33180r818850_fix">Configure RHEL 8 to not allow interfaces to perform IPv4 ICMP redirects.
+          <xccdf:fixtext fixref="F-33180r858794_fix">Configure RHEL 8 to not allow interfaces to perform IPv4 ICMP redirects.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv4.conf.all.send_redirects=0
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33180r818850_fix" />
+          <xccdf:fix id="F-33180r858794_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:349" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:349" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230537">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230537r833344_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230537r858797_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040230</xccdf:version>
           <xccdf:title>RHEL 8 must not respond to Internet Control Message Protocol (ICMP) echoes sent to a broadcast address.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Responding to broadcast ICMP echoes facilitates network mapping and provides a vector for amplification attacks.
@@ -8654,25 +8724,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33181r818853_fix">Configure RHEL 8 to not respond to IPv4 ICMP echoes sent to a broadcast address.
+          <xccdf:fixtext fixref="F-33181r858796_fix">Configure RHEL 8 to not respond to IPv4 ICMP echoes sent to a broadcast address.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv4.icmp_echo_ignore_broadcasts=1
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33181r818853_fix" />
+          <xccdf:fix id="F-33181r858796_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:350" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:350" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230538">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230538r833346_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230538r858801_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040240</xccdf:version>
           <xccdf:title>RHEL 8 must not forward IPv6 source-routed packets.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Source-routed packets allow the source of the packet to suggest that routers forward the packet along a different path than configured on the router, which can be used to bypass network security measures. This requirement applies only to the forwarding of source-routed traffic, such as when forwarding is enabled and the system is functioning as a router.
@@ -8692,25 +8770,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33182r818859_fix">Configure RHEL 8 to not forward IPv6 source-routed packets.
+          <xccdf:fixtext fixref="F-33182r858800_fix">Configure RHEL 8 to not forward IPv6 source-routed packets.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv6.conf.all.accept_source_route=0
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33182r818859_fix" />
+          <xccdf:fix id="F-33182r858800_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:351" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:351" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230539">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230539r838722_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230539r861085_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040250</xccdf:version>
           <xccdf:title>RHEL 8 must not forward IPv6 source-routed packets by default.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Source-routed packets allow the source of the packet to suggest that routers forward the packet along a different path than configured on the router, which can be used to bypass network security measures. This requirement applies only to the forwarding of source-routed traffic, such as when forwarding is enabled and the system is functioning as a router.
@@ -8730,25 +8816,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33183r818865_fix">Configure RHEL 8 to not forward IPv6 source-routed packets by default.
+          <xccdf:fixtext fixref="F-33183r858805_fix">Configure RHEL 8 to not forward IPv6 source-routed packets by default.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv6.conf.default.accept_source_route=0
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33183r818865_fix" />
+          <xccdf:fix id="F-33183r858805_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:352" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:352" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230540">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230540r833349_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230540r858810_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040260</xccdf:version>
           <xccdf:title>RHEL 8 must not enable IPv6 packet forwarding unless the system is a router.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Routing protocol daemons are typically used on routers to exchange network topology information with other routers. If this software is used when not required, system network information may be unnecessarily transmitted across the network.
@@ -8768,25 +8862,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33184r818871_fix">Configure RHEL 8 to not allow IPv6 packet forwarding, unless the system is a router.
+          <xccdf:fixtext fixref="F-33184r858809_fix">Configure RHEL 8 to not allow IPv6 packet forwarding, unless the system is a router.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv6.conf.all.forwarding=0
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33184r818871_fix" />
+          <xccdf:fix id="F-33184r858809_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:353" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:353" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230541">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230541r833351_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230541r858812_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040261</xccdf:version>
           <xccdf:title>RHEL 8 must not accept router advertisements on all IPv6 interfaces.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Routing protocol daemons are typically used on routers to exchange network topology information with other routers. If this software is used when not required, system network information may be unnecessarily transmitted across the network.
@@ -8808,25 +8910,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33185r818874_fix">Configure RHEL 8 to not accept router advertisements on all IPv6 interfaces unless the system is a router.
+          <xccdf:fixtext fixref="F-33185r858811_fix">Configure RHEL 8 to not accept router advertisements on all IPv6 interfaces unless the system is a router.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv6.conf.all.accept_ra=0
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33185r818874_fix" />
+          <xccdf:fix id="F-33185r858811_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:354" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:354" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230542">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230542r833353_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230542r858814_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040262</xccdf:version>
           <xccdf:title>RHEL 8 must not accept router advertisements on all IPv6 interfaces by default.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Routing protocol daemons are typically used on routers to exchange network topology information with other routers. If this software is used when not required, system network information may be unnecessarily transmitted across the network.
@@ -8848,25 +8958,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33186r818877_fix">Configure RHEL 8 to not accept router advertisements on all IPv6 interfaces by default unless the system is a router.
+          <xccdf:fixtext fixref="F-33186r858813_fix">Configure RHEL 8 to not accept router advertisements on all IPv6 interfaces by default unless the system is a router.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv6.conf.default.accept_ra=0
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33186r818877_fix" />
+          <xccdf:fix id="F-33186r858813_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:355" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:355" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230543">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230543r833355_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230543r858816_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040270</xccdf:version>
           <xccdf:title>RHEL 8 must not allow interfaces to perform Internet Control Message Protocol (ICMP) redirects by default.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages contain information from the system's route table, possibly revealing portions of the network topology.
@@ -8888,25 +9006,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33187r818880_fix">Configure RHEL 8 to not allow interfaces to perform Internet Protocol version 4 (IPv4) ICMP redirects by default.
+          <xccdf:fixtext fixref="F-33187r858815_fix">Configure RHEL 8 to not allow interfaces to perform Internet Protocol version 4 (IPv4) ICMP redirects by default.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv4.conf.default.send_redirects = 0
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33187r818880_fix" />
+          <xccdf:fix id="F-33187r858815_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:356" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:356" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230544">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230544r833357_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230544r858820_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040280</xccdf:version>
           <xccdf:title>RHEL 8 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect messages.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ICMP redirect messages are used by routers to inform hosts that a more direct route exists for a particular destination. These messages modify the host's route table and are unauthenticated. An illicit ICMP redirect message could result in a man-in-the-middle attack.
@@ -8926,25 +9052,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33188r818886_fix">Configure RHEL 8 to ignore IPv6 ICMP redirect messages.
+          <xccdf:fixtext fixref="F-33188r858819_fix">Configure RHEL 8 to ignore IPv6 ICMP redirect messages.
 
 Add or edit the following line in a system configuration file, in the "/etc/sysctl.d/" directory:
 
 net.ipv6.conf.all.accept_redirects = 0
 
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
+
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33188r818886_fix" />
+          <xccdf:fix id="F-33188r858819_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:357" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:357" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230545">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230545r833359_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230545r858822_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040281</xccdf:version>
           <xccdf:title>RHEL 8 must disable access to network bpf syscall from unprivileged processes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
@@ -8964,23 +9098,31 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33189r818889_fix">Configure RHEL 8 to prevent privilege escalation thru the kernel by disabling access to the bpf syscall by adding the following line to a file, in the "/etc/sysctl.d" directory:
+          <xccdf:fixtext fixref="F-33189r858821_fix">Configure RHEL 8 to prevent privilege escalation thru the kernel by disabling access to the bpf syscall by adding the following line to a file, in the "/etc/sysctl.d" directory:
 
 kernel.unprivileged_bpf_disabled = 1
+
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
 
 The system configuration files need to be reloaded for the changes to take effect. To reload the contents of the files, run the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33189r818889_fix" />
+          <xccdf:fix id="F-33189r858821_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:358" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:358" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230546">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230546r833361_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230546r858824_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040282</xccdf:version>
           <xccdf:title>RHEL 8 must restrict usage of ptrace to descendant  processes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
@@ -9000,23 +9142,31 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33190r818892_fix">Configure RHEL 8 to restrict usage of ptrace to descendant processes by adding the following line to a file, in the "/etc/sysctl.d" directory:
+          <xccdf:fixtext fixref="F-33190r858823_fix">Configure RHEL 8 to restrict usage of ptrace to descendant processes by adding the following line to a file, in the "/etc/sysctl.d" directory:
 
 kernel.yama.ptrace_scope = 1
+
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
 
 The system configuration files need to be reloaded for the changes to take effect. To reload the contents of the files, run the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33190r818892_fix" />
+          <xccdf:fix id="F-33190r858823_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:359" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:359" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230547">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230547r833363_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230547r858826_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040283</xccdf:version>
           <xccdf:title>RHEL 8 must restrict exposed kernel pointer addresses access.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
@@ -9036,23 +9186,31 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33191r818895_fix">Configure RHEL 8 to restrict exposed kernel pointer addresses access by adding the following line to a file, in the "/etc/sysctl.d" directory:
+          <xccdf:fixtext fixref="F-33191r858825_fix">Configure RHEL 8 to restrict exposed kernel pointer addresses access by adding the following line to a file, in the "/etc/sysctl.d" directory:
 
 kernel.kptr_restrict = 1
+
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
 
 The system configuration files need to be reloaded for the changes to take effect. To reload the contents of the files, run the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33191r818895_fix" />
+          <xccdf:fix id="F-33191r858825_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:360" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:360" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230548">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230548r833365_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230548r858828_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040284</xccdf:version>
           <xccdf:title>RHEL 8 must disable the use of user namespaces.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
@@ -9072,25 +9230,33 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33192r818898_fix">Configure RHEL 8 to disable the use of user namespaces by adding the following line to a file, in the "/etc/sysctl.d" directory:
+          <xccdf:fixtext fixref="F-33192r858827_fix">Configure RHEL 8 to disable the use of user namespaces by adding the following line to a file, in the "/etc/sysctl.d" directory:
 
-Note: User namespaces are used primarily for Linux containers. If containers are in use, this requirement is not applicable. 
+Note: User namespaces are used primarily for Linux containers. If containers are in use, this requirement is not applicable.
 
 user.max_user_namespaces = 0
+
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
 
 The system configuration files need to be reloaded for the changes to take effect. To reload the contents of the files, run the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33192r818898_fix" />
+          <xccdf:fix id="F-33192r858827_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:361" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:361" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230549">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230549r833367_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230549r858830_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040285</xccdf:version>
           <xccdf:title>RHEL 8 must use reverse path filtering on all IPv4 interfaces.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
@@ -9110,16 +9276,24 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-33193r818901_fix">Configure RHEL 8 to use reverse path filtering on all IPv4 interfaces by adding the following line to a file, in the "/etc/sysctl.d" directory:
+          <xccdf:fixtext fixref="F-33193r858829_fix">Configure RHEL 8 to use reverse path filtering on all IPv4 interfaces by adding the following line to a file, in the "/etc/sysctl.d" directory:
 
 net.ipv4.conf.all.rp_filter = 1
+
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
 
 The system configuration files need to be reloaded for the changes to take effect. To reload the contents of the files, run the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-33193r818901_fix" />
+          <xccdf:fix id="F-33193r858829_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:362" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:362" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9143,14 +9317,14 @@ $ sudo sysctl --system</xccdf:fixtext>
 $ sudo postconf -e 'smtpd_client_restrictions = permit_mynetworks,reject'</xccdf:fixtext>
           <xccdf:fix id="F-33194r568397_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:363" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:363" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230555">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230555r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230555r858721_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040340</xccdf:version>
           <xccdf:title>RHEL 8 remote X connections for interactive users must be disabled unless to fulfill documented and validated mission requirements.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The security risk of using X11 forwarding is that the client's X11 display server may be exposed to attack when the SSH client requests forwarding.  A system administrator may have a stance in which they want to protect clients that may expose themselves to attack by unwittingly requesting X11 forwarding, which can warrant a "no" setting.
@@ -9175,14 +9349,14 @@ The SSH service must be restarted for changes to take effect:
 $ sudo systemctl restart sshd</xccdf:fixtext>
           <xccdf:fix id="F-33199r568412_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:364" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:364" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-230556">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230556r627750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-230556r858723_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040341</xccdf:version>
           <xccdf:title>The RHEL 8 SSH daemon must prevent remote hosts from connecting to the proxy display.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;When X11 forwarding is enabled, there may be additional exposure to the server and client displays if the sshd proxy display is configured to listen on the wildcard address.  By default, sshd binds the forwarding server to the loopback address and sets the hostname part of the DIPSLAY environment variable to localhost.  This prevents remote hosts from connecting to the proxy display.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -9201,7 +9375,7 @@ Edit the "/etc/ssh/sshd_config" file to uncomment or add the line for the "X11Us
 X11UseLocalhost yes</xccdf:fixtext>
           <xccdf:fix id="F-33200r568415_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:365" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:365" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9225,7 +9399,7 @@ X11UseLocalhost yes</xccdf:fixtext>
 server_args = -s /var/lib/tftpboot</xccdf:fixtext>
           <xccdf:fix id="F-33201r568418_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:366" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:366" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9249,7 +9423,7 @@ server_args = -s /var/lib/tftpboot</xccdf:fixtext>
 $ sudo yum remove vsftpd</xccdf:fixtext>
           <xccdf:fix id="F-33202r568421_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:367" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:367" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9277,7 +9451,7 @@ The gssproxy package is a proxy for GSS API credential handling and could expose
 $ sudo yum remove gssproxy</xccdf:fixtext>
           <xccdf:fix id="F-33203r568424_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:368" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:368" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9305,7 +9479,7 @@ The iprutils package provides a suite of utilities to manage and configure SCSI 
 $ sudo yum remove iprutils</xccdf:fixtext>
           <xccdf:fix id="F-33204r568427_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:369" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:369" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9333,7 +9507,7 @@ The tuned package contains a daemon that tunes the system settings dynamically. 
 $ sudo yum remove tuned</xccdf:fixtext>
           <xccdf:fix id="F-33205r568430_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:370" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:370" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9363,7 +9537,7 @@ FIPS 140-2 is the current standard for validating that mechanisms used to access
 $ sudo yum remove krb5-server</xccdf:fixtext>
           <xccdf:fix id="F-40822r646889_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:413" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:413" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9387,17 +9561,17 @@ ALL     ALL=(ALL) ALL
 ALL     ALL=(ALL:ALL) ALL</xccdf:fixtext>
           <xccdf:fix id="F-40823r646892_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:414" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:414" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-237642">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237642r833369_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237642r880727_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010383</xccdf:version>
           <xccdf:title>RHEL 8 must use the invoking user's password for privilege escalation when using "sudo".</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;The sudoers security policy requires that users authenticate themselves before they can use sudo. When sudoers requires authentication, it validates the invoking user's credentials. If the rootpw, targetpw, or runaspw flags are defined and not disabled, by default the operating system will prompt the invoking user for the "root" user password. 
+          <xccdf:description>&lt;VulnDiscussion&gt;The sudoers security policy requires that users authenticate themselves before they can use sudo. When sudoers requires authentication, it validates the invoking user's credentials. If the rootpw, targetpw, or runaspw flags are defined and not disabled, by default the operating system will prompt the invoking user for the "root" user password.
 For more information on each of the listed configurations, reference the sudoers(5) manual page.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Red Hat Enterprise Linux 8</dc:title>
@@ -9407,23 +9581,27 @@ For more information on each of the listed configurations, reference the sudoers
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002227</xccdf:ident>
-          <xccdf:fixtext fixref="F-40824r646895_fix">Define the following in the Defaults section of the /etc/sudoers file or a configuration file in the /etc/sudoers.d/ directory:
-Defaults !targetpw
-Defaults !rootpw
-Defaults !runaspw</xccdf:fixtext>
-          <xccdf:fix id="F-40824r646895_fix" />
+          <xccdf:fixtext fixref="F-40824r880726_fix">Define the following in the Defaults section of the /etc/sudoers file or a configuration file in the /etc/sudoers.d/ directory:
+     Defaults !targetpw
+     Defaults !rootpw
+     Defaults !runaspw
+
+Remove any configurations that conflict with the above from the following locations:
+     /etc/sudoers
+     /etc/sudoers.d/</xccdf:fixtext>
+          <xccdf:fix id="F-40824r880726_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:415" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:415" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-237643">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237643r838720_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-237643r861088_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-010384</xccdf:version>
           <xccdf:title>RHEL 8 must require re-authentication when using the "sudo" command.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization.
 
 When operating systems provide the capability to escalate a functional capability, it is critical the organization requires the user to re-authenticate when using the "sudo" command.
 
@@ -9436,16 +9614,18 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002038</xccdf:ident>
-          <xccdf:fixtext fixref="F-40825r646898_fix">Configure the "sudo" command to require re-authentication.
+          <xccdf:fixtext fixref="F-40825r858763_fix">Configure the "sudo" command to require re-authentication.
 Edit the /etc/sudoers file:
 $ sudo visudo
 
 Add or modify the following line:
 Defaults timestamp_timeout=[value]
-Note: The "[value]" must be a number that is greater than or equal to "0".</xccdf:fixtext>
-          <xccdf:fix id="F-40825r646898_fix" />
+Note: The "[value]" must be a number that is greater than or equal to "0".
+
+Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ files.</xccdf:fixtext>
+          <xccdf:fix id="F-40825r858763_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:416" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:416" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9469,7 +9649,7 @@ Note: The "[value]" must be a number that is greater than or equal to "0".</xccd
 Note: Manual changes to the listed file may be overwritten by the "authselect" program.</xccdf:fixtext>
           <xccdf:fix id="F-47772r743868_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:463" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:463" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9493,14 +9673,14 @@ Note: Manual changes to the listed file may be overwritten by the "authselect" p
 Note: Manual changes to the listed file may be overwritten by the "authselect" program.</xccdf:fixtext>
           <xccdf:fix id="F-47773r743871_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:464" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:464" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-244554">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-244554r833381_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-244554r858832_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-040286</xccdf:version>
           <xccdf:title>RHEL 8 must enable hardening for the Berkeley Packet Filter Just-in-time compiler.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
@@ -9522,16 +9702,24 @@ The sysctl --system command will load settings from all system configuration fil
             <dc:identifier>2921</dc:identifier>
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-47786r818904_fix">Configure RHEL 8 to enable hardening for the BPF JIT compiler by adding the following line to a file, in the "/etc/sysctl.d" directory:
+          <xccdf:fixtext fixref="F-47786r858831_fix">Configure RHEL 8 to enable hardening for the BPF JIT compiler by adding the following line to a file, in the "/etc/sysctl.d" directory:
 
 net.core.bpf_jit_harden = 2
+
+Remove any configurations that conflict with the above from the following locations:
+/run/sysctl.d/*.conf
+/usr/local/lib/sysctl.d/*.conf
+/usr/lib/sysctl.d/*.conf
+/lib/sysctl.d/*.conf
+/etc/sysctl.conf
+/etc/sysctl.d/*.conf
 
 The system configuration files need to be reloaded for the changes to take effect. To reload the contents of the files, run the following command:
 
 $ sudo sysctl --system</xccdf:fixtext>
-          <xccdf:fix id="F-47786r818904_fix" />
+          <xccdf:fix id="F-47786r858831_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:477" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:477" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9558,20 +9746,159 @@ Lock an account:
 $ sudo passwd -l [username]</xccdf:fixtext>
           <xccdf:fix id="F-55097r809341_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:482" href="U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8:def:482" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </xccdf:check>
+        </xccdf:Rule>
+      </xccdf:Group>
+      <xccdf:Group id="xccdf_mil.disa.stig_group_V-251714">
+        <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
+        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-251714r902743_rule" weight="10.0" severity="medium">
+          <xccdf:version update="http://iase.disa.mil/stigs">RHEL-08-020102</xccdf:version>
+          <xccdf:title>RHEL 8 systems below version 8.4 must ensure the password complexity module in the system-auth file is configured for three retries or less.</xccdf:title>
+          <xccdf:description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.
+
+RHEL 8 uses "pwquality" as a mechanism to enforce password complexity. This is set in both:
+/etc/pam.d/password-auth
+/etc/pam.d/system-auth
+
+By limiting the number of attempts to meet the pwquality module complexity requirements before returning with an error, the system will audit abnormal attempts at password changes.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:reference>
+            <dc:title>DPMS Target Red Hat Enterprise Linux 8</dc:title>
+            <dc:publisher>DISA</dc:publisher>
+            <dc:type>DPMS Target</dc:type>
+            <dc:subject>Red Hat Enterprise Linux 8</dc:subject>
+            <dc:identifier>2921</dc:identifier>
+          </xccdf:reference>
+          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_RHEL_8-3_or_Lower" />
+          <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
+          <xccdf:fixtext fixref="F-55105r902742_fix">Configure the operating system to limit the "pwquality" retry option to 3.
+
+Add the following line to the "/etc/pam.d/system-auth" file (or modify the line to have the required value):
+
+     password requisite pam_pwquality.so retry=3</xccdf:fixtext>
+          <xccdf:fix id="F-55105r902742_fix" />
+          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <xccdf:check-content-ref name="oval:mil.disa.stig.rhel8os:def:251714" href="U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
     </xccdf:Benchmark>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2022-06-28T15:27:20">
+  <component id="scap_mil.disa.stig_comp_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2023-03-28T17:41:02">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-06-28T15:27:20</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:02</oval:timestamp>
       </generator>
       <definitions>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230244" version="1">
+          <metadata>
+            <title>The operating system must be configured so that all network connections associated with SSH traffic are terminated at the end of the session or after 10 minutes of inactivity, except to fulfill documented and validated mission requirements.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23024400" comment="/etc/ssh/sshd_config:ClientAliveCountMax = 1" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230257" version="1">
+          <metadata>
+            <title>The operating system system commands must have mode 755 or less permissive.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.unix:tst:23025700" comment="System command files have mode 755 or less permissive" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230292" version="1">
+          <metadata>
+            <title>The operating system must use a separate file system for /var.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.linux:tst:23029200" comment="There is a separate file system for /var" />
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23029201" comment="There is a separate file system configured for /var" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230293" version="1">
+          <metadata>
+            <title>The operating system must use a separate file system for /var/log.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.linux:tst:23029300" comment="There is a separate file system for /var/log." />
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23029301" comment="There is a separate file system configured for /var/log." />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230346" version="1">
+          <metadata>
+            <title>The operating system must limit the number of concurrent sessions to ten for all accounts and/or account types.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23034600" comment="limits.conf and limits.d/*.conf:maxlogins is set to 10 or less by default" />
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23034601" comment="limits.conf and limits.d/*.conf:maxlogins is set to 10 or less for non-default domains" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230348" version="1">
+          <metadata>
+            <title>The operating system must enable a user session lock until that user re-establishes access using established identification and authentication procedures for command line sessions.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23034800" comment="The lock-command is set in /etc/tmux.conf" />
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23034801" comment="The lock-session is bound to X, in /etc/tmux.conf" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230356" version="1">
+          <metadata>
+            <title>The operating system must ensure the password complexity module is enabled in the password-auth file.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23035600" comment="The pam_pwquality module is included in password-auth." />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230368" version="1">
+          <metadata>
+            <title>The operating system must be configured in the password-auth file to prohibit password reuse for a minimum of five generations.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:23036800" comment="/etc/pam.d/password-auth: pam_pwhistory.so has remember set to 5 or greater" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:230396" version="1">
+          <metadata>
+            <title>The operating system audit logs must have a mode of 0600 or less permissive to prevent unauthorized read access.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.unix:tst:23039600" comment="Audit log is mode 0600 or less permissive" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:251714" version="1">
+          <metadata>
+            <title>Systems below version 8.4 must ensure the password complexity module in the system-auth file is configured for three retries or less.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.ind:tst:25171400" comment="/etc/pam.d/system-auth:retry not greater than 3 and not 0" />
+          </criteria>
+        </definition>
+        <definition class="inventory" id="oval:mil.disa.stig.linux:def:100008" version="1">
+          <metadata>
+            <title>The system is RHEL 8.3 or lower</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.linux:tst:10000800" comment="The redhat-release package is version 8.3 or lower" />
+          </criteria>
+        </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:10" version="1">
           <metadata>
             <title>The RHEL 8 version is RHEL 8.2 or newer.</title>
@@ -9637,7 +9964,7 @@ Red Hat offers the Extended Update Support (EUS) ad-on to a Red Hat Enterprise L
             </affected>
             <description>Use of weak or untested encryption algorithms undermines the purposes of using encryption to protect data. The operating system must implement cryptographic modules adhering to the higher standards approved by the Federal Government since this provides assurance they have been tested and validated.
 
-RHEL 8 utilizes GRUB 2 as the default bootloader. Note that GRUB 2 command-line parameters are defined in the "kernelopts" variable of the /boot/grub2/grubenv file for all kernel boot entries. The command "fips-mode-setup" modifies the "kernelopts" variable, which in turn updates all kernel boot entries. 
+RHEL 8 utilizes GRUB 2 as the default bootloader. Note that GRUB 2 command-line parameters are defined in the "kernelopts" variable of the /boot/grub2/grubenv file for all kernel boot entries. The command "fips-mode-setup" modifies the "kernelopts" variable, which in turn updates all kernel boot entries.
 
 The fips=1 kernel option needs to be added to the kernel command line during system installation so that key generation is done with FIPS-approved algorithms and continuous monitoring tests in place. Users must also ensure the system has plenty of entropy during the installation process by moving the mouse around, or if no mouse is available, ensuring that many keystrokes are typed. The recommended amount of keystrokes is 256 and more. Less than 256 keystrokes may generate a non-unique key.</description>
           </metadata>
@@ -9743,7 +10070,7 @@ Passwords need to be protected at all times, and encryption is the standard meth
             </affected>
             <description>Unapproved mechanisms that are used for authentication to the cryptographic module are not verified and therefore cannot be relied upon to provide confidentiality or integrity, and DoD data may be compromised.
 
-RHEL 8 systems utilizing encryption are required to use FIPS-compliant mechanisms for authenticating to cryptographic modules. 
+RHEL 8 systems utilizing encryption are required to use FIPS-compliant mechanisms for authenticating to cryptographic modules.
 
 FIPS 140-2 is the current standard for validating that mechanisms used to access cryptographic modules utilize authentication that meets DoD requirements. This allows for Security Levels 1, 2, 3, or 4 for use on a general-purpose computing system.</description>
           </metadata>
@@ -9803,23 +10130,6 @@ Policycoreutils contains the policy core utilities that are required for basic o
           </metadata>
           <criteria>
             <criterion comment="package policycoreutils is installed" test_ref="oval:mil.disa.stig.rhel8:tst:11200" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:115" version="3">
-          <metadata>
-            <title>RHEL-08-010200 - RHEL 8 must be configured so that all network connections associated with SSH traffic are terminated at the end of the session or after 10 minutes of inactivity, except to fulfill documented and validated mission requirements.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>Terminating an idle SSH session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle SSH session will also free up resources committed by the managed network element.
-
-Terminating network connections associated with communications sessions includes, for example, de-allocating associated TCP/IP address/port pairs at the operating system level and de-allocating networking assignments at the application level if multiple application sessions are using a single operating system-level network connection. This does not mean that the operating system terminates all sessions or network access; it only ends the inactive session and releases the resources associated with that session.
-
-RHEL 8 utilizes /etc/ssh/sshd_config for configurations of OpenSSH. Within the sshd_config the product of the values of "ClientAliveInterval" and "ClientAliveCountMax" are used to establish the inactivity threshold. The "ClientAliveInterval" is a timeout interval in seconds after which if no data has been received from the client, sshd will send a message through the encrypted channel to request a response from the client. The "ClientAliveCountMax" is the number of client alive messages that may be sent without sshd receiving any messages back from the client. If this threshold is met, sshd will disconnect the client.</description>
-          </metadata>
-          <criteria operator="OR" comment="IF openssh is installed, THEN ClientAliveInterval * ClientAliveCountMax is less than or equal to 600.">
-            <extend_definition comment="OpenSSH is installed" definition_ref="oval:mil.disa.stig.rhel8:def:99" negate="true" />
-            <criterion comment="/etc/ssh/sshd_config:ClientAliveCountMax = 0." test_ref="oval:mil.disa.stig.rhel8:tst:11501" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.rhel8:def:116" class="compliance" version="1">
@@ -9950,20 +10260,6 @@ RHEL 8 incorporates system-wide crypto policies by default.  The employed algori
             </criteria>
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.rhel8:def:124" class="compliance" version="2">
-          <metadata>
-            <title>RHEL-08-010300 - RHEL 8 system commands must have mode 755 or less permissive.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>If RHEL 8 were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
-
-This requirement applies to RHEL 8 with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs that execute with escalated privileges. Only qualified and authorized individuals will be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.</description>
-          </metadata>
-          <criteria>
-            <criterion test_ref="oval:mil.disa.stig.rhel8:tst:12400" comment="System command files have mode 755 or less permissive" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.rhel8:def:125" class="compliance" version="1">
           <metadata>
             <title>RHEL-08-010310 - RHEL 8 system commands must be owned by root.</title>
@@ -10054,13 +10350,13 @@ The sysctl --system command will load settings from all system configuration fil
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 8</platform>
             </affected>
-            <description>Discretionary Access Control (DAC) is based on the notion that individual users are "owners" of objects and therefore have discretion over who should be authorized to access the object and in which mode (e.g., read or write).  Ownership is usually acquired as a consequence of creating the object or via specified ownership assignment.  DAC allows the owner to determine who will have access to objects they control.  An example of DAC includes user-controlled file permissions.  
+            <description>Discretionary Access Control (DAC) is based on the notion that individual users are "owners" of objects and therefore have discretion over who should be authorized to access the object and in which mode (e.g., read or write).  Ownership is usually acquired as a consequence of creating the object or via specified ownership assignment.  DAC allows the owner to determine who will have access to objects they control.  An example of DAC includes user-controlled file permissions.
 
-When discretionary access control policies are implemented, subjects are not constrained with regard to what actions they can take with information for which they have already been granted access.  Thus, subjects that have been granted access to information are not prevented from passing (i.e., the subjects have the discretion to pass) the information to other subjects or objects.  A subject that is constrained in its operation by Mandatory Access Control policies is still able to operate under the less rigorous constraints of this requirement.  Thus, while Mandatory Access Control imposes constraints preventing a subject from passing information to another subject operating at a different sensitivity level, this requirement permits the subject to pass the information to any subject at the same sensitivity level.  The policy is bounded by the information system boundary.  Once the information is passed outside the control of the information system, additional means may be required to ensure the constraints remain in effect.  While the older, more traditional definitions of discretionary access control require identity-based access control, that limitation is not required for this use of discretionary access control.  
+When discretionary access control policies are implemented, subjects are not constrained with regard to what actions they can take with information for which they have already been granted access.  Thus, subjects that have been granted access to information are not prevented from passing (i.e., the subjects have the discretion to pass) the information to other subjects or objects.  A subject that is constrained in its operation by Mandatory Access Control policies is still able to operate under the less rigorous constraints of this requirement.  Thus, while Mandatory Access Control imposes constraints preventing a subject from passing information to another subject operating at a different sensitivity level, this requirement permits the subject to pass the information to any subject at the same sensitivity level.  The policy is bounded by the information system boundary.  Once the information is passed outside the control of the information system, additional means may be required to ensure the constraints remain in effect.  While the older, more traditional definitions of discretionary access control require identity-based access control, that limitation is not required for this use of discretionary access control.
 
-By enabling the fs.protected_symlinks kernel parameter, symbolic links are permitted to be followed only when outside a sticky world-writable directory, or when the UID of the link and follower match, or when the directory owner matches the symlink's owner.  Disallowing such symlinks helps mitigate vulnerabilities based on insecure file system accessed by privileged programs, avoiding an exploitation vector exploiting unsafe use of open() or creat().  
+By enabling the fs.protected_symlinks kernel parameter, symbolic links are permitted to be followed only when outside a sticky world-writable directory, or when the UID of the link and follower match, or when the directory owner matches the symlink's owner.  Disallowing such symlinks helps mitigate vulnerabilities based on insecure file system accessed by privileged programs, avoiding an exploitation vector exploiting unsafe use of open() or creat().
 
-The sysctl --system command will load settings from all system configuration files.  All configuration files are sorted by their filename in lexicographic order, regardless of which of the directories they reside in.  If multiple files specify the same option, the entry in the file with lexicographically latest name will take precedence.  Files are read from directories in the following list from top to bottom.  Once a file of a gien filename is loaded, any file of the same name in subsequent directories is ignored.  
+The sysctl --system command will load settings from all system configuration files.  All configuration files are sorted by their filename in lexicographic order, regardless of which of the directories they reside in.  If multiple files specify the same option, the entry in the file with lexicographically latest name will take precedence.  Files are read from directories in the following list from top to bottom.  Once a file of a gien filename is loaded, any file of the same name in subsequent directories is ignored.
 /etc/sysctl.d/*.conf
 /run/sysctl.d/*.conf
 /usr/local/lib/sysctl.d/*.conf/usr/lib/sysctl.d/*.conf
@@ -10083,7 +10379,7 @@ The sysctl --system command will load settings from all system configuration fil
 When discretionary access control policies are implemented, subjects are not constrained with regard to what actions they can take with information for which they have already been granted access. Thus, subjects that have been granted access to information are not prevented from passing (i.e., the subjects have the discretion to pass) the information to other subjects or objects. A subject that is constrained in its operation by Mandatory Access Control policies is still able to operate under the less rigorous constraints of this requirement. Thus, while Mandatory Access Control imposes constraints preventing a subject from passing information to another subject operating at a different sensitivity level, this requirement permits the subject to pass the information to any subject at the same sensitivity level. The policy is bounded by the information system boundary. Once the information is passed outside the control of the information system, additional means may be required to ensure the constraints remain in effect. While the older, more traditional definitions of discretionary access control require identity-based access control, that limitation is not required for this use of discretionary access control.
 
 By enabling the fs.protected_hardlinks kernel parameter, users can no longer create soft or hard links to files they do not own. Disallowing such hardlinks mitigate vulnerabilities based on insecure file system accessed by privileged programs, avoiding an exploitation vector exploiting unsafe use of open() or creat().
-		
+
 The sysctl --system command will load settings from all system configuration files. All configuration files are sorted by their filename in lexicographic order, regardless of which of the directories they reside in. If multiple files specify the same option, the entry in the file with the lexicographically latest name will take precedence. Files are read from directories in the following list from top to bottom. Once a file of a given filename is loaded, any file of the same name in subsequent directories is ignored.
 /etc/sysctl.d/*.conf
 /run/sysctl.d/*.conf
@@ -10111,7 +10407,7 @@ There may be shared resources with configurable protections (e.g., files in stor
 
 Restricting access to the kernel message buffer limits access to only root. This prevents attackers from gaining additional system information as a non-privileged user.
 
-The sysctl --system command will load settings from all system configuration files.  All configuration files are sorted by their filename in lexicographic order, regardless of which of the directories they reside in.  If multiple files specify the same option, the entry in the file with lexicographically latest name will take precedence.  Files are read from directories in the following list from top to bottom.  Once a file of a gien filename is loaded, any file of the same name in subsequent directories is ignored.  
+The sysctl --system command will load settings from all system configuration files.  All configuration files are sorted by their filename in lexicographic order, regardless of which of the directories they reside in.  If multiple files specify the same option, the entry in the file with lexicographically latest name will take precedence.  Files are read from directories in the following list from top to bottom.  Once a file of a gien filename is loaded, any file of the same name in subsequent directories is ignored.
 /etc/sysctl.d/*.conf
 /run/sysctl.d/*.conf
 /usr/local/lib/sysctl.d/*.conf/usr/lib/sysctl.d/*.conf
@@ -10134,7 +10430,7 @@ The sysctl --system command will load settings from all system configuration fil
 This requirement generally applies to the design of an information technology product, but it can also apply to the configuration of particular information system components that are, or use, such products. This can be verified by acceptance/validation processes in DoD or other government agencies.
 
 There may be shared resources with configurable protections (e.g., files in storage) that may be assessed on specific information system components.
-		
+
 Setting the kernel.perf_event_paranoid kernel parameter to "2" prevents attackers from gaining additional system information as a non-privileged user.
 
 The sysctl --system command will load settings from all system configuration files. All configuration files are sorted by their filename in lexicographic order, regardless of which of the directories they reside in. If multiple files specify the same option, the entry in the file with the lexicographically latest name will take precedence. Files are read from directories in the following list from top to bottom. Once a file of a given filename is loaded, any file of the same name in subsequent directories is ignored.
@@ -10286,9 +10582,9 @@ This requirement applies to operating systems performing security function verif
             <criterion comment="The SUSE operating system SSH daemon public host key files have mode 0644 or less permissive" test_ref="oval:mil.disa.stig.rhel8:tst:14900" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:150" version="3">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:150" version="4">
           <metadata>
-            <title>RHEL-08-010490 - The RHEL 8 SSH private host key files must have mode 0600 or less permissive.</title>
+            <title>RHEL-08-010490 - The RHEL 8 SSH private host key files must have mode 0640 or less permissive.</title>
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 8</platform>
             </affected>
@@ -10310,19 +10606,6 @@ This requirement applies to operating systems performing security function verif
           <criteria comment="OpenSSH is installed AND StrictModes == yes">
             <extend_definition comment="OpenSSH is installed" definition_ref="oval:mil.disa.stig.rhel8:def:324" />
             <criterion comment="/etc/ssh/sshd_config:StrictModes == yes" test_ref="oval:mil.disa.stig.rhel8:tst:15100" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:152" version="3">
-          <metadata>
-            <title>RHEL-08-010510 - The RHEL 8 SSH daemon must not allow compression or must only allow compression after successful authentication.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>If compression is allowed in an SSH connection prior to authentication, vulnerabilities in the compression software could result in compromise of the system from an unauthenticated connection, potentially with root privileges.</description>
-          </metadata>
-          <criteria comment="IF SSH is installed, THEN verify Compression is set to no in /etc/ssh/sshd_config." operator="OR">
-            <extend_definition comment="The openssh-server package is installed." definition_ref="oval:mil.disa.stig.rhel8:def:99" negate="true" />
-            <criterion comment="/etc/ssh/sshd_config:Compression == no or Compression == delayed" test_ref="oval:mil.disa.stig.rhel8:tst:15200" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:153" version="2">
@@ -10349,32 +10632,6 @@ This requirement applies to operating systems performing security function verif
           <criteria comment="IF SSH is installed, THEN verify KerberosAuthentication is set to no in /etc/ssh/sshd_config." operator="OR">
             <extend_definition comment="The openssh-server package is installed." definition_ref="oval:mil.disa.stig.rhel8:def:99" negate="true" />
             <criterion comment="/etc/ssh/sshd_config:KerberosAuthentication == no" test_ref="oval:mil.disa.stig.rhel8:tst:15400" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:155" version="1">
-          <metadata>
-            <title>RHEL-08-010540 - RHEL 8 must use a separate file system for /var.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>The use of separate file systems for different paths can protect the system from failures resulting from a file system becoming full or failing.</description>
-          </metadata>
-          <criteria>
-            <criterion comment="There is a separate file system for /var." test_ref="oval:mil.disa.stig.rhel8:tst:15500" />
-            <criterion comment="There is a separate file system configured for /var." test_ref="oval:mil.disa.stig.rhel8:tst:15501" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:156" version="1">
-          <metadata>
-            <title>RHEL-08-010541 - RHEL 8 must use a separate file system for /var/log.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>The use of separate file systems for different paths can protect the system from failures resulting from a file system becoming full or failing.</description>
-          </metadata>
-          <criteria>
-            <criterion comment="There is a separate file system for /var/log." test_ref="oval:mil.disa.stig.rhel8:tst:15600" />
-            <criterion comment="There is a separate file system configured for /var/log." test_ref="oval:mil.disa.stig.rhel8:tst:15601" />
           </criteria>
         </definition>
         <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:157" version="1">
@@ -10829,37 +11086,6 @@ From "faillock.conf" man pages: Note that the default directory that "pam_faillo
             <criterion comment="even_deny_root is set in /etc/security/faillock.conf" test_ref="oval:mil.disa.stig.rhel8:tst:19107" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.rhel8:def:192" class="compliance" version="3">
-          <metadata>
-            <title>RHEL-08-020024 - RHEL 8 must limit the number of concurrent sessions to ten for all accounts and/or account types.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>Operating system management includes the ability to control the number of users and user sessions that utilize an operating system. Limiting the number of allowed users and sessions per user is helpful in reducing the risks related to DoS attacks.
-
-This requirement addresses concurrent sessions for information system accounts and does not address concurrent sessions by single users via multiple system accounts. The maximum number of concurrent sessions should be defined based on mission needs and the operational environment for each system.</description>
-          </metadata>
-          <criteria>
-            <criterion comment="limits.conf:maxlogins is set to 10 or less by default" test_ref="oval:mil.disa.stig.rhel8:tst:19200" />
-            <criterion comment="limits.conf:maxlogins is set to 10 or less for non-default domains" test_ref="oval:mil.disa.stig.rhel8:tst:19201" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.rhel8:def:193" class="compliance" version="2">
-          <metadata>
-            <title>RHEL-08-020040 - RHEL 8 must enable a user session lock until that user re-establishes access using established identification and authentication procedures for command line sessions.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
-
-The session lock is implemented at the point where session activity can be determined. Rather than be forced to wait for a period of time to expire before the user session can be locked, RHEL 8 needs to provide users with the ability to manually invoke a session lock so users can secure their session if it is necessary to temporarily vacate the immediate physical vicinity.
-
-Tmux is a terminal multiplexer that enables a number of terminals to be created, accessed, and controlled from a single screen.  Red Hat endorses tmux as the recommended session controlling package.</description>
-          </metadata>
-          <criteria>
-            <criterion test_ref="oval:mil.disa.stig.rhel8:tst:19301" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.rhel8:def:194" class="compliance" version="2">
           <metadata>
             <title>RHEL-08-020041 - RHEL 8 must ensure session control is automatically started at shell initialization.</title>
@@ -10891,22 +11117,6 @@ Tmux is a terminal multiplexer that enables a number of terminals to be created,
           </metadata>
           <criteria>
             <criterion test_ref="oval:mil.disa.stig.rhel8:tst:19500" />
-          </criteria>
-        </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:196" version="2">
-          <metadata>
-            <title>RHEL-08-020100 - RHEL 8 must ensure the password complexity module is enabled in the password-auth file.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.
-
-RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. This is set in both:
-/etc/pam.d/password-auth
-/etc/pam.d/system-auth</description>
-          </metadata>
-          <criteria>
-            <criterion comment="The pam_pwquality module is included in password-auth." test_ref="oval:mil.disa.stig.rhel8:tst:19600" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.rhel8:def:197" class="compliance" version="1">
@@ -11071,24 +11281,6 @@ RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. The "
             <criterion comment="Root password in /etc/shadow does not have a maximum password age of 0 or greater than 60" test_ref="oval:mil.disa.stig.rhel8:tst:20701" />
             <criterion comment="Non-system users do not have a blank entry in /etc/shadow for maximum password age" test_ref="oval:mil.disa.stig.rhel8:tst:20702" />
             <criterion comment="Root does not have a blank entry in /etc/shadow for maximum password age" test_ref="oval:mil.disa.stig.rhel8:tst:20703" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.rhel8:def:208" class="compliance" version="4">
-          <metadata>
-            <title>RHEL-08-020220 - RHEL 8 must be configured in the password-auth file to prohibit password reuse for a minimum of five generations.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. If the information system or application allows the user to reuse their password consecutively when that password has exceeded its defined lifetime, the end result is a password that is not changed per policy requirements.
-
-RHEL 8 utilizes "pwhistory" consecutively as a mechanism to prohibit password reuse. This is set in both:
-/etc/pam.d/password-auth
-/etc/pam.d/system-auth.
-
-Note that manual changes to the listed files may be overwritten by the "authselect" program.</description>
-          </metadata>
-          <criteria>
-            <criterion test_ref="oval:mil.disa.stig.rhel8:tst:20801" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.rhel8:def:209" class="compliance" version="1">
@@ -11276,7 +11468,7 @@ This requirement applies to each audit data storage repository (i.e., distinct i
             </affected>
             <description>It is critical that when RHEL 8 is at risk of failing to process audit logs as required, it takes action to mitigate the failure. Audit processing failures include software/hardware errors; failures in the audit capturing mechanisms; and audit storage capacity being reached or exceeded. Responses to audit failure depend upon the nature of the failure mode.
 
-When availability is an overriding concern, other approved actions in response to an audit failure are as follows: 
+When availability is an overriding concern, other approved actions in response to an audit failure are as follows:
 
 1) If the failure was caused by the lack of audit record storage capacity, RHEL 8 must continue generating audit records if possible (automatically restarting the audit service if necessary) and overwriting the oldest audit records in a first-in-first-out manner.
 
@@ -11332,20 +11524,6 @@ Enriched logging aids in making sense of who, what, and when events occur on a s
           </metadata>
           <criteria>
             <criterion test_ref="oval:mil.disa.stig.rhel8:tst:22800" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.rhel8:def:229" class="compliance" version="1">
-          <metadata>
-            <title>RHEL-08-030070 - RHEL 8 audit logs must have a mode of 0600 or less permissive to prevent unauthorized read access.</title>
-            <affected family="unix">
-              <platform>Red Hat Enterprise Linux 8</platform>
-            </affected>
-            <description>Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the RHEL 8 system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
-
-The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.</description>
-          </metadata>
-          <criteria>
-            <criterion test_ref="oval:mil.disa.stig.rhel8:tst:22900" comment="audit log has mode 0600 or less permissive" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.rhel8:def:230" class="compliance" version="1">
@@ -12138,7 +12316,7 @@ The system call rules are loaded into a matching engine that intercepts each sys
             </affected>
             <description>Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
-Audit records can be generated from various components within the information system (e.g., module or policy filter). 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
 The "chown" command is used to change file owner and group.
 The "fchown" system call is used to change the ownership of a file referred to by the open file descriptor.
 The "fchownat" system call is used to change ownership of a file relative to a directory file descriptor.
@@ -12167,7 +12345,7 @@ The system call rules are loaded into a matching engine that intercepts each sys
             </affected>
             <description>Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
-Audit records can be generated from various components within the information system (e.g., module or policy filter). 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
 The "chmod" command system call changes the file mode bits of each given file according to mode, which can be either a symbolic representation of changes to make, or an octal number representing the bit pattern for the new mode bits.
 The "fchmod" system call is used to change permissions of a file.
 The "fchmodat" system call is used to change permissions of a file relative to a directory file descriptor.
@@ -12253,7 +12431,7 @@ DoD has defined the list of events for which RHEL 8 will provide an audit record
 
 2) Access actions, such as successful and unsuccessful logon attempts, privileged activities or other system-level access, starting and ending time for user access to the system, concurrent logons from different workstations, successful and unsuccessful accesses to objects, all program initiations, and all direct access to the information system;
 
-3) All account creations, modifications, disabling, and terminations; and 
+3) All account creations, modifications, disabling, and terminations; and
 
 4) All kernel module load, unload, and restart actions.</description>
           </metadata>
@@ -12280,7 +12458,7 @@ DoD has defined the list of events for which RHEL 8 will provide an audit record
 
 2) Access actions, such as successful and unsuccessful logon attempts, privileged activities or other system-level access, starting and ending time for user access to the system, concurrent logons from different workstations, successful and unsuccessful accesses to objects, all program initiations, and all direct access to the information system;
 
-3) All account creations, modifications, disabling, and terminations; and 
+3) All account creations, modifications, disabling, and terminations; and
 
 4) All kernel module load, unload, and restart actions.</description>
           </metadata>
@@ -12960,9 +13138,9 @@ The "nosuid" mount option causes the system to not execute "setuid" and "setgid"
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 8</platform>
             </affected>
-            <description>Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered. 
+            <description>Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered.
 
-This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. 
+This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification.
 
 Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa.</description>
           </metadata>
@@ -12977,9 +13155,9 @@ Protecting the confidentiality and integrity of organizational information can b
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 8</platform>
             </affected>
-            <description>Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered. 
+            <description>Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered.
 
-This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. 
+This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification.
 
 Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa.
 
@@ -13547,7 +13725,7 @@ FIPS 140-2 is the current standard for validating that mechanisms used to access
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 8</platform>
             </affected>
-            <description>The sudoers security policy requires that users authenticate themselves before they can use sudo. When sudoers requires authentication, it validates the invoking user's credentials. If the rootpw, targetpw, or runaspw flags are defined and not disabled, by default the operating system will prompt the invoking user for the "root" user password. 
+            <description>The sudoers security policy requires that users authenticate themselves before they can use sudo. When sudoers requires authentication, it validates the invoking user's credentials. If the rootpw, targetpw, or runaspw flags are defined and not disabled, by default the operating system will prompt the invoking user for the "root" user password.
 For more information on each of the listed configurations, reference the sudoers(5) manual page.</description>
           </metadata>
           <criteria operator="AND">
@@ -13571,7 +13749,7 @@ For more information on each of the listed configurations, reference the sudoers
             <affected family="unix">
               <platform>Red Hat Enterprise Linux 8</platform>
             </affected>
-            <description>Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
+            <description>Without re-authentication, users may access resources or perform tasks for which they do not have authorization.
 
 When operating systems provide the capability to escalate a functional capability, it is critical the organization requires the user to re-authenticate when using the "sudo" command.
 
@@ -13581,10 +13759,10 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <criterion test_ref="oval:mil.disa.stig.rhel8:tst:41600" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:463" version="1">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:463" version="2">
           <metadata>
             <title>RHEL-08-020331 - RHEL 8 must not allow blank or null passwords in the system-auth file.</title>
-            <affected family="windows">
+            <affected family="unix">
               <platform>Red Hat Enterprise Linux 8</platform>
             </affected>
             <description>If an account has an empty password, anyone could log on and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments.</description>
@@ -13593,10 +13771,10 @@ If the value is set to an integer less than 0, the user's time stamp will not ex
             <criterion test_ref="oval:mil.disa.stig.rhel8:tst:46300" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:464" version="1">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:464" version="2">
           <metadata>
             <title>RHEL-08-020332 - RHEL 8 must not allow blank or null passwords in the password-auth file.</title>
-            <affected family="windows">
+            <affected family="unix">
               <platform>Red Hat Enterprise Linux 8</platform>
             </affected>
             <description>If an account has an empty password, anyone could log on and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments.</description>
@@ -13628,10 +13806,10 @@ The sysctl --system command will load settings from all system configuration fil
             <criterion test_ref="oval:mil.disa.stig.rhel8:tst:47701" />
           </criteria>
         </definition>
-        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:482" version="1">
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8:def:482" version="2">
           <metadata>
             <title>RHEL-08-010121 - The RHEL 8 operating system must not have accounts configured with blank or null passwords.</title>
-            <affected family="windows">
+            <affected family="unix">
               <platform>Red Hat Enterprise Linux 8</platform>
             </affected>
             <description>If an account has an empty password, anyone could log on and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments.</description>
@@ -13640,8 +13818,209 @@ The sysctl --system command will load settings from all system configuration fil
             <criterion test_ref="oval:mil.disa.stig.rhel8:tst:48200" />
           </criteria>
         </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:230244" version="1">
+          <metadata>
+            <title>RHEL-08-010200 - RHEL 8 must be configured so that all network connections associated with SSH traffic are terminated at the end of the session or after 10 minutes of inactivity, except to fulfill documented and validated mission requirements.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>Terminating an idle SSH session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle SSH session will also free up resources committed by the managed network element.
+
+Terminating network connections associated with communications sessions includes, for example, de-allocating associated TCP/IP address/port pairs at the operating system level and de-allocating networking assignments at the application level if multiple application sessions are using a single operating system-level network connection. This does not mean that the operating system terminates all sessions or network access; it only ends the inactive session and releases the resources associated with that session.
+
+RHEL 8 utilizes /etc/ssh/sshd_config for configurations of OpenSSH. Within the sshd_config the product of the values of "ClientAliveInterval" and "ClientAliveCountMax" are used to establish the inactivity threshold. The "ClientAliveInterval" is a timeout interval in seconds after which if no data has been received from the client, sshd will send a message through the encrypted channel to request a response from the client. The "ClientAliveCountMax" is the number of client alive messages that may be sent without sshd receiving any messages back from the client. If this threshold is met, sshd will disconnect the client. For more information on these settings and others, refer to the sshd_config man pages.
+
+Satisfies: SRG-OS-000163-GPOS-00072, SRG-OS-000126-GPOS-00066, SRG-OS-000279-GPOS-00109</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230244" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:230257" version="1">
+          <metadata>
+            <title>RHEL-08-010300 - RHEL 8 system commands must have mode 755 or less permissive.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>If RHEL 8 were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to RHEL 8 with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs that execute with escalated privileges. Only qualified and authorized individuals will be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230257" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:230292" version="1">
+          <metadata>
+            <title>RHEL-08-010540 - RHEL 8 must use a separate file system for /var.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>The use of separate file systems for different paths can protect the system from failures resulting from a file system becoming full or failing.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230292" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:230293" version="1">
+          <metadata>
+            <title>RHEL-08-010541 - RHEL 8 must use a separate file system for /var/log.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>The use of separate file systems for different paths can protect the system from failures resulting from a file system becoming full or failing.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230293" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:230346" version="1">
+          <metadata>
+            <title>RHEL-08-020024 - RHEL 8 must limit the number of concurrent sessions to ten for all accounts and/or account types.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>Operating system management includes the ability to control the number of users and user sessions that utilize an operating system. Limiting the number of allowed users and sessions per user is helpful in reducing the risks related to DoS attacks.
+
+This requirement addresses concurrent sessions for information system accounts and does not address concurrent sessions by single users via multiple system accounts. The maximum number of concurrent sessions should be defined based on mission needs and the operational environment for each system.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230346" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:230348" version="1">
+          <metadata>
+            <title>RHEL-08-020040 - RHEL 8 must enable a user session lock until that user re-establishes access using established identification and authentication procedures for command line sessions.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
+
+The session lock is implemented at the point where session activity can be determined. Rather than be forced to wait for a period of time to expire before the user session can be locked, RHEL 8 needs to provide users with the ability to manually invoke a session lock so users can secure their session if it is necessary to temporarily vacate the immediate physical vicinity.
+
+Tmux is a terminal multiplexer that enables a number of terminals to be created, accessed, and controlled from a single screen.  Red Hat endorses tmux as the recommended session controlling package.
+
+Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000030-GPOS-00011</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230348" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:230356" version="1">
+          <metadata>
+            <title>RHEL-08-020100 - RHEL 8 must ensure the password complexity module is enabled in the password-auth file.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.
+
+RHEL 8 utilizes "pwquality" as a mechanism to enforce password complexity. This is set in both:
+/etc/pam.d/password-auth
+/etc/pam.d/system-auth</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230356" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:230368" version="1">
+          <metadata>
+            <title>RHEL-08-020220 - RHEL 8 must be configured in the password-auth file to prohibit password reuse for a minimum of five generations.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. If the information system or application allows the user to reuse their password consecutively when that password has exceeded its defined lifetime, the end result is a password that is not changed per policy requirements.
+
+RHEL 8 uses "pwhistory" consecutively as a mechanism to prohibit password reuse. This is set in both:
+/etc/pam.d/password-auth
+/etc/pam.d/system-auth.
+
+Note that manual changes to the listed files may be overwritten by the "authselect" program.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230368" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:230396" version="1">
+          <metadata>
+            <title>RHEL-08-030070 - RHEL 8 audit logs must have a mode of 0600 or less permissive to prevent unauthorized read access.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the RHEL 8 system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
+
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029, SRG-OS-000206-GPOS-00084</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:230396" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.rhel8os:def:251714" version="1">
+          <metadata>
+            <title>RHEL-08-020102 - RHEL 8 systems below version 8.4 must ensure the password complexity module in the system-auth file is configured for three retries or less.</title>
+            <affected family="unix">
+              <platform>Red Hat Enterprise Linux 8</platform>
+            </affected>
+            <description>Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.
+
+RHEL 8 uses "pwquality" as a mechanism to enforce password complexity. This is set in both:
+/etc/pam.d/password-auth
+/etc/pam.d/system-auth
+
+By limiting the number of attempts to meet the pwquality module complexity requirements before returning with an error, the system will audit abnormal attempts at password changes.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:251714" />
+          </criteria>
+        </definition>
       </definitions>
       <tests>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="/etc/ssh/sshd_config:ClientAliveCountMax = 1" id="oval:mil.disa.stig.ind:tst:23024400" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23024400" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20000003" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="There is a separate file system configured for /var." id="oval:mil.disa.stig.ind:tst:23029201" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23029201" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="There is a separate file system configured for /var/log." id="oval:mil.disa.stig.ind:tst:23029301" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23029301" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="limits.conf and limits.d/*.conf:maxlogins is set to 10 or less by default" id="oval:mil.disa.stig.ind:tst:23034600" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23034600" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:23034600" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="any_exist" comment="limits.conf and limits.d/*.conf:maxlogins is set to 10 or less for non-default domains" id="oval:mil.disa.stig.ind:tst:23034601" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23034603" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:23034600" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The lock-command is set in /etc/tmux.conf" check="all" id="oval:mil.disa.stig.ind:tst:23034800" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23034800" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The lock-session is bound to X, in /etc/tmux.conf" check="all" id="oval:mil.disa.stig.ind:tst:23034801" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23034801" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="The pam_pwquality module is included in password-auth." id="oval:mil.disa.stig.ind:tst:23035600" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23035600" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="/etc/pam.d/password-auth: pam_pwhistory.so has remember set to 5 or greater" check="all" id="oval:mil.disa.stig.ind:tst:23036800" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:23036800" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:23036800" />
+        </textfilecontent54_test>
+        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="/etc/pam.d/system-auth:retry not greater than 3 and not 0" id="oval:mil.disa.stig.ind:tst:25171400" version="1">
+          <object object_ref="oval:mil.disa.stig.ind:obj:25171400" />
+          <state state_ref="oval:mil.disa.stig.ind:ste:20000018" />
+        </textfilecontent54_test>
+        <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" id="oval:mil.disa.stig.linux:tst:10000800" comment="The redhat-release package is version 8.3 or lower." version="1">
+          <object object_ref="oval:mil.disa.stig.linux:obj:10000004" />
+          <state state_ref="oval:mil.disa.stig.linux:ste:10000800" />
+        </rpminfo_test>
+        <partition_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" comment="There is a separate file system for /var." id="oval:mil.disa.stig.linux:tst:23029200" version="1">
+          <object object_ref="oval:mil.disa.stig.linux:obj:23029200" />
+        </partition_test>
+        <partition_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" comment="There is a separate file system for /var/log." id="oval:mil.disa.stig.linux:tst:23029300" version="1">
+          <object object_ref="oval:mil.disa.stig.linux:obj:23029300" />
+        </partition_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="The RHEL 8 version is 8.2 or greater." id="oval:mil.disa.stig.rhel8:tst:1000" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:10000" />
           <state state_ref="oval:mil.disa.stig.rhel8:ste:1000" />
@@ -13760,10 +14139,6 @@ The sysctl --system command will load settings from all system configuration fil
         <rpminfo_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" comment="package policycoreutils is installed" id="oval:mil.disa.stig.rhel8:tst:11200" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:11200" />
         </rpminfo_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="/etc/ssh/sshd_config:ClientAliveCountMax = 0" id="oval:mil.disa.stig.rhel8:tst:11501" version="2">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:11501" />
-          <state state_ref="oval:mil.disa.stig.rhel8:ste:17100" />
-        </textfilecontent54_test>
         <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" comment="/var/log/messages file has mode 0640 or less permissive" id="oval:mil.disa.stig.rhel8:tst:11600" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:11600" />
           <state state_ref="oval:mil.disa.stig.rhel8:ste:11600" />
@@ -13810,10 +14185,6 @@ The sysctl --system command will load settings from all system configuration fil
           <state state_ref="oval:mil.disa.stig.rhel8:ste:12303" />
           <state state_ref="oval:mil.disa.stig.rhel8:ste:12304" />
         </textfilecontent54_test>
-        <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="System command files have mode 755 or less permissive" id="oval:mil.disa.stig.rhel8:tst:12400" version="2">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:12401" />
-          <state state_ref="oval:mil.disa.stig.rhel8:ste:12401" />
-        </file_test>
         <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="System command files are owned by root" id="oval:mil.disa.stig.rhel8:tst:12500" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:12401" />
           <state state_ref="oval:mil.disa.stig.rhel8:ste:11700" />
@@ -13914,18 +14285,13 @@ The sysctl --system command will load settings from all system configuration fil
           <object object_ref="oval:mil.disa.stig.rhel8:obj:14900" />
           <state state_ref="oval:mil.disa.stig.rhel8:ste:14900" />
         </file_test>
-        <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="any_exist" comment="/etc/ssh/ssh_host*key file permissions" id="oval:mil.disa.stig.rhel8:tst:15000" version="2">
+        <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="any_exist" comment="/etc/ssh/ssh_host*key file permissions are 0640 or less" id="oval:mil.disa.stig.rhel8:tst:15000" version="3">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:15000" />
-          <state state_ref="oval:mil.disa.stig.rhel8:ste:22900" />
+          <state state_ref="oval:mil.disa.stig.rhel8:ste:11600" />
         </file_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="/etc/ssh/sshd_config:StrictModes == yes" id="oval:mil.disa.stig.rhel8:tst:15100" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:15100" />
           <state state_ref="oval:mil.disa.stig.rhel8:ste:15100" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" state_operator="OR" comment="/etc/ssh/sshd_config:Compression == no or Compression == delayed" id="oval:mil.disa.stig.rhel8:tst:15200" version="3">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:15200" />
-          <state state_ref="oval:mil.disa.stig.rhel8:ste:15200" />
-          <state state_ref="oval:mil.disa.stig.rhel8:ste:15201" />
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="/etc/ssh/sshd_config:IgnoreUserKnownHosts == yes" id="oval:mil.disa.stig.rhel8:tst:15300" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:15300" />
@@ -13934,18 +14300,6 @@ The sysctl --system command will load settings from all system configuration fil
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="/etc/ssh/sshd_config:KerberosAuthentication == no" id="oval:mil.disa.stig.rhel8:tst:15400" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:15400" />
           <state state_ref="oval:mil.disa.stig.rhel8:ste:15400" />
-        </textfilecontent54_test>
-        <partition_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" comment="There is a separate file system for /var." id="oval:mil.disa.stig.rhel8:tst:15500" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:15500" />
-        </partition_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="There is a separate file system configured for /var." id="oval:mil.disa.stig.rhel8:tst:15501" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:15501" />
-        </textfilecontent54_test>
-        <partition_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" comment="There is a separate file system for /var/log." id="oval:mil.disa.stig.rhel8:tst:15600" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:15600" />
-        </partition_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="There is a separate file system configured for /var/log." id="oval:mil.disa.stig.rhel8:tst:15601" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:15601" />
         </textfilecontent54_test>
         <partition_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" check="all" check_existence="all_exist" comment="There is a separate file system for audit data directory." id="oval:mil.disa.stig.rhel8:tst:15700" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:15700" />
@@ -14157,17 +14511,6 @@ The sysctl --system command will load settings from all system configuration fil
         <ind:textfilecontent54_test xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="all_exist" comment="check /etc/security/faillock.conf for the even_deny_root setting" id="oval:mil.disa.stig.rhel8:tst:19107" version="2">
           <ind:object object_ref="oval:mil.disa.stig.rhel8:obj:19106" />
         </ind:textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="at_least_one_exists" comment="limits.conf:maxlogins is set to 10 or less by default" id="oval:mil.disa.stig.rhel8:tst:19200" version="2">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:19200" />
-          <state state_ref="oval:mil.disa.stig.rhel8:ste:19200" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="any_exist" comment="limits.conf:maxlogins is set to 10 or less for non-default domains" id="oval:mil.disa.stig.rhel8:tst:19201" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:19203" />
-          <state state_ref="oval:mil.disa.stig.rhel8:ste:19200" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="the lock-command is set in /etc/tmux.conf" check="all" id="oval:mil.disa.stig.rhel8:tst:19301" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:19301" />
-        </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="/etc/profile.d/*.sh contains a shell script to initialize the tmux terminal multiplexer as each shell is called." check="all" id="oval:mil.disa.stig.rhel8:tst:19400" version="3">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:19400" />
         </textfilecontent54_test>
@@ -14176,9 +14519,6 @@ The sysctl --system command will load settings from all system configuration fil
         </process58_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="/etc/shells does not contain any instances of tmux" check="all" check_existence="none_exist" id="oval:mil.disa.stig.rhel8:tst:19500" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:19500" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" comment="The pam_pwquality module is included in password-auth." id="oval:mil.disa.stig.rhel8:tst:19600" version="2">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:19600" />
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="at least one uppercase character is required" check="all" id="oval:mil.disa.stig.rhel8:tst:19700" version="2">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:19702" />
@@ -14240,10 +14580,6 @@ The sysctl --system command will load settings from all system configuration fil
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" check="all" check_existence="none_exist" comment="Root does not have a blank entry in /etc/shadow for maximum password age" id="oval:mil.disa.stig.rhel8:tst:20703" version="2">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:20704" />
-        </textfilecontent54_test>
-        <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="/etc/pam.d/password-auth: pam_pwhistory.so has remember set to 5 or greater" check="all" id="oval:mil.disa.stig.rhel8:tst:20801" version="2">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:20801" />
-          <state state_ref="oval:mil.disa.stig.rhel8:ste:20800" />
         </textfilecontent54_test>
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="passwords must have a minimum of 15 characters" check="all" id="oval:mil.disa.stig.rhel8:tst:20900" version="2">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:20902" />
@@ -14323,10 +14659,6 @@ The sysctl --system command will load settings from all system configuration fil
           <object object_ref="oval:mil.disa.stig.rhel8:obj:22800" />
           <state state_ref="oval:mil.disa.stig.rhel8:ste:22800" />
         </textfilecontent54_test>
-        <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="audit log has mode 0600 or less permissive" check="all" id="oval:mil.disa.stig.rhel8:tst:22900" version="1">
-          <object object_ref="oval:mil.disa.stig.rhel8:obj:23000" />
-          <state state_ref="oval:mil.disa.stig.rhel8:ste:22900" />
-        </file_test>
         <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="audit logs are owned by root" check="all" id="oval:mil.disa.stig.rhel8:tst:23000" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:23000" />
           <state state_ref="oval:mil.disa.stig.rhel8:ste:23200" />
@@ -15155,8 +15487,104 @@ The sysctl --system command will load settings from all system configuration fil
         <textfilecontent54_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="There are no accounts in /etc/shadow that have blank password fields." check="all" check_existence="none_exist" id="oval:mil.disa.stig.rhel8:tst:48200" version="1">
           <object object_ref="oval:mil.disa.stig.rhel8:obj:48200" />
         </textfilecontent54_test>
+        <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" check="all" check_existence="all_exist" comment="System command files have mode 755 or less permissive" id="oval:mil.disa.stig.unix:tst:23025700" version="1">
+          <object object_ref="oval:mil.disa.stig.unix:obj:20000009" />
+          <state state_ref="oval:mil.disa.stig.unix:ste:20000003" />
+        </file_test>
+        <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="Audit log is mode 0600 or less permissive" check="all" id="oval:mil.disa.stig.unix:tst:23039600" version="1">
+          <object object_ref="oval:mil.disa.stig.unix:obj:20000011" />
+          <state state_ref="oval:mil.disa.stig.unix:ste:20000004" />
+        </file_test>
       </tests>
       <objects>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:20000001" version="1" comment="Audit log file">
+          <filepath>/etc/audit/auditd.conf</filepath>
+          <pattern operation="pattern match">^\s*log_file\s*=\s*(\S+)\s*(?:#.*)?$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:23024400" version="1">
+          <filepath>/etc/ssh/sshd_config</filepath>
+          <pattern operation="pattern match">^\s*(?i)ClientAliveCountMax(?-i)\s+"?(\d+)"?\s*(?:|(?:#.*))?$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:23029201" version="1">
+          <filepath>/etc/fstab</filepath>
+          <pattern datatype="string" operation="pattern match">^[^# \t]+\s+/var\s+</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:23029301" version="1">
+          <filepath>/etc/fstab</filepath>
+          <pattern datatype="string" operation="pattern match">^[^# \t]+\s+/var/log\s+</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all default maxlogins settings in /etc/security/limits.conf and /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.ind:obj:23034600" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.ind:obj:23034601</object_reference>
+            <object_reference>oval:mil.disa.stig.ind:obj:23034602</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="default maxlogins in /etc/security/limits.conf" id="oval:mil.disa.stig.ind:obj:23034601" version="1">
+          <filepath>/etc/security/limits.conf</filepath>
+          <pattern operation="pattern match">^\s*\*\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="default maxlogins in /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.ind:obj:23034602" version="1">
+          <path>/etc/security/limits.d</path>
+          <filename operation="pattern match">.*\.conf$</filename>
+          <pattern operation="pattern match">^\s*\*\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all non-default maxlogins settings in /etc/security/limits.conf and /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.ind:obj:23034603" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.ind:obj:23034604</object_reference>
+            <object_reference>oval:mil.disa.stig.ind:obj:23034605</object_reference>
+          </set>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="non-default maxlogins in /etc/security/limits.conf" id="oval:mil.disa.stig.ind:obj:23034604" version="1">
+          <filepath>/etc/security/limits.conf</filepath>
+          <pattern operation="pattern match">^\s*[^#*\s]+\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="non-default maxlogins in /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.ind:obj:23034605" version="1">
+          <path>/etc/security/limits.d</path>
+          <filename operation="pattern match">.*\.conf$</filename>
+          <pattern operation="pattern match">^\s*[^#*\s]+\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:23034800" version="1">
+          <filepath>/etc/tmux.conf</filepath>
+          <pattern operation="pattern match">^\s*set\s+-g\s+lock-command\s+vlock\s*(?:#.*)?$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:23034801" version="1">
+          <filepath>/etc/tmux.conf</filepath>
+          <pattern operation="pattern match">^\s*bind\s+X\s+lock-session\s*(?:#.*)?$</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:23035600" version="1">
+          <filepath>/etc/pam.d/password-auth</filepath>
+          <pattern operation="pattern match">^\s*password\s+(?:required|requisite)\s+pam_pwquality\.so\b</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:23036800" version="1">
+          <filepath>/etc/pam.d/password-auth</filepath>
+          <pattern operation="pattern match">^\s*password\s+(?:required|requisite)\s+pam_pwhistory\.so\s+[^#\n]*\bremember=(\d+)\b</pattern>
+          <instance datatype="int" operation="greater than or equal">1</instance>
+        </textfilecontent54_object>
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:obj:25171400" version="1" comment="in /etc/pam.d/system-auth check for pam_pwquality.so retry equals value">
+          <filepath>/etc/pam.d/system-auth</filepath>
+          <pattern operation="pattern match">^[ \t]*password[ \t]+(?:(?:required)|(?:requisite))[ \t]+pam_pwquality\.so(?:[ \t]+|(?:[ \t][^#\r\f\n]+[ \t]+))retry=([0-9]+)(?:\s|$)</pattern>
+          <instance datatype="int">1</instance>
+        </textfilecontent54_object>
+        <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.linux:obj:10000004" version="1">
+          <name>redhat-release</name>
+        </rpminfo_object>
+        <partition_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.linux:obj:23029200" version="1">
+          <mount_point>/var</mount_point>
+        </partition_object>
+        <partition_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.linux:obj:23029300" version="1">
+          <mount_point>/var/log</mount_point>
+        </partition_object>
         <sysctl_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel8:obj:9800" version="1">
           <name>net.ipv6.conf.all.disable_ipv6</name>
         </sysctl_object>
@@ -15285,11 +15713,6 @@ The sysctl --system command will load settings from all system configuration fil
         <rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel8:obj:11200" version="1">
           <name>policycoreutils</name>
         </rpminfo_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:11501" version="2">
-          <filepath>/etc/ssh/sshd_config</filepath>
-          <pattern operation="pattern match">^\s*(?i)ClientAliveCountMax(?-i)\s+"?(\d+)"?\s*(?:|(?:#.*))?$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
         <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel8:obj:11600" version="1">
           <filepath>/var/log/messages</filepath>
         </file_object>
@@ -15523,11 +15946,6 @@ The sysctl --system command will load settings from all system configuration fil
           <pattern operation="pattern match">^\s*(?i)StrictModes(?-i)[ \t]+([\w\"]+)[\s]*(?:|(?:#.*))?$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:15200" comment="/etc/ssh/sshd_config:Compression" version="1">
-          <filepath>/etc/ssh/sshd_config</filepath>
-          <pattern operation="pattern match">^\s*(?i)Compression(?-i)\s+(\w+)\s*(?:|(?:#.*))?$</pattern>
-          <instance operation="greater than or equal" datatype="int">1</instance>
-        </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:15300" version="1" comment="Pull value of /etc/ssh/sshd_config:IgnoreUserKnownHosts">
           <filepath>/etc/ssh/sshd_config</filepath>
           <pattern operation="pattern match">^\s*(?i)IgnoreUserKnownHosts(?-i)[ \t]+([\w\"]+)[\s]*(?:|(?:#.*))?$</pattern>
@@ -15538,22 +15956,9 @@ The sysctl --system command will load settings from all system configuration fil
           <pattern operation="pattern match">^\s*(?i)KerberosAuthentication(?-i)\s+(\w+)\s*(?:|(?:#.*))?$</pattern>
           <instance operation="greater than or equal" datatype="int">1</instance>
         </textfilecontent54_object>
-        <partition_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel8:obj:15500" version="1">
-          <mount_point>/var</mount_point>
-        </partition_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:15501" version="1">
-          <filepath>/etc/fstab</filepath>
-          <pattern datatype="string" operation="pattern match">^[^# \t]+\s+/var\s+</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
         <partition_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel8:obj:15600" version="1">
           <mount_point>/var/log</mount_point>
         </partition_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:15601" version="1">
-          <filepath>/etc/fstab</filepath>
-          <pattern datatype="string" operation="pattern match">^[^# \t]+\s+/var/log\s+</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
         <partition_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.rhel8:obj:15700" version="1">
           <mount_point datatype="string" var_ref="oval:mil.disa.stig.rhel8:var:15700" var_check="at least one" />
         </partition_object>
@@ -15819,49 +16224,10 @@ The sysctl --system command will load settings from all system configuration fil
           <ind:pattern operation="pattern match" datatype="string">^\s*even_deny_root\s*$</ind:pattern>
           <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
         </ind:textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all limits.conf default maxlogins settings" id="oval:mil.disa.stig.rhel8:obj:19200" version="2">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
-            <object_reference>oval:mil.disa.stig.rhel8:obj:19201</object_reference>
-            <object_reference>oval:mil.disa.stig.rhel8:obj:19202</object_reference>
-          </set>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="default maxlogins in /etc/security/limits.conf" id="oval:mil.disa.stig.rhel8:obj:19201" version="2">
-          <filepath>/etc/security/limits.conf</filepath>
-          <pattern operation="pattern match">^\s*\*\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="default maxlogins in /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.rhel8:obj:19202" version="2">
-          <path>/etc/security/limits.d</path>
-          <filename operation="pattern match">.*.conf$</filename>
-          <pattern operation="pattern match">^\s*\*\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="all non-default limits.conf maxlogins settings" id="oval:mil.disa.stig.rhel8:obj:19203" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
-            <object_reference>oval:mil.disa.stig.rhel8:obj:19204</object_reference>
-            <object_reference>oval:mil.disa.stig.rhel8:obj:19205</object_reference>
-          </set>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="non-default maxlogins in /etc/security/limits.conf" id="oval:mil.disa.stig.rhel8:obj:19204" version="1">
-          <filepath>/etc/security/limits.conf</filepath>
-          <pattern operation="pattern match">^\s*[^#*\s]+\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="non-default maxlogins in /etc/security/limits.d/*.conf" id="oval:mil.disa.stig.rhel8:obj:19205" version="1">
-          <path>/etc/security/limits.d</path>
-          <filename operation="pattern match">.*.conf$</filename>
-          <pattern operation="pattern match">^\s*[^#*\s]+\s+(?:(?:hard)|(?:-))\s+maxlogins\s+(\d+)\s*$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:19301" version="1">
-          <filepath>/etc/tmux.conf</filepath>
-          <pattern operation="pattern match">^\s*set\s+-g\s+lock-command\s+vlock\s*(?:#.*)?$</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:19400" version="7">
+        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:19400" version="8">
           <path>/etc/profile.d</path>
           <filename operation="pattern match">\.sh$</filename>
-          <pattern operation="pattern match">^\s*if\s+\[\s*"\$PS1"\s*\];\s+then\s+parent=\$\(ps\s+-o\s+ppid=\s+-p\s+\$\$\)\s+name=\$\(ps\s+-o\s+comm=\s+-p\s+\$parent\)\s+case\s+"\$name"\s+in\s+\(sshd\|login\)\s+exec\s+tmux\s+;;\s+esac\s+fi\s*$</pattern>
+          <pattern operation="pattern match">^\s*if\s+\[\s*"\$PS1"\s*\];\s+then\s+parent=\$\(ps\s+-o\s+ppid=\s+-p\s+\$\$\)\s+name=\$\(ps\s+-o\s+comm=\s+-p\s+\$parent\)\s+case\s+"\$name"\s+in\s+\(sshd\|login\)\s+tmux\s+;;\s+esac\s+fi\s*$</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
         <process58_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.rhel8:obj:19401" version="2">
@@ -15872,11 +16238,6 @@ The sysctl --system command will load settings from all system configuration fil
           <behaviors ignore_case="true" />
           <filepath>/etc/shells</filepath>
           <pattern operation="pattern match">tmux</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:19600" version="2" comment="pam_pwquality in password-auth">
-          <filepath>/etc/pam.d/password-auth</filepath>
-          <pattern operation="pattern match">^\s*password\s+(?:required|requisite)\s+pam_pwquality\.so\b</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="ucredit setting in /etc/security/pwquality.conf*" id="oval:mil.disa.stig.rhel8:obj:19700" version="2">
@@ -16038,11 +16399,6 @@ The sysctl --system command will load settings from all system configuration fil
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="root /etc/shadow line with a blank max password age" id="oval:mil.disa.stig.rhel8:obj:20704" version="2">
           <filepath datatype="string">/etc/shadow</filepath>
           <pattern datatype="string" operation="pattern match">^root:[^:]*:[^:]*:[^:]*::</pattern>
-          <instance datatype="int" operation="greater than or equal">1</instance>
-        </textfilecontent54_object>
-        <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:20801" version="6">
-          <filepath>/etc/pam.d/password-auth</filepath>
-          <pattern operation="pattern match">^\s*password\s+(?:required|requisite)\s+pam_pwhistory\.so\s+[^#\n]*\bremember=(\d+)\b</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
         <textfilecontent54_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:obj:20900" version="4">
@@ -17407,8 +17763,36 @@ The sysctl --system command will load settings from all system configuration fil
           <pattern operation="pattern match">^[^:]+::[^:]*:[^:]*:</pattern>
           <instance datatype="int" operation="greater than or equal">1</instance>
         </textfilecontent54_object>
+        <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="All files in system command directories" id="oval:mil.disa.stig.unix:obj:20000008" version="1">
+          <path datatype="string" var_ref="oval:mil.disa.stig.defs:var:20000003" var_check="at least one" />
+          <filename datatype="string" operation="pattern match">.*</filename>
+        </file_object>
+        <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="All files in system command directories, less symbolic links" id="oval:mil.disa.stig.unix:obj:20000009" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.unix:obj:20000008</object_reference>
+            <filter>oval:mil.disa.stig.unix:ste:20000002</filter>
+          </set>
+        </file_object>
+        <file_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.unix:obj:20000011" version="1" comment="Audit log file location">
+          <filepath var_ref="oval:mil.disa.stig.defs:var:20000004" />
+        </file_object>
       </objects>
       <states>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:ste:20000003" version="1">
+          <subexpression datatype="int" operation="equals">1</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:ste:20000018" version="1">
+          <subexpression datatype="string" operation="pattern match">^[123]$</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:ste:23034600" version="1">
+          <subexpression datatype="int" operation="less than or equal">10</subexpression>
+        </textfilecontent54_state>
+        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.ind:ste:23036800" version="1">
+          <subexpression datatype="int" operation="greater than or equal">5</subexpression>
+        </textfilecontent54_state>
+        <rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:mil.disa.stig.linux:ste:10000800" version="1">
+          <version operation="pattern match">8\.[0-3]</version>
+        </rpminfo_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The minor version is greater than or equal to 2." id="oval:mil.disa.stig.rhel8:ste:1000" version="1">
           <subexpression datatype="int" operation="greater than or equal">2</subexpression>
         </textfilecontent54_state>
@@ -17512,10 +17896,6 @@ The sysctl --system command will load settings from all system configuration fil
         <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="symbolic links" id="oval:mil.disa.stig.rhel8:ste:12400" version="1">
           <type datatype="string" operation="equals" entity_check="all">symbolic link</type>
         </file_state>
-        <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="mode 755 or less permissive" id="oval:mil.disa.stig.rhel8:ste:12401" version="1">
-          <gwrite datatype="boolean">false</gwrite>
-          <owrite datatype="boolean">false</owrite>
-        </file_state>
         <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="group-owned by root or a system account" id="oval:mil.disa.stig.rhel8:ste:12600" version="1">
           <group_id datatype="int" operation="less than">1000</group_id>
         </file_state>
@@ -17579,12 +17959,6 @@ The sysctl --system command will load settings from all system configuration fil
         </file_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:15100" version="1" comment="StrictModes value is set to yes">
           <subexpression datatype="string" operation="pattern match">^(yes|"yes")$</subexpression>
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:15200" comment="no" version="1">
-          <subexpression operation="equals">no</subexpression>
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:15201" comment="delayed" version="1">
-          <subexpression operation="equals">delayed</subexpression>
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:15300" version="1" comment="IgnoreUserKnownHosts value is set to yes">
           <subexpression datatype="string" operation="pattern match">^(yes|"yes")$</subexpression>
@@ -17673,9 +18047,6 @@ The sysctl --system command will load settings from all system configuration fil
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="The minor version is less than 2." id="oval:mil.disa.stig.rhel8:ste:19101" version="1">
           <subexpression datatype="int" operation="less than">2</subexpression>
         </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:19200" version="1">
-          <subexpression datatype="int" operation="less than or equal">10</subexpression>
-        </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:19700" version="2">
           <subexpression datatype="int" operation="less than">0</subexpression>
         </textfilecontent54_state>
@@ -17717,9 +18088,6 @@ The sysctl --system command will load settings from all system configuration fil
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" comment="Lines starting with nobody" id="oval:mil.disa.stig.rhel8:ste:20703" version="4">
           <text datatype="string" operation="pattern match">^nobody</text>
-        </textfilecontent54_state>
-        <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:20800" version="1">
-          <subexpression datatype="int" operation="greater than or equal">5</subexpression>
         </textfilecontent54_state>
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:20900" version="1">
           <subexpression datatype="int" operation="greater than or equal">15</subexpression>
@@ -17769,18 +18137,6 @@ The sysctl --system command will load settings from all system configuration fil
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:22800" version="1">
           <subexpression operation="pattern match">(?i)^enriched$</subexpression>
         </textfilecontent54_state>
-        <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="mode 0600 or less permissive" id="oval:mil.disa.stig.rhel8:ste:22900" version="1">
-          <suid datatype="boolean">false</suid>
-          <sgid datatype="boolean">false</sgid>
-          <sticky datatype="boolean">false</sticky>
-          <uexec datatype="boolean">false</uexec>
-          <gread datatype="boolean">false</gread>
-          <gwrite datatype="boolean">false</gwrite>
-          <gexec datatype="boolean">false</gexec>
-          <oread datatype="boolean">false</oread>
-          <owrite datatype="boolean">false</owrite>
-          <oexec datatype="boolean">false</oexec>
-        </file_state>
         <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="owned by root" id="oval:mil.disa.stig.rhel8:ste:23200" version="1">
           <user_id datatype="int">0</user_id>
         </file_state>
@@ -17939,8 +18295,38 @@ The sysctl --system command will load settings from all system configuration fil
         <textfilecontent54_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.rhel8:ste:41600" version="1">
           <subexpression datatype="int" operation="greater than or equal">0</subexpression>
         </textfilecontent54_state>
+        <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="symbolic links" id="oval:mil.disa.stig.unix:ste:20000002" version="1">
+          <type datatype="string" operation="equals" entity_check="all">symbolic link</type>
+        </file_state>
+        <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" id="oval:mil.disa.stig.unix:ste:20000003" version="1" comment="Mode 755 or less permissive">
+          <gwrite datatype="boolean">false</gwrite>
+          <owrite datatype="boolean">false</owrite>
+        </file_state>
+        <file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" comment="Mode 0600 or less permissive" id="oval:mil.disa.stig.unix:ste:20000004" version="1">
+          <suid datatype="boolean">false</suid>
+          <sgid datatype="boolean">false</sgid>
+          <sticky datatype="boolean">false</sticky>
+          <uexec datatype="boolean">false</uexec>
+          <gread datatype="boolean">false</gread>
+          <gwrite datatype="boolean">false</gwrite>
+          <gexec datatype="boolean">false</gexec>
+          <oread datatype="boolean">false</oread>
+          <owrite datatype="boolean">false</owrite>
+          <oexec datatype="boolean">false</oexec>
+        </file_state>
       </states>
       <variables>
+        <constant_variable comment="system command directories" datatype="string" id="oval:mil.disa.stig.defs:var:20000003" version="1">
+          <value>/bin</value>
+          <value>/sbin</value>
+          <value>/usr/bin</value>
+          <value>/usr/sbin</value>
+          <value>/usr/local/bin</value>
+          <value>/usr/local/sbin</value>
+        </constant_variable>
+        <local_variable datatype="string" comment="Audit log location from /etc/audit/auditd.conf" id="oval:mil.disa.stig.defs:var:20000004" version="1">
+          <object_component object_ref="oval:mil.disa.stig.ind:obj:20000001" item_field="subexpression" />
+        </local_variable>
         <constant_variable comment="system command directories" datatype="string" id="oval:mil.disa.stig.rhel8:var:12400" version="1">
           <value>/bin</value>
           <value>/sbin</value>
@@ -18029,12 +18415,12 @@ The sysctl --system command will load settings from all system configuration fil
       </variables>
     </oval_definitions>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_RHEL_8_V1R6_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2022-06-28T15:27:20">
+  <component id="scap_mil.disa.stig_comp_U_RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2023-03-28T17:41:02">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-06-28T15:27:20</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:02</oval:timestamp>
       </generator>
       <definitions>
         <definition class="inventory" id="oval:mil.disa.stig.rhel8:def:1" version="2">

--- a/scap/content/guides/disa/stig-ie11.xml
+++ b/scap/content/guides/disa/stig-ie11.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
-  <data-stream id="scap_mil.disa.stig_datastream_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2022-06-28T13:56:51">
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
+  <data-stream id="scap_mil.disa.stig_datastream_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2023-03-28T17:40:35">
     <dictionaries>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+          <cat:uri name="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
         </cat:catalog>
       </component-ref>
     </dictionaries>
     <checklists>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-xccdf.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          <cat:uri name="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
         </cat:catalog>
       </component-ref>
     </checklists>
     <checks>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
     </checks>
   </data-stream>
-  <component id="scap_mil.disa.stig_comp_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2022-06-28T13:56:51">
+  <component id="scap_mil.disa.stig_comp_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2023-03-28T17:40:35">
     <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0">
       <cpe-item name="cpe:/a:microsoft:internet_explorer:11">
         <title>Microsoft Internet Explorer 11</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.ie:def:18343</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.ie:def:18343</check>
       </cpe-item>
     </cpe-list>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2022-06-28T13:56:51">
+  <component id="scap_mil.disa.stig_comp_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2023-03-28T17:40:35">
     <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_IE_11_STIG" xml:lang="en" style="SCAP_1.2">
-      <xccdf:status date="2022-06-10">accepted</xccdf:status>
-      <xccdf:title>Microsoft Internet Explorer 11 Security Technical Implementation Guide</xccdf:title>
-      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
+      <xccdf:status date="2023-02-13">accepted</xccdf:status>
+      <xccdf:title>Microsoft Internet Explorer 11 STIG SCAP Benchmark</xccdf:title>
+      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
       <xccdf:notice id="terms-of-use" xml:lang="en" />
       <xccdf:front-matter xml:lang="en" />
       <xccdf:rear-matter xml:lang="en" />
@@ -40,11 +40,11 @@
         <dc:publisher>DISA</dc:publisher>
         <dc:source>STIG.DOD.MIL</dc:source>
       </xccdf:reference>
-      <xccdf:plain-text id="release-info">Release: 2.2 Benchmark Date: 27 Jul 2022</xccdf:plain-text>
-      <xccdf:plain-text id="generator">3.3.0.27375</xccdf:plain-text>
+      <xccdf:plain-text id="release-info">Release: 2.5 Benchmark Date: 27 Apr 2023</xccdf:plain-text>
+      <xccdf:plain-text id="generator">3.4.0.34222</xccdf:plain-text>
       <xccdf:plain-text id="conventionsVersion">1.10.0</xccdf:plain-text>
       <xccdf:platform idref="cpe:/a:microsoft:internet_explorer:11" />
-      <xccdf:version update="http://iase.disa.mil/stigs">002.002</xccdf:version>
+      <xccdf:version update="http://iase.disa.mil/stigs">002.005</xccdf:version>
       <xccdf:metadata>
         <dc:creator>DISA</dc:creator>
         <dc:publisher>DISA</dc:publisher>
@@ -185,7 +185,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223147" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223148" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223149" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-223150" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250540" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252910" selected="true" />
@@ -324,7 +323,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223147" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223148" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223149" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-223150" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250540" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252910" selected="true" />
@@ -463,7 +461,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223147" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223148" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223149" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-223150" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250540" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252910" selected="true" />
@@ -602,7 +599,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223147" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223148" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223149" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-223150" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250540" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252910" selected="true" />
@@ -741,7 +737,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223147" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223148" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223149" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-223150" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250540" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252910" selected="true" />
@@ -880,7 +875,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223147" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223148" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223149" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-223150" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250540" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252910" selected="true" />
@@ -1019,7 +1013,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223147" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223148" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223149" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-223150" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250540" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252910" selected="true" />
@@ -1158,7 +1151,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223147" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223148" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223149" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-223150" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250540" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252910" selected="true" />
@@ -1297,7 +1289,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223147" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223148" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-223149" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-223150" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250540" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250541" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252910" selected="true" />
@@ -1305,140 +1296,139 @@
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_CAT_I_Only">
         <xccdf:title>CAT I Only</xccdf:title>
         <xccdf:description>This profile only includes rules that are Severity Category I.</xccdf:description>
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223015r428597_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223017r428603_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223018r428606_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223019r428609_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223020r428612_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223021r428615_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223022r428618_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223023r428621_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223024r428624_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223025r428627_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223026r428630_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223027r428633_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223028r428636_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223029r428639_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223030r428642_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223031r428645_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223032r428648_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223033r428651_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223034r428654_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223035r428657_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223036r428660_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223037r428663_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223038r428666_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223039r428669_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223040r428672_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223041r428675_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223042r428678_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223043r428681_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223044r428684_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223045r428687_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223046r428690_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223048r428696_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223049r428699_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223050r428702_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223051r428705_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223052r428708_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223053r428711_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223054r428714_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223055r428717_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223056r428720_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223057r428723_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223058r428726_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223059r428729_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223060r428732_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223061r428735_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223062r428738_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223063r428741_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223064r428744_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223065r428747_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223066r428750_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223067r428753_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223068r428756_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223069r428759_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223070r428762_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223071r428765_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223072r428768_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223073r428771_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223074r428774_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223075r428777_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223076r428780_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223077r428783_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223078r428786_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223079r428789_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223080r428792_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223081r428795_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223082r428798_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223083r428801_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223084r428804_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223085r428807_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223086r428810_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223087r428813_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223088r428816_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223089r428819_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223090r428822_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223091r428825_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223092r428828_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223093r428831_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223094r428834_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223095r428837_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223096r428840_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223097r428843_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223098r428846_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223099r428849_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223100r428852_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223101r428855_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223102r428858_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223103r428861_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223104r428864_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223105r428867_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223106r428870_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223107r428873_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223108r428876_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223109r428879_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223110r428882_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223111r428885_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223112r428888_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223113r428891_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223114r428894_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223115r428897_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223116r428900_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223117r428903_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223118r428906_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223119r428909_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223120r428912_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223121r428915_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223123r428921_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223125r428927_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223126r428930_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223127r428933_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223128r428936_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223129r428939_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223130r428942_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223131r428945_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223132r428948_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223133r428951_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223134r428954_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223135r428957_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223136r428960_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223137r428963_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223138r428966_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223139r428969_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223140r428972_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223141r428975_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223142r428978_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223143r428981_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223144r428984_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223145r428987_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223146r428990_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223147r428993_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223148r428996_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223149r428999_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223150r429002_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-250540r804978_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-250541r799949_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223015r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223017r879629_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223018r879629_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223019r879630_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223020r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223021r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223022r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223023r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223024r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223025r879642_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223026r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223027r879636_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223028r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223029r879628_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223030r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223031r879628_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223032r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223033r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223034r879573_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223035r879573_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223036r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223037r879628_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223038r879628_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223039r879664_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223040r879629_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223041r879630_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223042r879798_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223043r879664_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223044r879664_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223045r879630_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223046r879630_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223048r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223049r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223050r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223051r879629_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223052r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223053r879629_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223054r879629_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223055r879629_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223056r879655_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223057r879630_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223058r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223059r879630_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223060r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223061r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223062r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223063r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223064r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223065r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223066r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223067r879642_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223068r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223069r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223070r879636_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223071r879559_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223072r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223073r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223074r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223075r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223076r879630_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223077r879643_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223078r879612_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223079r879584_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223080r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223081r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223082r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223083r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223084r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223085r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223086r879628_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223087r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223088r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223089r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223090r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223091r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223092r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223093r879643_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223094r879643_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223095r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223096r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223097r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223098r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223099r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223100r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223101r879627_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223102r879627_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223103r879627_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223104r879627_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223105r879627_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223106r879627_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223107r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223108r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223109r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223110r879643_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223111r879643_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223112r879643_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223113r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223114r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223115r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223116r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223117r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223118r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223119r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223120r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223121r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223123r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223125r879627_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223126r879559_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223127r879559_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223128r879554_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223129r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223130r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223131r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223132r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223133r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223134r879630_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223135r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223136r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223137r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223138r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223139r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223140r879630_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223141r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223142r879573_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223143r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223144r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223145r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223146r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223147r879587_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223148r879887_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-223149r879534_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-250540r879944_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-250541r879944_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Value id="xccdf_mil.disa.stig_value_WebSitesInLessPrivilegedWebContentZonesCanNavigateIntoThisZone_RestrictedSitesZone_LocalComputer_var" type="number" operator="equals">
         <xccdf:title>WebSitesInLessPrivilegedWebContentZonesCanNavigateIntoThisZone_RestrictedSitesZone_LocalComputer_var</xccdf:title>
@@ -2006,7 +1996,7 @@
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223015">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223015r428597_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223015r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI015-IE11</xccdf:version>
           <xccdf:title>The Internet Explorer warning about certificate address mismatch must be enforced.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This parameter warns users if the certificate being presented by the website is invalid. Since server certificates are used to validate the identity of the web server it is critical to warn the user of a potential issue with the certificate being presented by the web server. This setting aids to prevent spoofing attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2023,14 +2013,14 @@
           <xccdf:fixtext fixref="F-24676r428596_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Security Page 'Turn on certificate address mismatch warning' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24676r428596_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:421" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:421" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223017">
         <xccdf:title>SRG-APP-000209</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223017r428603_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223017r879629_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI022-IE11</xccdf:version>
           <xccdf:title>The Download signed ActiveX controls property must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Active X controls can contain potentially malicious code and must only be allowed to be downloaded from trusted sites. Signed code is better than unsigned code in that it may be easier to determine its author, but it is still potentially harmful, especially when coming from an untrusted zone. This policy setting allows you to manage whether users may download signed ActiveX controls from a page in the zone. If you enable this policy, users can download signed controls without user intervention. If you select Prompt in the drop-down box, users are queried whether to download controls signed by untrusted publishers. Code signed by trusted publishers is silently downloaded. If you disable the policy setting, signed controls cannot be downloaded.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2048,14 +2038,14 @@
           <xccdf:fix id="F-24678r428602_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_DownloadSignedActiveXControls_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:42200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:422" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:422" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223018">
         <xccdf:title>SRG-APP-000209</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223018r428606_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223018r879629_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI023-IE11</xccdf:version>
           <xccdf:title>The Download unsigned ActiveX controls property must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unsigned code is potentially harmful, especially when coming from an untrusted zone. This policy setting allows you to manage whether users may download unsigned ActiveX controls from the zone. If you enable this policy setting, users can run unsigned controls without user intervention. If you select "Prompt" in the drop-down box, users are queried to choose whether to allow the unsigned control to run. If you disable this policy setting, users cannot run unsigned controls. If you do not configure this policy setting, users cannot run unsigned controls.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2073,14 +2063,14 @@
           <xccdf:fix id="F-24679r428605_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_DownloadUnsignedActiveXControls_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:42300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:423" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:423" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223019">
         <xccdf:title>SRG-APP-000210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223019r428609_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223019r879630_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI024-IE11</xccdf:version>
           <xccdf:title>The Initialize and script ActiveX controls not marked as safe property must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ActiveX controls that are not marked safe for scripting should not be executed. Although this is not a complete security measure for a control to be marked safe for scripting, if a control is not marked safe, it should not be initialized and executed. This setting causes both unsafe and safe controls to be initialized and scripted, ignoring the Script ActiveX controls marked safe for scripting option. This increases the risk of malicious code being loaded and executed by the browser. If you enable this policy setting, ActiveX controls are run, loaded with parameters and scripted without setting object safety for untrusted data or scripts. If you disable this policy setting, ActiveX controls that cannot be made safe are not loaded with parameters or scripted. This setting is not recommended, except for secure and administered zones.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2098,14 +2088,14 @@
           <xccdf:fix id="F-24680r428608_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_InitializeScriptActiveXControlsNotMarkedAsSafe_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:42400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:424" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:424" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223020">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223020r428612_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223020r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI031-IE11</xccdf:version>
           <xccdf:title>The Java permissions must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Java applications could contain malicious code; sites located in this security zone are more likely to be hosted by malicious individuals. This policy setting allows you to manage permissions for Java applets. If you enable this policy setting, options can be chosen from the drop-down box. Use of the Custom permission will control permissions settings individually. Use of the Low Safety permission enables applets to perform all operations. Use of the Medium Safety permission enables applets to run in their sandbox (an area in memory outside of which the program cannot make calls), plus adds capabilities like scratch space (a safe and secure storage area on the client computer) and a user-controlled file I/O. Use of the High Safety permission enables applets to run in their sandbox. If you disable this policy setting, Java applets cannot run. If you do not configure this policy setting, the permission is set to High Safety.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2122,14 +2112,14 @@
           <xccdf:fixtext fixref="F-24681r428611_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Security Page -&gt; Internet Zone -&gt; 'Java permissions' to 'Enabled', and select 'Disable Java' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24681r428611_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:426" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:426" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223021">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223021r428615_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223021r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI032-IE11</xccdf:version>
           <xccdf:title>Accessing data sources across domains must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The ability to access data zones across domains could cause the user to unknowingly access content hosted on an unauthorized server. Access to data sources across multiple domains must be controlled based upon the site being browsed. This policy setting allows you to manage whether Internet Explorer can access data from another security zone using the Microsoft XML Parser (MSXML) or ActiveX Data Objects (ADO).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2147,14 +2137,14 @@
           <xccdf:fix id="F-24682r428614_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AccessDataSourcesAcrossDomains_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:42700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:427" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:427" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223022">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223022r428618_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223022r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI036-IE11</xccdf:version>
           <xccdf:title>Functionality to drag and drop or copy and paste files must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Content hosted on sites located in the Internet zone are likely to contain malicious payloads and therefore this feature should be blocked for this zone. Drag and drop or copy and paste files must have a level of protection based upon the site being accessed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2172,14 +2162,14 @@
           <xccdf:fix id="F-24683r428617_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowDragDropOrCopyPasteFiles_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:42800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:428" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:428" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223023">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223023r428621_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223023r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI038-IE11</xccdf:version>
           <xccdf:title>Launching programs and files in IFRAME must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether applications may be run and files may be downloaded from an IFRAME reference in the HTML of the pages in this zone. Launching of programs in IFRAME must have a level of protection based upon the site being accessed. If you enable this policy setting, applications can run and files can be downloaded from IFRAMEs on the pages in this zone without user intervention. If you disable this setting, users are prevented from running applications and downloading files from IFRAMEs on the pages in this zone.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2197,14 +2187,14 @@
           <xccdf:fix id="F-24684r428620_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_LaunchingApplicationsAndFilesInIFRAME_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:42900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:429" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:429" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223024">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223024r428624_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223024r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI039-IE11</xccdf:version>
           <xccdf:title>Navigating windows and frames across different domains must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Frames that navigate across different domains are a security concern, because the user may think they are accessing pages on one site while they are actually accessing pages on another site. It is possible that a website hosting malicious content could use this feature in a manner similar to cross-site scripting (XSS). This policy setting allows you to manage the opening of sub-frames and access of applications across different domains.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2221,14 +2211,14 @@
           <xccdf:fixtext fixref="F-24685r428623_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Security Page -&gt; Internet Zone -&gt; 'Navigate windows and frames across different domains' to 'Enabled', and select 'Disable' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24685r428623_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:430" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:430" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223025">
         <xccdf:title>SRG-APP-000231</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223025r428627_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223025r879642_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI042-IE11</xccdf:version>
           <xccdf:title>Userdata persistence must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Userdata persistence must have a level of protection based upon the site being accessed. It is possible for sites hosting malicious content to exploit this feature as part of an attack against visitors browsing the site. This policy setting allows you to manage the preservation of information in the browser's history, in Favorites, in an XML store, or directly within a web page saved to disk. When a user returns to a persisted page, the state of the page can be restored if this policy setting is not appropriately configured. &lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2246,14 +2236,14 @@
           <xccdf:fix id="F-24686r428626_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_UserdataPersistence_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:43100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:431" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:431" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223026">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223026r428630_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223026r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI044-IE11</xccdf:version>
           <xccdf:title>Clipboard operations via script must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A malicious script could use the clipboard in an undesirable manner, for example, if the user had recently copied confidential information to the clipboard while editing a document, a malicious script could harvest that information. It might be possible to exploit other vulnerabilities in order to send the harvested data to the attacker. Allow paste operations via script must have a level of protection based upon the site being accessed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2271,14 +2261,14 @@
           <xccdf:fix id="F-24687r428629_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowCutCopyPasteOperationsFromClipboardViaScript_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:43200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:432" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:432" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223027">
         <xccdf:title>SRG-APP-000219</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223027r428633_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223027r879636_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI046-IE11</xccdf:version>
           <xccdf:title>Logon options must be configured to prompt (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Users could submit credentials to servers operated by malicious individuals who could then attempt to connect to legitimate servers with those captured credentials. Care must be taken with user credentials, automatic logon performance, and how default Windows credentials are passed to the websites. This policy setting allows management of settings for logon options. If you enable this policy setting, you can choose from varying logon options. “Anonymous logon” disables HTTP authentication and uses the guest account only for the Common Internet File System (CIFS) protocol. “Prompt for user name and password” queries users for user IDs and passwords. After a user is queried, these values can be used silently for the remainder of the session. “Automatic logon only in Intranet zone” queries users for user IDs and passwords in other zones. After a user is queried, these values can be used silently for the remainder of the session. “Automatic logon with current user name and password” attempts logon using Windows NT Challenge Response. If Windows NT Challenge Response is supported by the server, the logon uses the user's network user name and password for login. If Windows NT Challenge Response is not supported by the server, the user is queried to provide the user name and password. If you disable this policy setting, logon is set to “Automatic logon only in Intranet zone”. If you do not configure this policy setting, logon is set to “Automatic logon only in Intranet zone”. The most secure option is to configure this setting to “Enabled”; “Anonymous logon”, but configuring this setting to “Enabled”; “Prompt for user name and password”, provides a reasonable balance between security and usability.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2296,14 +2286,14 @@
           <xccdf:fix id="F-24688r428632_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_LogonOptions_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:43300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:433" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:433" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223028">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223028r428636_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223028r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI061-IE11</xccdf:version>
           <xccdf:title>Java permissions must be configured with High Safety (Intranet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Java applications could contain malicious code. This policy setting allows you to manage permissions for Java applets. If you enable this policy setting, options can be chosen from the drop-down box. Use of the Custom permission will control permissions settings individually. Use of the Low Safety permission enables applets to perform all operations. Use of the Medium Safety permission enables applets to run in their sandbox (an area in memory outside of which the program cannot make calls), plus adds capabilities like scratch space (a safe and secure storage area on the client computer) and a user-controlled file I/O. Use of the High Safety permission enables applets to run in their sandbox. If you disable this policy setting, Java applets cannot run. If you do not configure this policy setting, the permission is set to High Safety.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2320,14 +2310,14 @@
           <xccdf:fixtext fixref="F-24689r428635_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Security Page -&gt; Intranet Zone -&gt; 'Java permissions' to 'Enabled', and select 'High Safety' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24689r428635_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:434" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:434" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223029">
         <xccdf:title>SRG-APP-000207</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223029r428639_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223029r879628_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI062-IE11</xccdf:version>
           <xccdf:title>Anti-Malware programs against ActiveX controls must be run for the Intranet zone.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether Internet Explorer runs Anti-Malware programs against ActiveX controls, to check if they're safe to load on pages.      If you enable this policy setting, Internet Explorer won't check with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you disable this policy setting, Internet Explorer always checks with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you don't configure this policy setting, Internet Explorer won't check with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. Users can turn this behavior on or off, using Internet Explorer Security settings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2344,14 +2334,14 @@
           <xccdf:fixtext fixref="F-24690r428638_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel -&gt; Security Page -&gt; Intranet Zone 'Don't run antimalware programs against ActiveX controls' to 'Enabled' and select 'Disable' in the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24690r428638_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:566" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:566" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223030">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223030r428642_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223030r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI091-IE11</xccdf:version>
           <xccdf:title>Java permissions must be configured with High Safety (Trusted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Java applications could contain malicious code. This policy setting allows you to manage permissions for Java applets. If you enable this policy setting, options can be chosen from the drop-down box. Use of the Custom permission will control permissions settings individually. Use of the Low Safety permission enables applets to perform all operations. Use of the Medium Safety permission enables applets to run in their sandbox (an area in memory outside of which the program cannot make calls), plus adds capabilities like scratch space (a safe and secure storage area on the client computer) and a user-controlled file I/O. Use of the High Safety permission enables applets to run in their sandbox. If you disable this policy setting, Java applets cannot run. If you do not configure this policy setting, the permission is set to High Safety&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2368,14 +2358,14 @@
           <xccdf:fixtext fixref="F-24691r428641_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Security Page -&gt; Trusted Sites Zone -&gt; 'Java permissions' to 'Enabled', and select 'High Safety' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24691r428641_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:435" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:435" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223031">
         <xccdf:title>SRG-APP-000207</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223031r428645_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223031r879628_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI092-IE11</xccdf:version>
           <xccdf:title>Anti-Malware programs against ActiveX controls must be run for the Trusted Sites zone.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether Internet Explorer runs Anti-Malware programs against ActiveX controls, to check if they're safe to load on pages.      If you enable this policy setting, Internet Explorer won't check with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you disable this policy setting, Internet Explorer always checks with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you don't configure this policy setting, Internet Explorer won't check with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. Users can turn this behavior on or off, using Internet Explorer Security settings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2392,14 +2382,14 @@
           <xccdf:fixtext fixref="F-24692r428644_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel -&gt; Security Page -&gt; Trusted Sites Zone 'Don't run antimalware programs against ActiveX controls' to 'Enabled' and select 'Disable' in the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24692r428644_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:569" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:569" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223032">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223032r428648_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223032r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1000-IE11</xccdf:version>
           <xccdf:title>Dragging of content from different domains within a window must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to set options for dragging content from one domain to a different domain when the source and destination are in the same window. If you enable this policy setting, users can drag content from one domain to a different domain when the source and destination are in the same window. Users cannot change this setting. If you disable this policy setting, users cannot drag content from one domain to a different domain when the source and destination are in the same window. Users cannot change this setting in the Internet Options dialog box. If you do not configure this policy setting, users cannot drag content from one domain to a different domain when the source and destination are in the same window. Users can change this setting in the Internet Options dialog box.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2416,14 +2406,14 @@
           <xccdf:fixtext fixref="F-24693r428647_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel-&gt; Security Page-&gt; Internet Zone 'Enable dragging of content from different domains within a window' to 'Enabled', and select 'Disabled' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24693r428647_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:549" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:549" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223033">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223033r428651_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223033r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1005-IE11</xccdf:version>
           <xccdf:title>Dragging of content from different domains across windows must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to set options for dragging content from one domain to a different domain when the source and destination are in different windows. If you enable this policy setting, users can drag content from one domain to a different domain when the source and destination are in different windows. Users cannot change this setting. If you enable this policy setting, users cannot drag content from one domain to a different domain when both the source and destination are in different windows. Users cannot change this setting. If you do not configure this policy setting, users cannot drag content from one domain to a different domain when the source and destination are in different windows. Users can change this setting in the Internet Options dialog box.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2440,14 +2430,14 @@
           <xccdf:fixtext fixref="F-24694r428650_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel-&gt; Security Page-&gt; Restricted Sites Zone 'Enable dragging of content from different domains across windows' to 'Enabled', and select 'Disabled' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24694r428650_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:548" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:548" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223034">
         <xccdf:title>SRG-APP-000112</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223034r428654_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223034r879573_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1010-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes Restrict ActiveX Install must be enforced (Explorer).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Users often choose to install software such as ActiveX controls that are not permitted by their organization's security policy. Such software can pose significant security and privacy risks to networks. This policy setting enables blocking of ActiveX control installation prompts for Internet Explorer processes. If you enable this policy setting, prompts for ActiveX control installations will be blocked for Internet Explorer processes. If you disable this policy setting, prompts for ActiveX control installations will not be blocked and these prompts will be displayed to users. If you do not configure this policy setting, the user's preference will be used to determine whether to block ActiveX control installations for Internet Explorer processes.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2464,14 +2454,14 @@
           <xccdf:fixtext fixref="F-24695r428653_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Restrict ActiveX Install -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24695r428653_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:535" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:535" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223035">
         <xccdf:title>SRG-APP-000112</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223035r428657_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223035r879573_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1020-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes Restrict ActiveX Install must be enforced (iexplore).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Users often choose to install software such as ActiveX controls that are not permitted by their organization's security policy. Such software can pose significant security and privacy risks to networks. This policy setting enables blocking of ActiveX control installation prompts for Internet Explorer processes. If you enable this policy setting, prompts for ActiveX control installations will be blocked for Internet Explorer processes. If you disable this policy setting, prompts for ActiveX control installations will not be blocked and these prompts will be displayed to users. If you do not configure this policy setting, the user's preference will be used to determine whether to block ActiveX control installations for Internet Explorer processes.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2488,14 +2478,14 @@
           <xccdf:fixtext fixref="F-24696r428656_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Restrict ActiveX Install -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24696r428656_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:536" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:536" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223036">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223036r428660_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223036r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1025-IE11</xccdf:version>
           <xccdf:title>Dragging of content from different domains within a window must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to set options for dragging content from one domain to a different domain when the source and destination are in the same window. If you enable this policy setting, users can drag content from one domain to a different domain when the source and destination are in the same window. Users cannot change this setting. If you disable this policy setting, users cannot drag content from one domain to a different domain when the source and destination are in the same window. Users cannot change this setting in the Internet Options dialog box. If you do not configure this policy setting, users cannot drag content from one domain to a different domain when the source and destination are in the same window. Users can change this setting in the Internet Options dialog box.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2512,14 +2502,14 @@
           <xccdf:fixtext fixref="F-24697r428659_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel-&gt; Security Page-&gt; Restricted Sites Zone 'Enable dragging of content from different domains within a window' to 'Enabled', and select 'Disabled' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24697r428659_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:550" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:550" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223037">
         <xccdf:title>SRG-APP-000207</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223037r428663_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223037r879628_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1046-IE11</xccdf:version>
           <xccdf:title>Anti-Malware programs against ActiveX controls must be run for the Internet zone.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether Internet Explorer runs Anti-Malware programs against ActiveX controls, to check if they're safe to load on pages.      If you enable this policy setting, Internet Explorer won't check with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you disable this policy setting, Internet Explorer always checks with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you don't configure this policy setting, Internet Explorer always checks with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. Users can turn this behavior on or off, using Internet Explorer Security settings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2536,14 +2526,14 @@
           <xccdf:fixtext fixref="F-24698r428662_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel -&gt; Security Page -&gt; Internet Zone 'Don't run antimalware programs against ActiveX controls' to 'Enabled' and select 'Disable' in the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24698r428662_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:565" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:565" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223038">
         <xccdf:title>SRG-APP-000207</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223038r428666_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223038r879628_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1051-IE11</xccdf:version>
           <xccdf:title>Anti-Malware programs against ActiveX controls must be run for the Restricted Sites zone.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether Internet Explorer runs Anti-Malware programs against ActiveX controls, to check if they're safe to load on pages.      If you enable this policy setting, Internet Explorer won't check with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you disable this policy setting, Internet Explorer always checks with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you don't configure this policy setting, Internet Explorer always checks with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. Users can turn this behavior on or off, using Internet Explorer Security settings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2560,14 +2550,14 @@
           <xccdf:fixtext fixref="F-24699r428665_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel -&gt; Security Page -&gt; Restricted Sites Zone 'Don't run antimalware programs against ActiveX controls' to 'Enabled' and select 'Disable' in the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24699r428665_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:568" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:568" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223039">
         <xccdf:title>SRG-APP-000278</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223039r428669_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223039r879664_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1060-IE11</xccdf:version>
           <xccdf:title>Prevent bypassing SmartScreen Filter warnings must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether the user can bypass warnings from SmartScreen Filter. SmartScreen Filter prevents the user from browsing to or downloading from sites that are known to host malicious content. SmartScreen Filter also prevents the execution of files that are known to be malicious. If you enable this policy setting, SmartScreen Filter warnings block the user. If you disable or do not configure this policy setting, the user can bypass SmartScreen Filter warnings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2586,14 +2576,14 @@
 Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; ”Prevent bypassing SmartScreen Filter warnings” to ”Enabled”.</xccdf:fixtext>
           <xccdf:fix id="F-24700r428668_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:578" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:578" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223040">
         <xccdf:title>SRG-APP-000209</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223040r428672_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223040r879629_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1065-IE11</xccdf:version>
           <xccdf:title>Prevent bypassing SmartScreen Filter warnings about files that are not commonly downloaded from the internet must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether the user can bypass warnings from SmartScreen Filter. SmartScreen Filter warns the user about executable files that Internet Explorer users do not commonly download from the internet. If you enable this policy setting, SmartScreen Filter warnings block the user. If you disable or do not configure this policy setting, the user can bypass SmartScreen Filter warnings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2612,14 +2602,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
 Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; ”Prevent bypassing SmartScreen Filter warnings about files that are not commonly downloaded from the internet” to ”Enabled”.</xccdf:fixtext>
           <xccdf:fix id="F-24701r428671_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:572" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:572" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223041">
         <xccdf:title>SRG-APP-000210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223041r428675_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223041r879630_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1070-IE11</xccdf:version>
           <xccdf:title>Prevent per-user installation of ActiveX controls must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to prevent the installation of ActiveX controls on a per-user basis. If you enable this policy setting, ActiveX controls cannot be installed on a per-user basis. If you disable or do not configure this policy setting, ActiveX controls can be installed on a per-user basis.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2636,14 +2626,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24702r428674_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; ”Prevent per-user installation of ActiveX controls” to ”Enabled”.</xccdf:fixtext>
           <xccdf:fix id="F-24702r428674_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:574" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:574" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223042">
         <xccdf:title>SRG-APP-000427</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223042r428678_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223042r879798_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1075-IE11</xccdf:version>
           <xccdf:title>Prevent ignoring certificate errors option must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting prevents the user from ignoring Secure Sockets Layer/Transport Layer Security (SSL/TLS) certificate errors that interrupt browsing (such as “expired”, “revoked”, or “name mismatch” errors) in Internet Explorer. If you enable this policy setting, the user cannot continue browsing. If you disable or do not configure this policy setting, the user can choose to ignore certificate errors and continue browsing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2660,14 +2650,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24703r428677_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Panel &gt;&gt; ”Prevent ignoring certificate errors” to ”Enabled”.</xccdf:fixtext>
           <xccdf:fix id="F-24703r428677_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:575" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:575" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223043">
         <xccdf:title>SRG-APP-000278</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223043r428681_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223043r879664_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1080-IE11</xccdf:version>
           <xccdf:title>Turn on SmartScreen Filter scan option for the Internet Zone must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether SmartScreen Filter scans pages in this zone for malicious content. If you enable this policy setting, SmartScreen Filter scans pages in this zone for malicious content. If you disable this policy setting, SmartScreen Filter does not scan pages in this zone for malicious content. If you do not configure this policy setting, the user can choose whether SmartScreen Filter scans pages in this zone for malicious content.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2684,14 +2674,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24704r428680_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Panel &gt;&gt; Security Page &gt;&gt; Internet Zone &gt;&gt; ”Turn on SmartScreen Filter scan” to ”Enabled”, and select ”Enable” from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24704r428680_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:577" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:577" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223044">
         <xccdf:title>SRG-APP-000278</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223044r428684_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223044r879664_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1085-IE11</xccdf:version>
           <xccdf:title>Turn on SmartScreen Filter scan option for the Restricted Sites Zone must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether SmartScreen Filter scans pages in this zone for malicious content. If you enable this policy setting, SmartScreen Filter scans pages in this zone for malicious content. If you disable this policy setting, SmartScreen Filter does not scan pages in this zone for malicious content. If you do not configure this policy setting, the user can choose whether SmartScreen Filter scans pages in this zone for malicious content.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2708,14 +2698,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24705r428683_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Panel &gt;&gt; Security Page &gt;&gt; Restricted Sites Zone &gt;&gt; ”Turn on SmartScreen Filter scan” to ”Enabled”, and select ”Enable” from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24705r428683_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:576" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:576" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223045">
         <xccdf:title>SRG-APP-000210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223045r428687_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223045r879630_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1090-IE11</xccdf:version>
           <xccdf:title>The Initialize and script ActiveX controls not marked as safe must be disallowed (Intranet Zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ActiveX controls that are not marked safe for scripting should not be executed. Although this is not a complete security measure for a control to be marked safe for scripting, if a control is not marked safe, it should not be initialized and executed. This setting causes both unsafe and safe controls to be initialized and scripted, ignoring the Script ActiveX controls marked safe for scripting option. This increases the risk of malicious code being loaded and executed by the browser. If you enable this policy setting, ActiveX controls are run, loaded with parameters and scripted without setting object safety for untrusted data or scripts. If you disable this policy setting, ActiveX controls that cannot be made safe are not loaded with parameters or scripted. This setting is not recommended, except for secure and administered zones.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2732,14 +2722,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24706r428686_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Panel &gt;&gt; Security Page &gt;&gt; Intranet Zone &gt;&gt; ”Initialize and script ActiveX controls not marked as safe” to ”Enabled”, and select ”Disable” from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24706r428686_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:579" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:579" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223046">
         <xccdf:title>SRG-APP-000210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223046r428690_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223046r879630_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1095-IE11</xccdf:version>
           <xccdf:title>The Initialize and script ActiveX controls not marked as safe must be disallowed (Trusted Sites Zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ActiveX controls that are not marked safe for scripting should not be executed. Although this is not a complete security measure for a control to be marked safe for scripting, if a control is not marked safe, it should not be initialized and executed. This setting causes both unsafe and safe controls to be initialized and scripted, ignoring the Script ActiveX controls marked safe for scripting option. This increases the risk of malicious code being loaded and executed by the browser. If you enable this policy setting, ActiveX controls are run, loaded with parameters and scripted without setting object safety for untrusted data or scripts. If you disable this policy setting, ActiveX controls that cannot be made safe are not loaded with parameters or scripted. This setting is not recommended, except for secure and administered zones.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2756,14 +2746,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24707r428689_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Panel &gt;&gt; Security Page &gt;&gt; Trusted Sites Zone &gt;&gt; ”Initialize and script ActiveX controls not marked as safe” to ”Enabled”, and select ”Disable” from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24707r428689_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:573" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:573" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223048">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223048r428696_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223048r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1105-IE11</xccdf:version>
           <xccdf:title>Run once selection for running outdated ActiveX controls must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This feature keeps ActiveX controls up to date and helps make them safer to use in Internet Explorer. Many ActiveX controls are not automatically updated as new versions are released. It is very important to keep ActiveX controls up to date because malicious or compromised webpages can target security flaws in out-of-date ActiveX controls.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2780,14 +2770,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24709r428695_fix">In the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Security Features &gt;&gt; Add-on Management, set "Remove the Run this time button for outdated ActiveX controls in IE" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-24709r428695_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:585" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:585" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223049">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223049r428699_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223049r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1110-IE11</xccdf:version>
           <xccdf:title>Enabling outdated ActiveX controls for Internet Explorer must be blocked.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This feature keeps ActiveX controls up to date and helps make them safer to use in Internet Explorer. Many ActiveX controls are not automatically updated as new versions are released. It is very important to keep ActiveX controls up to date because malicious or compromised webpages can target security flaws in out-of-date ActiveX controls.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2804,14 +2794,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24710r428698_fix">In the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Security Features &gt;&gt; Add-on Management, set "Turn off blocking of outdated ActiveX controls for Internet Explorer" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-24710r428698_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:586" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:586" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223050">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223050r428702_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223050r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1115-IE11</xccdf:version>
           <xccdf:title>Use of the Tabular Data Control (TDC) ActiveX control must be disabled for the Internet Zone.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether users can run the Tabular Data Control (TDC) ActiveX control, based on security zone. By default, the TDC ActiveX Control is disabled in the Internet and Restricted Sites security zones. If you enable this policy setting, users will not be able to run the TDC ActiveX control from all sites in the specified zone.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2825,20 +2815,20 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:ident system="http://cyber.mil/legacy">SV-87399</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-72761</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000381</xccdf:ident>
-          <xccdf:fixtext fixref="F-24711r428701_fix">In the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Pane &gt;&gt; Security Page &gt;&gt; Internet Zone, set the "Allow only approved domains to use the TDC ActiveX control" to “Enabled”. 
+          <xccdf:fixtext fixref="F-24711r428701_fix">In the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Pane &gt;&gt; Security Page &gt;&gt; Internet Zone, set the "Allow only approved domains to use the TDC ActiveX control" to “Enabled”.
 
 In the Options window, select "Enable" from the “Only allow approved domains to use the TDC ActiveX control" drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24711r428701_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowApprovedDomainsToUseTDCActiveXControl_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:58300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:583" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:583" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223051">
         <xccdf:title>SRG-APP-000209</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223051r428705_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223051r879629_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI112-IE11</xccdf:version>
           <xccdf:title>The Download signed ActiveX controls property must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ActiveX controls can contain potentially malicious code and must only be allowed to be downloaded from trusted sites. Signed code is better than unsigned code in that it may be easier to determine its author, but it is still potentially harmful, especially when coming from an untrusted zone.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2856,14 +2846,14 @@ In the Options window, select "Enable" from the “Only allow approved domains t
           <xccdf:fix id="F-24712r428704_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_DownloadSignedActiveXControls_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:43600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:436" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:436" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223052">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223052r428708_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223052r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1120-IE11</xccdf:version>
           <xccdf:title>Use of the Tabular Data Control (TDC) ActiveX control must be disabled for the Restricted Sites Zone.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether users can run the Tabular Data Control (TDC) ActiveX control, based on security zone. By default, the TDC ActiveX Control is disabled in the Internet and Restricted Sites security zones. If you enable this policy setting, users won’t be able to run the TDC ActiveX control from all sites in the specified zone.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2883,14 +2873,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24713r428707_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowApprovedDomainsToUseTDCActiveXControl_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:58400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:584" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:584" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223053">
         <xccdf:title>SRG-APP-000209</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223053r428711_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223053r879629_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1125-IE11</xccdf:version>
           <xccdf:title>VBScript must not be allowed to run in Internet Explorer (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows the management of whether VBScript can be run on pages from the specified zone in Internet Explorer. By selecting "Enable" in the drop-down box, VBScript can run without user intervention. By selecting "Prompt" in the drop-down box, users are asked to choose whether to allow VBScript to run. By selecting "Disable" in the drop-down box, VBScript is prevented from running. If this policy setting is not configured or disabled, VBScript will run without user intervention.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2907,14 +2897,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fixtext fixref="F-24714r428710_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Panel &gt;&gt; Security Page &gt;&gt; Internet Zone &gt;&gt; "Allow VBScript to run in Internet Explorer" to "Enabled" and select "Disable" from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24714r428710_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:588" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:588" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223054">
         <xccdf:title>SRG-APP-000209</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223054r428714_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223054r879629_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI113-IE11</xccdf:version>
           <xccdf:title>The Download unsigned ActiveX controls property must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unsigned code is potentially harmful, especially when coming from an untrusted zone. ActiveX controls can contain potentially malicious code and must only be allowed to be downloaded from trusted sites. They must also be digitally signed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2932,14 +2922,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24715r428713_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_DownloadUnsignedActiveXControls_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:43700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:437" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:437" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223055">
         <xccdf:title>SRG-APP-000209</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223055r428717_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223055r879629_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1130-IE11</xccdf:version>
           <xccdf:title>VBScript must not be allowed to run in Internet Explorer (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows the management of whether VBScript can be run on pages from the specified zone in Internet Explorer. By selecting "Enable" in the drop-down box, VBScript can run without user intervention. By selecting "Prompt" in the drop-down box, users are asked to choose whether to allow VBScript to run. By selecting "Disable" in the drop-down box, VBScript is prevented from running. If this policy setting is not configured or disabled, VBScript will run without user intervention.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2956,14 +2946,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fixtext fixref="F-24716r428716_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Panel &gt;&gt; Security Page &gt;&gt; Restricted Sites Zone &gt;&gt; "Allow VBScript to run in Internet Explorer" to "Enabled" and select "Disable" from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24716r428716_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:589" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:589" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223056">
         <xccdf:title>SRG-APP-000266</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223056r428720_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223056r879655_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1135-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Development Tools Must Be Disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;While the risk associated with browser development tools is more related to the proper design of a web application, a risk vector remains within the browser. The developer tools allow end users and application developers to view and edit all types of web application related data via the browser. Page elements, source code, javascript, API calls, application data, etc. may all be viewed and potentially manipulated. Manipulation could be useful for troubleshooting legitimate issues, and this may be performed in a development environment. Manipulation could also be malicious and must be addressed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2980,14 +2970,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fixtext fixref="F-24717r428719_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Toolbars &gt;&gt; “Turn off Developer Tools” to “Enabled”.</xccdf:fixtext>
           <xccdf:fix id="F-24717r428719_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:591" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:591" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223057">
         <xccdf:title>SRG-APP-000210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223057r428723_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223057r879630_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI114-IE11</xccdf:version>
           <xccdf:title>The Initialize and script ActiveX controls not marked as safe property must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;ActiveX controls not marked safe for scripting should not be executed. Although this is not a complete security measure for a control to be marked safe for scripting, if a control is not marked safe, it should not be initialized and executed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3005,14 +2995,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24718r428722_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_InitializeScriptActiveXControlsNotMarkedAsSafe_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:43800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:438" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:438" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223058">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223058r428726_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223058r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI115-IE11</xccdf:version>
           <xccdf:title>ActiveX controls and plug-ins must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether ActiveX controls and plug-ins can be run on pages from the specified zone. ActiveX controls not marked as safe should not be executed. If you enable this policy setting, controls and plug-ins can run without user intervention. If you disable this policy setting, controls and plug-ins are prevented from running.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3030,14 +3020,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24719r428725_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_RunActiveXControlsAndPlugins_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:43900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:439" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:439" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223059">
         <xccdf:title>SRG-APP-000210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223059r428729_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223059r879630_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI116-IE11</xccdf:version>
           <xccdf:title>ActiveX controls marked safe for scripting must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows management of whether ActiveX controls marked safe for scripting can interact with a script. If you enable this policy setting, script interaction can occur automatically without user intervention. ActiveX controls not marked as safe for scripting should not be executed. Although this is not a complete security measure for a control to be marked safe for scripting, if a control is not marked safe, it should not be initialized and executed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3055,14 +3045,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24720r428728_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ScriptActiveXControlsMarkedSafeForScripting_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:44000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:440" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:440" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223060">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223060r428732_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223060r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI119-IE11</xccdf:version>
           <xccdf:title>File downloads must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Sites located in the Restricted Sites Zone are more likely to contain malicious payloads and therefore downloads from this zone should be blocked. Files should not be able to be downloaded from sites that are considered restricted. This policy setting allows you to manage whether file downloads are permitted from the zone. This option is determined by the zone of the page with the link causing the download, not the zone from which the file is delivered.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3080,14 +3070,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24721r428731_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowFileDownloads_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:44100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:441" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:441" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223061">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223061r428735_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223061r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI121-IE11</xccdf:version>
           <xccdf:title>Java permissions must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Java applications could contain malicious code; sites located in this security zone are more likely to be hosted by malicious individuals. This policy setting allows you to manage permissions for Java applets. If you enable this policy setting, options can be chosen from the drop-down box. Use of the Custom permission will control permissions settings individually. Use of the Low Safety permission enables applets to perform all operations. Use of the Medium Safety permission enables applets to run in their sandbox (an area in memory outside of which the program cannot make calls), plus adds capabilities like scratch space (a safe and secure storage area on the client computer) and a user-controlled file I/O. Use of the High Safety permission enables applets to run in their sandbox. If you disable this policy setting, Java applets cannot run. If you do not configure this policy setting, the permission is set to High Safety.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3105,14 +3095,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24722r428734_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_JavaPermissions_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:45300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:453" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:453" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223062">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223062r428738_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223062r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI122-IE11</xccdf:version>
           <xccdf:title>Accessing data sources across domains must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The ability to access data zones across domains could cause the user to unknowingly access content hosted on an unauthorized server. This policy setting allows you to manage whether Internet Explorer can access data from another security zone using the Microsoft XML Parser (MSXML) or ActiveX Data Objects (ADO).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3130,14 +3120,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24723r428737_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AccessDataSourcesAcrossDomains_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:44300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:443" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:443" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223063">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223063r428741_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223063r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI123-IE11</xccdf:version>
           <xccdf:title>The Allow META REFRESH property must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It is possible that users will unknowingly be redirected to a site hosting malicious content. 'Allow META REFRESH' must have a level of protection based upon the site being browsed. This policy setting allows you to manage whether a user's browser can be redirected to another web page if the author of the web page uses the Meta Refresh setting to redirect browsers to another web page.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3155,14 +3145,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24724r428740_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowMETAREFRESH_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:44400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:444" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:444" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223064">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223064r428744_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223064r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI126-IE11</xccdf:version>
           <xccdf:title>Functionality to drag and drop or copy and paste files must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Content hosted on sites located in the Restricted Sites zone are more likely to contain malicious payloads and therefore this feature should be blocked for this zone. Drag and drop or copy and paste files must have a level of protection based upon the site being accessed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3180,14 +3170,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24725r428743_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowDragDropOrCopyPasteFiles_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:44500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:445" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:445" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223065">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223065r428747_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223065r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI128-IE11</xccdf:version>
           <xccdf:title>Launching programs and files in IFRAME must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether applications may be run and files may be downloaded from an IFRAME reference in the HTML of the pages in this zone. Launching of programs in IFRAME must have a level of protection based upon the site being accessed. If you enable this policy setting, applications can run and files can be downloaded from IFRAMEs on the pages in this zone without user intervention. If you disable this setting, users are prevented from running applications and downloading files from IFRAMEs on the pages in this zone.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3205,14 +3195,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24726r428746_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_LaunchingApplicationsAndFilesInIFRAME_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:44700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:447" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:447" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223066">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223066r428750_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223066r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI129-IE11</xccdf:version>
           <xccdf:title>Navigating windows and frames across different domains must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Frames navigating across different domains are a security concern, because the user may think they are accessing pages on one site while they are actually accessing pages on another site. It is possible that a website hosting malicious content could use this feature in a manner similar to cross-site scripting (XSS). This policy setting allows you to manage the opening of sub-frames and access of applications across different domains.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3230,14 +3220,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24727r428749_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_NavigateSub-framesAcrossDifferentDomains_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:44800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:448" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:448" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223067">
         <xccdf:title>SRG-APP-000231</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223067r428753_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223067r879642_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI132-IE11</xccdf:version>
           <xccdf:title>Userdata persistence must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Userdata persistence must have a level of protection based upon the site being accessed. This policy setting allows you to manage the preservation of information in the browser's history, in Favorites, in an XML store, or directly within a web page saved to disk. When a user returns to a persisted page, the state of the page can be restored if this policy setting is not appropriately configured.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3255,14 +3245,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24728r428752_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_UserdataPersistence_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:44900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:449" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:449" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223068">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223068r428756_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223068r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI133-IE11</xccdf:version>
           <xccdf:title>Active scripting must be disallowed (Restricted Sites Zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Active scripts hosted on sites located in this zone are more likely to contain malicious code. Active scripting must have a level of protection based upon the site being accessed. This policy setting allows you to manage whether script code on pages in the zone are run.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3280,14 +3270,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24729r428755_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowActiveScripting_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:45000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:450" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:450" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223069">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223069r428759_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223069r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI134-IE11</xccdf:version>
           <xccdf:title>Clipboard operations via script must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A malicious script could use the clipboard in an undesirable manner, for example, if the user had recently copied confidential information to the clipboard while editing a document, a malicious script could harvest that information. It might be possible to exploit other vulnerabilities in order to send the harvested data to the attacker. Allow paste operations via script must have a level of protection based upon the site being accessed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3305,14 +3295,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24730r428758_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowCutCopyPasteOperationsFromClipboardViaScript_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:45100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:451" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:451" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223070">
         <xccdf:title>SRG-APP-000219</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223070r428762_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223070r879636_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI136-IE11</xccdf:version>
           <xccdf:title>Logon options must be configured and enforced (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Users could submit credentials to servers operated by malicious individuals who could then attempt to connect to legitimate servers with those captured credentials. Care must be taken with user credentials, automatic logon performance, and how default Windows credentials are passed to the websites. This policy setting allows management of settings for logon options. If you enable this policy setting, you can choose from varying logon options. “Anonymous logon” disables HTTP authentication and uses the guest account only for the Common Internet File System (CIFS) protocol. “Prompt for user name and password” queries users for user IDs and passwords. After a user is queried, these values can be used silently for the remainder of the session. “Automatic logon only in Intranet zone” queries users for user IDs and passwords in other zones. After a user is queried, these values can be used silently for the remainder of the session. “Automatic logon with current user name and password” attempts logon using Windows NT Challenge Response. If Windows NT Challenge Response is supported by the server, the logon uses the user's network user name and password for login. If Windows NT Challenge Response is not supported by the server, the user is queried to provide the user name and password. If you disable this policy setting, logon is set to “Automatic logon only in Intranet zone”. If you do not configure this policy setting, logon is set to “Automatic logon only in Intranet zone”. The most secure option is to configure this setting to “Enabled”; “Anonymous logon”. This will prevent users from submitting credentials to servers in this security zone.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3330,14 +3320,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24731r428761_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_LogonOptions_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:45200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:452" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:452" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223071">
         <xccdf:title>SRG-APP-000089</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223071r428765_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223071r879559_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI300-IE11</xccdf:version>
           <xccdf:title>Configuring History setting must be set to 40 days.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting specifies the number of days that Internet Explorer keeps track of the pages viewed in the History List. The delete Browsing History option can be accessed using Tools, Internet Options, "General" tab, and then click Settings under Browsing History. If you enable this policy setting, a user cannot set the number of days that Internet Explorer keeps track of the pages viewed in the History List. The number of days that Internet Explorer keeps track of the pages viewed in the History List must be specified. Users will not be able to delete browsing history. If you disable or do not configure this policy setting, a user can set the number of days that Internet Explorer tracks views of pages in the History List. Users can delete browsing history.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3354,14 +3344,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fixtext fixref="F-24732r428764_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Delete Browsing History -&gt; 'Disable Configuring History' to 'Enabled', and enter '40' in 'Days to keep pages in History'.</xccdf:fixtext>
           <xccdf:fix id="F-24732r428764_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:513" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:513" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223072">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223072r428768_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223072r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI318-IE11</xccdf:version>
           <xccdf:title>Internet Explorer must be set to disallow users to add/delete sites.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting prevents users from adding sites to various security zones. Users should not be able to add sites to different zones, as this could allow them to bypass security controls of the system. If you do not configure this policy setting, users will be able to add or remove sites from the Trusted Sites and Restricted Sites zones at will and change settings in the Local Intranet zone. This configuration could allow sites that host malicious mobile code to be added to these zones, and users could execute the code.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3379,14 +3369,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24733r428767_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_DoNotAllowUsersAddDeleteSites_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:41900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:419" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:419" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223073">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223073r428771_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223073r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI319-IE11</xccdf:version>
           <xccdf:title>Internet Explorer must be configured to disallow users to change policies.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Users who change their Internet Explorer security settings could enable the execution of dangerous types of code from the Internet and websites listed in the Restricted Sites zone in the browser. This setting prevents users from changing the Internet Explorer policies on the machine. Policy changes should be made by administrators only, so this setting should be enabled. If you enable this policy setting, you disable the "Custom level" button and "Security" level for this zone slider on the Security tab in the Internet Options dialog box. If this policy setting is disabled or not configured, users will be able to change the settings for security zones. It prevents users from changing security zone policy settings that are established by the administrator.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3404,14 +3394,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24734r428770_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_DoNotAllowUsersChangePolicies_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:41800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:418" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:418" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223074">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223074r428774_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223074r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI320-IE11</xccdf:version>
           <xccdf:title>Internet Explorer must be configured to use machine settings.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Users who change their Internet Explorer security settings could enable the execution of dangerous types of code from the Internet and websites listed in the Restricted Sites zone in the browser. This setting enforces consistent security zone settings to all users of the computer. Security zones control browser behavior at various websites and it is desirable to maintain a consistent policy for all users of a machine. This policy setting affects how security zone changes apply to different users. If you enable this policy setting, changes that one user makes to a security zone will apply to all users of that computer. If this policy setting is disabled or not configured, users of the same computer are allowed to establish their own security zone settings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3429,14 +3419,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24735r428773_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_UseOnlyMachineSettings_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:41700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:417" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:417" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223075">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223075r428777_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223075r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI325-IE11</xccdf:version>
           <xccdf:title>Security checking features must be enforced.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting turns off the Security Settings Check feature, which checks Internet Explorer security settings to determine when the settings put Internet Explorer at risk. If you enable this policy setting, the security settings check will not be performed. If you disable or do not configure this policy setting, the security settings check will be performed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3454,14 +3444,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24736r428776_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_TurnOffSecuritySettingsCheckFeature_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:45700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:457" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:457" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223076">
         <xccdf:title>SRG-APP-000210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223076r428780_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223076r879630_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI350-IE11</xccdf:version>
           <xccdf:title>Software must be disallowed to run or install with invalid signatures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Microsoft ActiveX controls and file downloads often have digital signatures attached that certify the file's integrity and the identity of the signer (creator) of the software. Such signatures help ensure unmodified software is downloaded and the user can positively identify the signer to determine whether you trust them enough to run their software.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3479,14 +3469,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fix id="F-24737r428779_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowSoftwareRunInstallSignatureInvalid_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:45900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:459" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:459" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223077">
         <xccdf:title>SRG-APP-000233</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223077r428783_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223077r879643_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI356-IE11</xccdf:version>
           <xccdf:title>The 64-bit tab processes, when running in Enhanced Protected Mode on 64-bit versions of Windows, must be turned on.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether Internet Explorer 11 uses 64-bit processes (for greater security) or 32-bit processes (for greater compatibility) when running in Enhanced Protected Mode on 64-bit versions of Windows.Important: Some ActiveX controls and toolbars may not be available when 64-bit processes are used. If you enable this policy setting, Internet Explorer 11 will use 64-bit tab processes when running in Enhanced Protected Mode on 64-bit versions of Windows. If you disable this policy setting, Internet Explorer 11 will use 32-bit tab processes when running in Enhanced Protected Mode on 64-bit versions of Windows. If you don't configure this policy setting, users can turn this feature on or off using Internet Explorer settings. This feature is turned off by default.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3503,14 +3493,14 @@ In the Options windows, select "Enable" from the “Only allow approved domains 
           <xccdf:fixtext fixref="F-24738r428782_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel -&gt; Advanced Page 'Turn on 64-bit tab processes when running in Enhanced Protected Mode on 64-bit versions of Windows' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24738r428782_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:564" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:564" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223078">
         <xccdf:title>SRG-APP-000175</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223078r428786_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223078r879612_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI365-IE11</xccdf:version>
           <xccdf:title>Checking for server certificate revocation must be enforced.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether Internet Explorer will check revocation status of servers' certificates. Certificates are revoked when they have been compromised or are no longer valid, and this option protects users from submitting confidential data to a site that may be fraudulent or not secure. If you enable this policy setting, Internet Explorer will check to see if server certificates have been revoked. If you disable this policy setting, Internet Explorer will not check server certificates to see if they have been revoked. If you do not configure this policy setting, Internet Explorer will not check server certificates to see if they have been revoked.
@@ -3530,14 +3520,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24739r428785_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_CheckServerCertificateRevocation_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:46100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:461" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:461" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223079">
         <xccdf:title>SRG-APP-000131</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223079r428789_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223079r879584_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI370-IE11</xccdf:version>
           <xccdf:title>Checking for signatures on downloaded programs must be enforced.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether Internet Explorer checks for digital signatures (which identifies the publisher of signed software and verifies it has not been modified or tampered with) on user computers before downloading executable programs. If you enable this policy setting, Internet Explorer will check the digital signatures of executable programs and display their identities before downloading them to the user computers. If you disable this policy setting, Internet Explorer will not check the digital signatures of executable programs or display their identities before downloading them to the user computers. If you do not configure this policy, Internet Explorer will not check the digital signatures of executable programs or display their identities before downloading them to the user computers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3550,19 +3540,19 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/legacy">SV-59497</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-46633</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-001749</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-001779</xccdf:ident>
           <xccdf:fixtext fixref="F-24740r428788_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Advanced Page -&gt; 'Check for signatures on downloaded programs' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24740r428788_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_CheckSignatureDownloadedPrograms_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:46200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:462" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:462" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223080">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223080r428792_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223080r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI375-IE11</xccdf:version>
           <xccdf:title>All network paths (UNCs) for Intranet sites must be disallowed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Some UNC paths could refer to servers not managed by the organization, which means they could host malicious content; and therefore, it is safest to not include all UNC paths in the Intranet Sites zone. This policy setting controls whether URLs representing UNCs are mapped into the local Intranet security zone. If you enable this policy setting, all network paths are mapped into the Intranet Zone. If you disable this policy setting, network paths are not necessarily mapped into the Intranet Zone (other rules might map one there). If you do not configure this policy setting, users choose whether network paths are mapped into the Intranet Zone.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3580,14 +3570,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24741r428791_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_IncludeAllNetworkPaths_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:46300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:463" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:463" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223081">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223081r428795_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223081r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI385-IE11</xccdf:version>
           <xccdf:title>Script-initiated windows without size or position constraints must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage restrictions on script-initiated pop-up windows and windows including the title and status bars. If you enable this policy setting, Windows Restrictions security will not apply in this zone. The security zone runs without the added layer of security provided by this feature. If you disable this policy setting, the possible harmful actions contained in script-initiated pop-up windows and windows including the title and status bars cannot be run. This Internet Explorer security feature will be on in this zone as dictated by the Scripted Windows Security Restrictions feature control setting for the process. If you do not configure this policy setting, the possible harmful actions contained in script-initiated pop-up windows and windows including the title and status bars cannot be run. This Internet Explorer security feature will be on in this zone as dictated by the Scripted Windows Security Restrictions feature control setting for the process.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3605,14 +3595,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24742r428794_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowScriptInitiatedWindowsWithoutSizeOrPositionConstraints_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:46400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:464" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:464" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223082">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223082r428798_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223082r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI390-IE11</xccdf:version>
           <xccdf:title>Script-initiated windows without size or position constraints must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage restrictions on script-initiated pop-up windows and windows including the title and status bars. If you enable this policy setting, Windows Restrictions security will not apply in this zone. The security zone runs without the added layer of security provided by this feature. If you disable this policy setting, the possible harmful actions contained in script-initiated pop-up windows and windows including the title and status bars cannot be run. This Internet Explorer security feature will be on in this zone as dictated by the Scripted Windows Security Restrictions feature control setting for the process. If you do not configure this policy setting, the possible harmful actions contained in script-initiated pop-up windows and windows including the title and status bars cannot be run. This Internet Explorer security feature will be on in this zone as dictated by the Scripted Windows Security Restrictions feature control setting for the process.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3630,14 +3620,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24743r428797_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowScriptInitiatedWindowsWithoutSizeOrPositionConstraints_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:46500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:465" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:465" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223083">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223083r428801_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223083r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI395-IE11</xccdf:version>
           <xccdf:title>Scriptlets must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether scriptlets can be allowed. Scriptlets hosted on sites located in this zone are more likely to contain malicious code. If you enable this policy setting, users will be able to run scriptlets. If you disable this policy setting, users will not be able to run scriptlets. If you do not configure this policy setting, a scriptlet can be enabled or disabled by the user.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3655,14 +3645,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24744r428800_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowScriptlets_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:46600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:466" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:466" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223084">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223084r428804_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223084r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI415-IE11</xccdf:version>
           <xccdf:title>Automatic prompting for file downloads must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether users will be prompted for non user-initiated file downloads. Regardless of this setting, users will receive file download dialogs for user-initiated downloads. Users may accept downloads that they did not request, and those downloaded files may include malicious code. If you enable this setting, users will receive a file download dialog for automatic download attempts. If you disable or do not configure this setting, file downloads that are not user-initiated will be blocked, and users will see the information bar instead of the file download dialog. Users can then click the information bar to allow the file download prompt.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3680,14 +3670,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24745r428803_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AutomaticPromptingFileDownloads_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:46700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:467" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:467" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223085">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223085r428807_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223085r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI425-IE11</xccdf:version>
           <xccdf:title>Java permissions must be disallowed (Local Machine zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Java applications could contain malicious code. This policy setting allows you to manage permissions for Java applets. If you enable this policy setting, options can be chosen from the drop-down box. Use of the Custom permission will control permissions settings individually. Use of the Low Safety permission enables applets to perform all operations. Use of the Medium Safety permission enables applets to run in their sandbox (an area in memory outside of which the program cannot make calls), plus adds capabilities like scratch space (a safe and secure storage area on the client computer) and a user-controlled file I/O. Use of the High Safety permission enables applets to run in their sandbox. If you disable this policy setting, Java applets cannot run. If you do not configure this policy setting, the permission is set to High Safety.  &lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3705,14 +3695,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24746r428806_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_JavaPermissions_LocalMachineZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:46800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:468" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:468" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223086">
         <xccdf:title>SRG-APP-000207</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223086r428810_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223086r879628_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI426-IE11</xccdf:version>
           <xccdf:title>Anti-Malware programs against ActiveX controls must be run for the Local Machine zone.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether Internet Explorer runs Anti-Malware programs against ActiveX controls, to check if they're safe to load on pages.      If you enable this policy setting, Internet Explorer won't check with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you disable this policy setting, Internet Explorer always checks with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. If you don't configure this policy setting, Internet Explorer won't check with your Anti-Malware program to see if it's safe to create an instance of the ActiveX control. Users can turn this behavior on or off, using Internet Explorer Security settings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3729,14 +3719,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24747r428809_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel -&gt; Security Page -&gt; Local Machine Zone 'Don't run antimalware programs against ActiveX controls' to 'Enabled' and select 'Disable' in the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24747r428809_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:567" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:567" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223087">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223087r428813_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223087r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI430-IE11</xccdf:version>
           <xccdf:title>Java permissions must be disallowed (Locked Down Local Machine zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Java applications could contain malicious code. This policy setting allows you to manage permissions for Java applets. If you enable this policy setting, options can be chosen from the drop-down box. Use of the Custom permission will control permissions settings individually. Use of the Low Safety permission enables applets to perform all operations. Use of the Medium Safety permission enables applets to run in their sandbox (an area in memory outside of which the program cannot make calls), plus adds capabilities like scratch space (a safe and secure storage area on the client computer) and a user-controlled file I/O. Use of the High Safety permission enables applets to run in their sandbox. If you disable this policy setting, Java applets cannot run. If you do not configure this policy setting, the permission is set to High Safety.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3754,14 +3744,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24748r428812_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_JavaPermissions_LockedDownLocalMachineZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:46900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:469" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:469" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223088">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223088r428816_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223088r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI435-IE11</xccdf:version>
           <xccdf:title>Java permissions must be disallowed (Locked Down Intranet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Java applications could contain malicious code. This policy setting allows you to manage permissions for Java applets. If you enable this policy setting, options can be chosen from the drop-down box. Use of the Custom permission will control permissions settings individually. Use of the Low Safety permission enables applets to perform all operations. Use of the Medium Safety permission enables applets to run in their sandbox (an area in memory outside of which the program cannot make calls), plus adds capabilities like scratch space (a safe and secure storage area on the client computer) and a user-controlled file I/O. Use of the High Safety permission enables applets to run in their sandbox. If you disable this policy setting, Java applets cannot run. If you do not configure this policy setting, the permission is set to High Safety.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3779,14 +3769,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24749r428815_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_JavaPermissions_LockedDownIntranetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:47000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:470" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:470" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223089">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223089r428819_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223089r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI440-IE11</xccdf:version>
           <xccdf:title>Java permissions must be disallowed (Locked Down Trusted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Java applications could contain malicious code; sites located in this security zone are more likely to be hosted by malicious individuals. This policy setting allows you to manage permissions for Java applets. If you enable this policy setting, options can be chosen from the drop-down box. Use of the Custom permission will control permissions settings individually. Use of the Low Safety permission enables applets to perform all operations. Use of the Medium Safety permission enables applets to run in their sandbox (an area in memory outside of which the program cannot make calls), plus adds capabilities like scratch space (a safe and secure storage area on the client computer) and a user-controlled file I/O. Use of the High Safety permission enables applets to run in their sandbox. If you disable this policy setting, Java applets cannot run. If you do not configure this policy setting, the permission is set to High Safety. &lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3804,14 +3794,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24750r428818_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_JavaPermissions_LockedDownTrustedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:47100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:471" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:471" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223090">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223090r428822_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223090r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI450-IE11</xccdf:version>
           <xccdf:title>Java permissions must be disallowed (Locked Down Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Java applications could contain malicious code. This policy setting allows you to manage permissions for Java applets. If you enable this policy setting, options can be chosen from the drop-down box. Use of the Custom permission will control permissions settings individually. Use of the Low Safety permission enables applets to perform all operations. Use of the Medium Safety permission enables applets to run in their sandbox (an area in memory outside of which the program cannot make calls), plus adds capabilities like scratch space (a safe and secure storage area on the client computer) and a user-controlled file I/O. Use of the High Safety permission enables applets to run in their sandbox. If you disable this policy setting, Java applets cannot run. If you do not configure this policy setting, the permission is set to High Safety. &lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3829,14 +3819,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24751r428821_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_JavaPermissions_LockedDownRestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:47300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:473" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:473" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223091">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223091r428825_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223091r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI455-IE11</xccdf:version>
           <xccdf:title>XAML files must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;These are eXtensible Application Markup Language (XAML) files. XAML is an XML-based declarative markup language commonly used for creating rich user interfaces and graphics that leverage the Windows Presentation Foundation. If you enable this policy setting and the drop-down box is set to Enable, XAML files will be automatically loaded inside Internet Explorer. Users will not be able to change this behavior. If the drop-down box is set to Prompt, users will receive a prompt for loading XAML files. If you disable this policy setting, XAML files will not be loaded inside Internet Explorer. Users will not be able to change this behavior. If you do not configure this policy setting, users will have the freedom to decide whether to load XAML files inside Internet Explorer.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3854,14 +3844,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24752r428824_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_LooseXAMLFiles_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:47400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:474" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:474" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223092">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223092r428828_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223092r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI460-IE11</xccdf:version>
           <xccdf:title>XAML files must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;These are eXtensible Application Markup Language (XAML) files. XAML is an XML-based declarative markup language commonly used for creating rich user interfaces and graphics that leverage the Windows Presentation Foundation. If you enable this policy setting and the drop-down box is set to Enable, XAML files will be automatically loaded inside Internet Explorer. Users will not be able to change this behavior. If the drop-down box is set to Prompt, users will receive a prompt for loading XAML files. If you disable this policy setting, XAML files will not be loaded inside Internet Explorer. Users will not be able to change this behavior. If you do not configure this policy setting, users will have the freedom to decide whether to load XAML files inside Internet Explorer.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3879,14 +3869,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24753r428827_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_LooseXAMLFiles_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:47500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:475" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:475" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223093">
         <xccdf:title>SRG-APP-000233</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223093r428831_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223093r879643_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI485-IE11</xccdf:version>
           <xccdf:title>Protected Mode must be enforced (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Protected Mode protects Internet Explorer from exploited vulnerabilities by reducing the locations Internet Explorer can write to in the registry and the file system. If you enable this policy setting, Protected Mode will be turned on. Users will not be able to turn off Protected Mode. If you disable this policy setting, Protected Mode will be turned off. It will revert to Internet Explorer 6 behavior that allows for Internet Explorer to write to the registry and the file system. Users will not be able to turn on Protected Mode. If you do not configure this policy, users will be able to turn on or off Protected Mode.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3904,14 +3894,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24754r428830_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_TurnOnProtectedMode_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:48000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:480" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:480" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223094">
         <xccdf:title>SRG-APP-000233</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223094r428834_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223094r879643_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI490-IE11</xccdf:version>
           <xccdf:title>Protected Mode must be enforced (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Protected Mode protects Internet Explorer from exploited vulnerabilities by reducing the locations Internet Explorer can write to in the registry and the file system. If you enable this policy setting, Protected Mode will be turned on. Users will not be able to turn off Protected Mode. If you disable this policy setting, Protected Mode will be turned off. It will revert to Internet Explorer 6 behavior that allows for Internet Explorer to write to the registry and the file system. Users will not be able to turn on Protected Mode. If you do not configure this policy, users will be able to turn on or off Protected Mode.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3929,14 +3919,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24755r428833_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_TurnOnProtectedMode_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:48100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:481" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:481" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223095">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223095r428837_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223095r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI495-IE11</xccdf:version>
           <xccdf:title>Pop-up Blocker must be enforced (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether unwanted pop-up windows appear. Pop-up windows that are opened when the end user clicks a link are not blocked. If you enable this policy setting, most unwanted pop-up windows are prevented from appearing. If you disable this policy setting, pop-up windows are not prevented from appearing. If you do not configure this policy setting, most unwanted pop-up windows are prevented from appearing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3954,14 +3944,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24756r428836_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_UsePop-upBlocker_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:48200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:482" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:482" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223096">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223096r428840_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223096r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI500-IE11</xccdf:version>
           <xccdf:title>Pop-up Blocker must be enforced (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether unwanted pop-up windows appear. Pop-up windows that are opened when the end user clicks a link are not blocked. If you enable this policy setting, most unwanted pop-up windows are prevented from appearing. If you disable this policy setting, pop-up windows are not prevented from appearing. If you do not configure this policy setting, most unwanted pop-up windows are prevented from appearing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3979,14 +3969,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24757r428839_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_UsePop-upBlocker_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:48300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:483" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:483" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223097">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223097r428843_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223097r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI515-IE11</xccdf:version>
           <xccdf:title>Websites in less privileged web content zones must be prevented from navigating into the Internet zone.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows a user to manage whether websites from less privileged zones, such as Restricted Sites, can navigate into the Internet zone. If this policy setting is enabled, websites from less privileged zones can open new windows in, or navigate into, this zone. The security zone will run without the added layer of security that is provided by the Protection from Zone Elevation security feature. If "Prompt" is selected in the drop-down box, a warning is issued to the user that potentially risky navigation is about to occur. If this policy setting is disabled, the potentially risky navigation is prevented. The Internet Explorer security feature will be on in this zone as set by the Protection from Zone Elevation feature control. If this policy setting is not configured, websites from less privileged zones can open new windows in, or navigate into, this zone.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4004,14 +3994,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24758r428842_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_WebSitesInLessPrivilegedWebContentZonesCanNavigateIntoThisZone_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:48400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:484" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:484" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223098">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223098r428846_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223098r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI520-IE11</xccdf:version>
           <xccdf:title>Websites in less privileged web content zones must be prevented from navigating into the Restricted Sites zone.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether websites from less privileged zones, such as Restricted Sites, can navigate into the Restricted zone. If this policy setting is enabled, websites from less privileged zones can open new windows in, or navigate into, this zone. The security zone will run without the added layer of security that is provided by the Protection from Zone Elevation security feature. If Prompt is selected in the drop-down box, a warning is issued to the user that potentially risky navigation is about to occur. If this policy setting is disabled, the potentially risky navigation is prevented. The Internet Explorer security feature will be on in this zone as set by the Protection from Zone Elevation feature control. If this policy setting is not configured, websites from less privileged zones can open new windows in, or navigate into, this zone.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4029,14 +4019,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24759r428845_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_WebSitesInLessPrivilegedWebContentZonesCanNavigateIntoThisZone_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:48500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:485" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:485" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223099">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223099r428849_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223099r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI575-IE11</xccdf:version>
           <xccdf:title>Allow binary and script behaviors must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage dynamic binary and script behaviors of components that encapsulate specific functionality for HTML elements, to which they were attached. If you enable this policy setting, binary and script behaviors are available.   If you select "Administrator approved" in the drop-down box, only the behaviors listed in the Admin-approved Behaviors under Binary Behaviors Security Restriction policy are available.    If you disable this policy setting, binary and script behaviors are not available unless applications have implemented a custom security manager. If you do not configure this policy setting, binary and script behaviors are available.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4054,14 +4044,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24760r428848_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowBinaryAndScriptBehaviors_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:48600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:486" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:486" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223100">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223100r428852_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223100r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI580-IE11</xccdf:version>
           <xccdf:title>Automatic prompting for file downloads must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether users will be prompted for non user-initiated file downloads. Regardless of this setting, users will receive file download dialogs for user-initiated downloads. Users may accept downloads that they did not request, and those downloaded files may include malicious code. If you enable this setting, users will receive a file download dialog for automatic download attempts. If you disable or do not configure this setting, file downloads that are not user-initiated will be blocked, and users will see the information bar instead of the file download dialog. Users can then click the information bar to allow the file download prompt.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4078,14 +4068,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24761r428851_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Security Page -&gt; Restricted Sites Zone -&gt; 'Automatic prompting for file downloads' to 'Enabled', and select 'Disable' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24761r428851_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:487" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:487" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223101">
         <xccdf:title>SRG-APP-000206</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223101r428855_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223101r879627_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI590-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for MIME handling must be enforced. (Reserved)</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer uses Multipurpose Internet Mail Extensions (MIME) data to determine file handling procedures for files received through a web server. The Consistent MIME Handling\Internet Explorer Processes policy setting determines whether Internet Explorer requires all file-type information provided by web servers to be consistent. For example, if the MIME type of a file is text/plain but the MIME data indicates the file is really an executable file, Internet Explorer changes its extension to reflect this executable status. This capability helps ensure executable code cannot masquerade as other types of data that may be trusted. If you enable this policy setting, Internet Explorer examines all received files and enforces consistent MIME data for them. If you disable or do not configure this policy setting, Internet Explorer does not require consistent MIME data for all received files and will use the MIME data provided by the file. MIME file-type spoofing is a potential threat to an organization. Ensuring these files are consistent and properly labeled helps prevent malicious file downloads from infecting your network.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4102,14 +4092,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24762r428854_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Consistent Mime Handling -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24762r428854_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:488" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:488" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223102">
         <xccdf:title>SRG-APP-000206</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223102r428858_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223102r879627_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI592-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for MIME handling must be enforced (Explorer).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer uses Multipurpose Internet Mail Extensions (MIME) data to determine file handling procedures for files received through a web server. The Consistent MIME Handling\Internet Explorer Processes policy setting determines whether Internet Explorer requires all file-type information provided by web servers to be consistent. For example, if the MIME type of a file is text/plain but the MIME data indicates the file is really an executable file, Internet Explorer changes its extension to reflect this executable status. This capability helps ensure executable code cannot masquerade as other types of data that may be trusted. If you enable this policy setting, Internet Explorer examines all received files and enforces consistent MIME data for them. If you disable or do not configure this policy setting, Internet Explorer does not require consistent MIME data for all received files and will use the MIME data provided by the file. MIME file-type spoofing is a potential threat to the organization. Ensuring these files are consistent and properly labeled helps prevent malicious file downloads from infecting the network. This guide recommends configuring this policy as "Enabled" for all environments specified in this guide.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4126,14 +4116,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24763r428857_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Consistent Mime Handling -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24763r428857_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:502" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:502" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223103">
         <xccdf:title>SRG-APP-000206</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223103r428861_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223103r879627_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI594-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for MIME handling must be enforced (iexplore).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer uses Multipurpose Internet Mail Extensions (MIME) data to determine file handling procedures for files received through a web server. The Consistent MIME Handling\Internet Explorer Processes policy setting determines whether Internet Explorer requires all file-type information provided by web servers to be consistent. For example, if the MIME type of a file is text/plain but the MIME data indicates that the file is really an executable file, Internet Explorer changes its extension to reflect this executable status. This capability helps ensure that executable code cannot masquerade as other types of data that may be trusted. If you enable this policy setting, Internet Explorer examines all received files and enforces consistent MIME data for them. If you disable or do not configure this policy setting, Internet Explorer does not require consistent MIME data for all received files and will use the MIME data provided by the file. MIME file-type spoofing is a potential threat to an organization. Ensuring these files are consistent and properly labeled helps prevent malicious file downloads from infecting the network. This guide recommends configuring this policy as "Enabled" for all environments specified in this guide.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4150,14 +4140,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24764r428860_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Consistent Mime Handling -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24764r428860_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:503" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:503" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223104">
         <xccdf:title>SRG-APP-000206</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223104r428864_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223104r879627_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI595-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for MIME sniffing must be enforced (Reserved).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;MIME sniffing is the process of examining the content of a MIME file to determine its context - whether it is a data file, an executable file, or some other type of file. This policy setting determines whether Internet Explorer MIME sniffing will prevent promotion of a file of one type to a more dangerous file type. When set to "Enabled", MIME sniffing will never promote a file of one type to a more dangerous file type. Disabling MIME sniffing configures Internet Explorer processes to allow a MIME sniff that promotes a file of one type to a more dangerous file type. For example, promoting a text file to an executable file is a dangerous promotion because any code in the supposed text file would be executed. MIME file-type spoofing is a potential threat to an organization. Ensuring these files are consistently handled helps prevent malicious file downloads from infecting the network. This guide recommends you configure this policy as "Enabled" for all environments specified in this guide. Note: This setting works in conjunction with, but does not replace, the Consistent MIME Handling settings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4174,14 +4164,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24765r428863_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Mime Sniffing Safety Feature -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24765r428863_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:489" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:489" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223105">
         <xccdf:title>SRG-APP-000206</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223105r428867_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223105r879627_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI596-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for MIME sniffing must be enforced (Explorer).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;MIME sniffing is the process of examining the content of a MIME file to determine its context - whether it is a data file, an executable file, or some other type of file. This policy setting determines whether Internet Explorer MIME sniffing will prevent promotion of a file of one type to a more dangerous file type. When set to "Enabled", MIME sniffing will never promote a file of one type to a more dangerous file type. Disabling MIME sniffing configures Internet Explorer processes to allow a MIME sniff that promotes a file of one type to a more dangerous file type. For example, promoting a text file to an executable file is a dangerous promotion because any code in the supposed text file would be executed. MIME file-type spoofing is a potential threat to an organization. Ensuring these files are consistently handled helps prevent malicious file downloads from infecting the network. This guide recommends configuring this policy as "Enabled" for all environments specified in this guide. Note: This setting works in conjunction with, but does not replace, the Consistent MIME Handling settings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4198,14 +4188,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24766r428866_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Mime Sniffing Safety Feature -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24766r428866_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:510" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:510" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223106">
         <xccdf:title>SRG-APP-000206</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223106r428870_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223106r879627_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI597-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for MIME sniffing must be enforced (iexplore).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;MIME sniffing is the process of examining the content of a MIME file to determine its context - whether it is a data file, an executable file, or some other type of file. This policy setting determines whether Internet Explorer MIME sniffing will prevent promotion of a file of one type to a more dangerous file type. When set to "Enabled", MIME sniffing will never promote a file of one type to a more dangerous file type. Disabling MIME sniffing configures Internet Explorer processes to allow a MIME sniff that promotes a file of one type to a more dangerous file type. For example, promoting a text file to an executable file is a dangerous promotion because any code in the supposed text file would be executed. MIME file-type spoofing is a potential threat to an organization. Ensuring these files are consistently handled helps prevent malicious file downloads from infecting the network. This guide recommends configuring this policy as "Enabled" for all environments specified in this guide. Note: This setting works in conjunction with, but does not replace, the Consistent MIME Handling settings.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4222,14 +4212,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24767r428869_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Mime Sniffing Safety Feature -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24767r428869_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:511" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:511" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223107">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223107r428873_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223107r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI599-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for MK protocol must be enforced (Reserved).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The MK Protocol Security Restriction policy setting reduces attack surface area by blocking the seldom used MK protocol. Some older web applications use the MK protocol to retrieve information from compressed files. Because the MK protocol is not widely used, it should be blocked wherever it is not needed. Setting this policy to "Enabled"; blocks the MK protocol for Windows Explorer and Internet Explorer, which causes resources that use the MK protocol to fail. Disabling this setting allows applications to use the MK protocol API. This guide recommends configuring this setting to "Enabled" to block the MK protocol unless it is specifically needed in the environment. Note: Because resources that use the MK protocol will fail when deploying this setting, ensure none of the applications use the MK protocol.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4246,14 +4236,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24768r428872_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; MK Protocol Security Restriction -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24768r428872_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:504" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:504" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223108">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223108r428876_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223108r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI600-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for MK protocol must be enforced (Explorer).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The MK Protocol Security Restriction policy setting reduces attack surface area by blocking the seldom used MK protocol. Some older web applications use the MK protocol to retrieve information from compressed files. Because the MK protocol is not widely used, it should be blocked wherever it is not needed. Setting this policy to "Enabled"; blocks the MK protocol for Windows Explorer and Internet Explorer, which causes resources that use the MK protocol to fail. Disabling this setting allows applications to use the MK protocol API. This guide recommends you configure this setting to "Enabled" to block the MK protocol unless it is specifically needed in the environment. Note: Because resources that use the MK protocol will fail when deploying this setting, ensure none of the applications use the MK protocol.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4270,14 +4260,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24769r428875_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; MK Protocol Security Restriction -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24769r428875_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:490" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:490" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223109">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223109r428879_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223109r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI605-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for MK protocol must be enforced (iexplore).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The MK Protocol Security Restriction policy setting reduces attack surface area by blocking the seldom used MK protocol. Some older web applications use the MK protocol to retrieve information from compressed files. Because the MK protocol is not widely used, it should be blocked wherever it is not needed. Setting this policy to "Enabled"; blocks the MK protocol for Windows Explorer and Internet Explorer, which causes resources that use the MK protocol to fail. Disabling this setting allows applications to use the MK protocol API. This guide recommends you configure this setting to "Enabled" to block the MK protocol unless specifically needed in the environment. Note: Because resources that use the MK protocol will fail when deploying this setting, ensure none of the applications use the MK protocol.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4294,14 +4284,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24770r428878_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; MK Protocol Security Restriction -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24770r428878_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:491" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:491" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223110">
         <xccdf:title>SRG-APP-000233</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223110r428882_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223110r879643_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI610-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for Zone Elevation must be enforced (Reserved).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer places restrictions on each web page it opens that are dependent upon the location of the web page (such as Internet Zone, Intranet Zone, or Local Machine Zone). Web pages on a local computer have the fewest security restrictions and reside in the Local Machine Zone, which makes the Local Machine Security Zone a prime target for malicious attackers. If you enable this policy setting, any zone can be protected from zone elevation by Internet Explorer processes. This approach stops content running in one zone from gaining the elevated privileges of another zone. If you disable this policy setting, no zone receives such protection from Internet Explorer processes. Because of the severity and relative frequency of zone elevation attacks, this guide recommends that you configure this setting as "Enabled" in all environments.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4318,14 +4308,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24771r428881_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Protection From Zone Elevation -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24771r428881_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:492" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:492" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223111">
         <xccdf:title>SRG-APP-000233</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223111r428885_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223111r879643_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI612-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for Zone Elevation must be enforced (Explorer).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer places restrictions on each web page it opens that are dependent upon the location of the web page (such as Internet Zone, Intranet Zone, or Local Machine Zone). Web pages on a local computer have the fewest security restrictions and reside in the Local Machine Zone, which makes the Local Machine Security Zone a prime target for malicious attackers. If you enable this policy setting, any zone can be protected from zone elevation by Internet Explorer processes. This approach stops content running in one zone from gaining the elevated privileges of another zone. If you disable this policy setting, no zone receives such protection from Internet Explorer processes. Because of the severity and relative frequency of zone elevation attacks, this guide recommends configuring this setting as "Enabled" in all environments.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4342,14 +4332,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24772r428884_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Protection From Zone Elevation -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24772r428884_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:505" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:505" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223112">
         <xccdf:title>SRG-APP-000233</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223112r428888_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223112r879643_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI614-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for Zone Elevation must be enforced (iexplore).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer places restrictions on each web page it opens that are dependent upon the location of the web page (such as Internet Zone, Intranet Zone, or Local Machine Zone). Web pages on a local computer have the fewest security restrictions and reside in the Local Machine Zone, which makes the Local Machine Security Zone a prime target for malicious attackers. If you enable this policy setting, any zone can be protected from zone elevation by Internet Explorer processes. This approach stops content running in one zone from gaining the elevated privileges of another zone. If you disable this policy setting, no zone receives such protection from Internet Explorer processes. Because of the severity and relative frequency of zone elevation attacks, this guide recommends that you configure this setting as "Enabled" in all environments.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4366,14 +4356,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24773r428887_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Protection From Zone Elevation -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24773r428887_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:506" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:506" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223113">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223113r428891_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223113r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI630-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for Restrict File Download must be enforced (Reserved).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;In certain circumstances, websites can initiate file download prompts without interaction from users. This technique can allow websites to put unauthorized files on users' hard drives if they click the wrong button and accept the download. If you configure the Restrict File Download\Internet Explorer Processes policy setting to "Enabled", file download prompts that are not user-initiated are blocked for Internet Explorer processes. If you configure this policy setting as "Disabled", prompting will occur for file downloads that are not user-initiated for Internet Explorer processes. Note: This setting is configured as "Enabled" in all environments specified in this guide to help prevent attackers from placing arbitrary code on users' computers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4390,14 +4380,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24774r428890_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Restrict File Download -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24774r428890_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:493" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:493" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223114">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223114r428894_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223114r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI635-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for Restrict File Download must be enforced (Explorer).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;In certain circumstances, websites can initiate file download prompts without interaction from users. This technique can allow websites to put unauthorized files on users' hard drives if they click the wrong button and accept the download. If you configure the Restrict File Download\Internet Explorer Processes policy setting to "Enabled", file download prompts that are not user-initiated are blocked for Internet Explorer processes. If you configure this policy setting as "Disabled", prompting will occur for file downloads that are not user-initiated for Internet Explorer processes. Note: This setting is configured as "Enabled" in all environments specified in this guide to help prevent attackers from placing arbitrary code on users' computers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4414,14 +4404,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24775r428893_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Restrict File Download -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24775r428893_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:494" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:494" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223115">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223115r428897_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223115r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI640-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for Restrict File Download must be enforced (iexplore).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;In certain circumstances, websites can initiate file download prompts without interaction from users. This technique can allow websites to put unauthorized files on users' hard drives if they click the wrong button and accept the download. If you configure the Restrict File Download\Internet Explorer Processes policy setting to "Enabled", file download prompts that are not user-initiated are blocked for Internet Explorer processes. If you configure this policy setting as "Disabled", prompting will occur for file downloads that are not user-initiated for Internet Explorer processes. Note: This setting is configured as "Enabled" in all environments specified in this guide to help prevent attackers from placing arbitrary code on users' computers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4438,14 +4428,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24776r428896_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Restrict File Download -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24776r428896_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:495" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:495" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223116">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223116r428900_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223116r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI645-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for restricting pop-up windows must be enforced (Reserved).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer allows scripts to programmatically open, resize, and reposition various types of windows. Often, disreputable websites will resize windows to either hide other windows or force the user to interact with a window containing malicious code. The Scripted Window Security Restrictions security feature restricts pop-up windows and prohibits scripts from displaying windows in which the title and status bars are not visible to the user, or which hide other windows' title and status bars. If you enable the Scripted Window Security Restrictions\Internet Explorer Processes policy setting, pop-up windows and other restrictions apply for Windows Explorer and Internet Explorer processes. If you disable or do not configure this policy setting, scripts can continue to create pop-up windows, and create windows that hide other windows. Recommend configuring this setting to "Enabled" to help prevent malicious websites from controlling the Internet Explorer windows or fooling users into clicking on the wrong window.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4462,14 +4452,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24777r428899_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Scripted Window Security Restrictions -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24777r428899_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:496" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:496" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223117">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223117r428903_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223117r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI647-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for restricting pop-up windows must be enforced (Explorer).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer allows scripts to programmatically open, resize, and reposition various types of windows. Often, disreputable websites will resize windows to either hide other windows or force a user to interact with a window that contains malicious code. The Scripted Window Security Restrictions security feature restricts pop-up windows and prohibits scripts from displaying windows in which the title and status bars are not visible to the user, or which hide other windows' title and status bars. If you enable the Scripted Window Security Restrictions\Internet Explorer Processes policy setting, pop-up windows and other restrictions apply for Windows Explorer and Internet Explorer processes. If you disable or do not configure this policy setting, scripts can continue to create pop-up windows and create windows that hide other windows. This guide recommends configuring this setting to "Enabled" to help prevent malicious websites from controlling the Internet Explorer windows or fooling users into clicking on the wrong window.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4486,14 +4476,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24778r428902_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Scripted Window Security Restrictions -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24778r428902_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:507" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:507" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223118">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223118r428906_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223118r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI649-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for restricting pop-up windows must be enforced (iexplore).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer allows scripts to programmatically open, resize, and reposition various types of windows. Often, disreputable websites will resize windows to either hide other windows or force a user to interact with a window that contains malicious code. The Scripted Window Security Restrictions security feature restricts pop-up windows and prohibits scripts from displaying windows in which the title and status bars are not visible to the user, or which hide other windows' title and status bars. If you enable the Scripted Window Security Restrictions\Internet Explorer Processes policy setting, pop-up windows and other restrictions apply for Windows Explorer and Internet Explorer processes. If you disable or do not configure this policy setting, scripts can continue to create pop-up windows and create windows that hide other windows. This guide recommends configuring this setting to "Enabled" to help prevent malicious websites from controlling the Internet Explorer windows or fooling users into clicking on the wrong window.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4510,14 +4500,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fixtext fixref="F-24779r428905_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Scripted Window Security Restrictions -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24779r428905_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:508" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:508" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223119">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223119r428909_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223119r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI650-IE11</xccdf:version>
           <xccdf:title>.NET Framework-reliant components not signed with Authenticode must be disallowed to run (Restricted Sites Zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether .NET Framework-reliant components that are not signed with Authenticode can be executed from Internet Explorer. These components include managed controls referenced from an object tag and managed executables referenced from a link. If you enable this policy setting, Internet Explorer will execute unsigned managed components. If you select "Prompt" in the drop-down box, Internet Explorer will prompt the user to determine whether to execute unsigned managed components. If you disable this policy setting, Internet Explorer will not execute unsigned managed components. If you do not configure this policy setting, Internet Explorer will execute unsigned managed components.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4535,14 +4525,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24780r428908_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_RunNETFrameworkReliantComponentsNotSignedWithAuthenticode_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:49700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:497" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:497" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223120">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223120r428912_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223120r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI655-IE11</xccdf:version>
           <xccdf:title>.NET Framework-reliant components signed with Authenticode must be disallowed to run (Restricted Sites Zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether .NET Framework-reliant components that are signed with Authenticode can be executed from Internet Explorer. It may be possible for malicious content hosted on a website to take advantage of these components. These components include managed controls referenced from an object tag and managed executables referenced from a link. If you enable this policy setting, Internet Explorer will execute signed managed components. If you select "Prompt" in the drop-down box, Internet Explorer will prompt the user to determine whether to execute signed managed components. If you disable this policy setting, Internet Explorer will not execute signed managed components. If you do not configure this policy setting, Internet Explorer will execute signed managed components.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4560,14 +4550,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24781r428911_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_RunNETFrameworkReliantComponentsSignedWithAuthenticode_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:49800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:498" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:498" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223121">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223121r428915_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223121r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI670-IE11</xccdf:version>
           <xccdf:title>Scripting of Java applets must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether applets are exposed to scripts within the zone. If you enable this policy setting, scripts can access applets automatically without user intervention. If you select "Prompt" in the drop-down box, users are queried to choose whether to allow scripts to access applets. If you disable this policy setting, scripts are prevented from accessing applets. If you do not configure this policy setting, scripts can access applets automatically without user intervention. &lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4585,14 +4575,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24782r428914_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ScriptingOfJavaApplets_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:49900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:499" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:499" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223123">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223123r428921_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223123r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI715-IE11</xccdf:version>
           <xccdf:title>Crash Detection management must be enforced.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The 'Turn off Crash Detection' policy setting allows you to manage the crash detection feature of add-on management in Internet Explorer. A crash report could contain sensitive information from the computer's memory. If you enable this policy setting, a crash in Internet Explorer will be similar to one on a computer running Windows XP Professional Service Pack 1 and earlier, where Windows Error Reporting will be invoked. If you disable this policy setting, the crash detection feature in add-on management will be functional. &lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4610,14 +4600,14 @@ Satisfies: SRG-APP-000605&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/False
           <xccdf:fix id="F-24784r428920_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_TurnOffCrashDetection_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:50900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:509" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:509" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223125">
         <xccdf:title>SRG-APP-000206</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223125r428927_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223125r879627_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI740-IE11</xccdf:version>
           <xccdf:title>Managing SmartScreen Filter use must be enforced.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting is important from a security perspective because Microsoft has extensive data illustrating the positive impact the SmartScreen filter has had on reducing the risk of malware infection via visiting malicious websites. This policy setting allows users to enable the SmartScreen Filter, which will warn if the website being visited is known for fraudulent attempts to gather personal information through 'phishing' or is known to host malware. If you enable this setting the user will not be prompted to enable the SmartScreen Filter. It must be specified which mode the SmartScreen Filter uses: On or Off. If the feature is On, all website addresses not contained on the filters allow list, will be sent automatically to Microsoft without prompting the user. If this feature is set to Off, the feature will not run. If you disable or do not configure this policy setting, the user is prompted to decide whether to turn on SmartScreen Filter during the first-run experience.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4637,14 +4627,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24786r428926_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_TurnoffManagingSmartScreenFilter_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:51400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:514" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:514" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223126">
         <xccdf:title>SRG-APP-000089</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223126r428930_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223126r879559_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI760-IE11</xccdf:version>
           <xccdf:title>Browser must retain history on exit.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Delete Browsing History on exit automatically deletes specified items when the last browser window closes.  Disabling this function will prevent users from deleting their browsing history, which could be used to identify malicious websites and files that could later be used for anti-virus and Intrusion Detection System (IDS) signatures.  Furthermore, preventing users from deleting browsing history could be used to identify abusive web surfing on government systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4662,14 +4652,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24787r428929_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ConfigureDeleteBrowsingHistoryonexit_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:51600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:516" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:516" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223127">
         <xccdf:title>SRG-APP-000089</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223127r428933_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223127r879559_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI770-IE11</xccdf:version>
           <xccdf:title>Deleting websites that the user has visited must be disallowed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy prevents users from deleting the history of websites the user has visited. If you enable this policy setting, websites the user has visited will be preserved when the user clicks "Delete". If you disable this policy setting, websites that the user has visited will be deleted when the user clicks "Delete". If you do not configure this policy setting, the user will be able to select whether to delete or preserve websites the user visited when the user clicks "Delete".&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4687,14 +4677,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24788r428932_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_PreventDeletingWebsitesthattheUserhasVisited_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:51700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:517" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:517" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223128">
         <xccdf:title>SRG-APP-000080</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223128r428936_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223128r879554_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI780-IE11</xccdf:version>
           <xccdf:title>InPrivate Browsing must be disallowed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;InPrivate Browsing lets the user control whether or not Internet Explorer saves the browsing history, cookies, and other data. User control of settings is not the preferred control method. The InPrivate Browsing feature in Internet Explorer makes browser privacy easy by not storing history, cookies, temporary Internet files, or other data. If you enable this policy setting, InPrivate Browsing will be disabled. If you disable this policy setting, InPrivate Browsing will be available for use. If you do not configure this setting, InPrivate Browsing can be turned on or off through the registry.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4712,14 +4702,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24789r428935_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_TurnOffInPrivateBrowsing_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:51800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:518" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:518" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223129">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223129r428939_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223129r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI800-IE11</xccdf:version>
           <xccdf:title>Scripting of Internet Explorer WebBrowser control property must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether a page may control embedded WebBrowser control via script. Scripted code hosted on sites located in this zone is more likely to contain malicious code. If you enable this policy setting, script access to the WebBrowser control is allowed. If you disable this policy setting, script access to the WebBrowser control is not allowed. If you do not configure this policy setting, script access to the WebBrowser control can be enabled or disabled by the user. By default, script access to the WebBrowser control is only allowed in the Local Machine and Intranet Zones.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4737,14 +4727,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24790r428938_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowScriptingOfInternetExplorerWebBrowserControl_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:51900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:519" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:519" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223130">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223130r428942_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223130r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI810-IE11</xccdf:version>
           <xccdf:title>When uploading files to a server, the local directory path must be excluded (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether or not the local path information will be sent when uploading a file via a HTML form. If the local path information is sent, some information may be unintentionally revealed to the server. If you do not configure this policy setting, the user can choose whether path information will be sent when uploading a file via a form. By default, path information will be sent.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4762,14 +4752,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24791r428941_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_IncludeLocalDirectoryPathWhenUploadingFilesToAServer_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:52000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:520" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:520" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223131">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223131r428945_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223131r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI815-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for Notification Bars must be enforced (Reserved).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether the Notification Bar is displayed for Internet Explorer processes when file or code installs are restricted. By default, the Notification Bar is displayed for Internet Explorer processes. If you enable this policy setting, the Notification Bar will be displayed for Internet Explorer processes. If you disable this policy setting, the Notification Bar will not be displayed for Internet Explorer processes. If you do not configure this policy setting, the Notification Bar will be displayed for Internet Explorer processes.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4786,14 +4776,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24792r428944_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features-&gt; Notification Bar-&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24792r428944_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:541" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:541" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223132">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223132r428948_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223132r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI820-IE11</xccdf:version>
           <xccdf:title>Security Warning for unsafe files must be set to prompt (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether or not the 'Open File - Security Warning' message appears when the user tries to open executable files or other potentially unsafe files (from an intranet file shared by using Windows Explorer, for example). If you enable this policy setting and set the drop-down box to "Enable", these files open without a security warning. If you set the drop-down box to " Prompt", a security warning appears before the files open. If you disable this policy these files do not open. If you do not configure this policy setting, the user can configure how the computer handles these files.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4811,14 +4801,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24793r428947_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_LaunchingProgramsAndUnsafeFiles_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:52100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:521" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:521" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223133">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223133r428951_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223133r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI825-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for Notification Bars must be enforced (Explorer).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether the Notification Bar is displayed for Internet Explorer processes when file or code installs are restricted. By default, the Notification Bar is displayed for Internet Explorer processes. If you enable this policy setting, the Notification Bar will be displayed for Internet Explorer processes. If you disable this policy setting, the Notification Bar will not be displayed for Internet Explorer processes. If you do not configure this policy setting, the Notification Bar will be displayed for Internet Explorer processes.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4835,14 +4825,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24794r428950_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features-&gt; Notification Bar-&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24794r428950_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:542" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:542" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223134">
         <xccdf:title>SRG-APP-000210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223134r428954_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223134r879630_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI830-IE11</xccdf:version>
           <xccdf:title>ActiveX controls without prompt property must be used in approved domains only (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether or not the user is prompted to allow ActiveX controls to run on websites other than the website that installed the ActiveX control. If the user were to disable the setting for the zone, malicious ActiveX controls could be executed without the user's knowledge. Disabling this setting would allow the possibility for malicious ActiveX controls to be executed from non-approved domains within this zone without the user's knowledge. Enabling this setting enforces the default value and prohibits the user from changing the value. Websites should be moved into another zone if permissions need to be changed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4860,14 +4850,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24795r428953_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_OnlyAllowApprovedDomainsToUseActiveXControlsWithoutPrompt_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:52200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:522" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:522" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223135">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223135r428957_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223135r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI835-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes for Notification Bars must be enforced (iexplore).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether the Notification Bar is displayed for Internet Explorer processes when file or code installs are restricted. By default, the Notification Bar is displayed for Internet Explorer processes. If you enable this policy setting, the Notification Bar will be displayed for Internet Explorer processes. If you disable this policy setting, the Notification Bar will not be displayed for Internet Explorer processes. If you do not configure this policy setting, the Notification Bar will be displayed for Internet Explorer processes.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4884,14 +4874,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24796r428956_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features-&gt; Notification Bar-&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24796r428956_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:543" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:543" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223136">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223136r428960_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223136r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI840-IE11</xccdf:version>
           <xccdf:title>Cross-Site Scripting Filter must be enforced (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The Cross-Site Scripting Filter is designed to prevent users from becoming victims of unintentional information disclosure. This setting controls if the Cross-Site Scripting (XSS) Filter detects and prevents cross-site script injection into websites in this zone. If you enable this policy setting, the XSS Filter will be enabled for sites in this zone, and the XSS Filter will attempt to block cross-site script injections. If you disable this policy setting, the XSS Filter will be disabled for sites in this zone, and Internet Explorer will permit cross-site script injections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4908,14 +4898,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24797r428959_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Security Page -&gt; Internet Zone -&gt; 'Turn on Cross-Site Scripting Filter' to 'Enabled', and select 'Enable' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24797r428959_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:523" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:523" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223137">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223137r428963_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223137r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI850-IE11</xccdf:version>
           <xccdf:title>Scripting of Internet Explorer WebBrowser Control must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether a page may control embedded WebBrowser Control via script. Scripted code hosted on sites located in this zone is more likely to contain malicious code. If you enable this policy setting, script access to the WebBrowser Control is allowed. If you disable this policy setting, script access to the WebBrowser Control is not allowed. If you do not configure this policy setting, script access to the WebBrowser Control can be enabled or disabled by the user. By default, script access to the WebBrowser Control is only allowed in the Local Machine and Intranet Zones.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4933,14 +4923,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24798r428962_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowScriptingOfInternetExplorerWebBrowserControl_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:52400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:524" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:524" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223138">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223138r428966_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223138r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI860-IE11</xccdf:version>
           <xccdf:title>When uploading files to a server, the local directory path must be excluded (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether or not the local path information will be sent when uploading a file via a HTML form. If the local path information is sent, some information may be unintentionally revealed to the server. If you do not configure this policy setting, the user can choose whether path information will be sent when uploading a file via a form. By default, path information will be sent.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4958,14 +4948,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24799r428965_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_IncludeLocalDirectoryPathWhenUploadingFilesToAServer_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:52500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:525" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:525" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223139">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223139r428969_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223139r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI870-IE11</xccdf:version>
           <xccdf:title>Security Warning for unsafe files must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether or not the 'Open File - Security Warning' message appears when the user tries to open executable files or other potentially unsafe files (from an intranet file shared by using Windows Explorer, for example). If you enable this policy setting and set the drop-down box to "Enable", these files open without a security warning. If you set the drop-down box to "Prompt", a security warning appears before the files open. If you disable this policy these files do not open. If you do not configure this policy setting, the user can configure how the computer handles these files.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4983,14 +4973,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24800r428968_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_LaunchingProgramsAndUnsafeFiles_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:52600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:526" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:526" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223140">
         <xccdf:title>SRG-APP-000210</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223140r428972_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223140r879630_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI880-IE11</xccdf:version>
           <xccdf:title>ActiveX controls without prompt property must be used in approved domains only (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting controls whether or not the user is prompted to allow ActiveX controls to run on websites other than the website that installed the ActiveX control. If the user were to disable the setting for the zone, malicious ActiveX controls could be executed without the user's knowledge. Disabling this setting would allow the possibility for malicious ActiveX controls to be executed from non-approved domains within this zone without the user's knowledge. Enabling this setting enforces the default value and prohibits the user from changing the value. Websites should be moved into another zone if permissions need to be changed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5008,14 +4998,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24801r428971_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_OnlyAllowApprovedDomainsToUseActiveXControlsWithoutPrompt_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:52700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:527" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:527" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223141">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223141r428975_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223141r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI890-IE11</xccdf:version>
           <xccdf:title>Cross-Site Scripting Filter property must be enforced (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The Cross-Site Scripting Filter is designed to prevent users from becoming victims of unintentional information disclosure. This setting controls if the Cross-Site Scripting (XSS) Filter detects and prevents cross-site script injection into websites in this zone. If you enable this policy setting, the XSS Filter will be enabled for sites in this zone, and the XSS Filter will attempt to block cross-site script injections. If you disable this policy setting, the XSS Filter will be disabled for sites in this zone, and Internet Explorer will permit cross-site script injections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5033,14 +5023,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24802r428974_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_TurnonCrossSiteScriptingFilter_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:52800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:528" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:528" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223142">
         <xccdf:title>SRG-APP-000112</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223142r428978_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223142r879573_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI900-IE11</xccdf:version>
           <xccdf:title>Internet Explorer Processes Restrict ActiveX Install must be enforced (Reserved).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Users often choose to install software such as ActiveX controls that are not permitted by their organization's security policy. Such software can pose significant security and privacy risks to networks. This policy setting enables blocking of ActiveX control installation prompts for Internet Explorer processes. If you enable this policy setting, prompts for ActiveX control installations will be blocked for Internet Explorer processes. If you disable this policy setting, prompts for ActiveX control installations will not be blocked and these prompts will be displayed to users. If you do not configure this policy setting, the user's preference will be used to determine whether to block ActiveX control installations for Internet Explorer processes.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5057,14 +5047,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24803r428977_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Security Features -&gt; Restrict ActiveX Install -&gt; 'Internet Explorer Processes' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24803r428977_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:529" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:529" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223143">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223143r428981_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223143r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI910-IE11</xccdf:version>
           <xccdf:title>Status bar updates via script must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether script is allowed to update the status bar within the zone. A script running in the zone could cause false information to be displayed on the status bar, which could confuse the user and cause them to perform an undesirable action. If you enable this policy setting, script is allowed to update the status bar. If you disable this policy setting, script is not allowed to update the status bar. If you do not configure this policy setting, status bar updates via scripts will be disabled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5081,14 +5071,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24804r428980_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Security Page -&gt; Internet Zone 'Allow updates to status bar via script' to 'Enabled', and select 'Disable' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24804r428980_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:530" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:530" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223144">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223144r428984_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223144r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI920-IE11</xccdf:version>
           <xccdf:title>.NET Framework-reliant components not signed with Authenticode must be disallowed to run (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unsigned components are more likely to contain malicious code and it is more difficult to determine the author of the application - therefore they should be avoided if possible. This policy setting allows you to manage whether .NET Framework components that are not signed with Authenticode can be executed from Internet Explorer. These components include managed controls referenced from an object tag and managed executables referenced from a link. If you enable this policy setting, Internet Explorer will execute unsigned managed components. If you select "Prompt" in the drop-down box, Internet Explorer will prompt the user to determine whether to execute unsigned managed components. If you disable this policy setting, Internet Explorer will not execute unsigned managed components. If you do not configure this policy setting, Internet Explorer will not execute unsigned managed components.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5106,14 +5096,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24805r428983_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_RunNETFrameworkReliantComponentsNotSignedWithAuthenticode_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:53100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:531" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:531" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223145">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223145r428987_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223145r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI930-IE11</xccdf:version>
           <xccdf:title>.NET Framework-reliant components signed with Authenticode must be disallowed to run (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;It may be possible for someone to host malicious content on a website that takes advantage of these components. This policy setting allows you to manage whether .NET Framework components that are signed with Authenticode can be executed from Internet Explorer. These components include managed controls referenced from an object tag and managed executables referenced from a link. If you enable this policy setting, Internet Explorer will execute signed managed components. If you select "Prompt" in the drop-down box, Internet Explorer will prompt the user to determine whether to execute signed managed components. If you disable this policy setting, Internet Explorer will not execute signed managed components. If you do not configure this policy setting, Internet Explorer will not execute signed managed components.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5131,14 +5121,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24806r428986_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_RunNETFrameworkReliantComponentsSignedWithAuthenticode_InternetZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:53200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:532" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:532" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223146">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223146r428990_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223146r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI940-IE11</xccdf:version>
           <xccdf:title>Scriptlets must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to manage whether scriptlets can be allowed. Scriptlets hosted on sites located in this zone are more likely to contain malicious code. If you enable this policy setting, users will be able to run scriptlets. If you disable this policy setting, users will not be able to run scriptlets. If you do not configure this policy setting, a scriptlet can be enabled or disabled by the user.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5156,14 +5146,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fix id="F-24807r428989_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_AllowScriptlets_RestrictedSitesZone_LocalComputer_var" export-name="oval:mil.disa.fso.ie:var:53300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:533" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:533" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223147">
         <xccdf:title>SRG-APP-000141</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223147r428993_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223147r879587_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI950-IE11</xccdf:version>
           <xccdf:title>Status bar updates via script must be disallowed (Restricted Sites zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A script running in the zone could cause false information to be displayed on the status bar, which could confuse the user and cause an undesirable action. This policy setting allows you to manage whether script is allowed to update the status bar within the zone. If you enable this policy setting, script is allowed to update the status bar. If you disable this policy setting, script is not allowed to update the status bar. If you do not configure this policy setting, status bar updates via scripts will be disabled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5180,14 +5170,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24808r428992_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer -&gt; Internet Control Panel -&gt; Security Page -&gt; Restricted Sites Zone 'Allow updates to status bar via script' to 'Enabled', and select 'Disable' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24808r428992_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:534" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:534" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223148">
         <xccdf:title>SRG-APP-000516</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223148r428996_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223148r879887_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI985-IE11</xccdf:version>
           <xccdf:title>When Enhanced Protected Mode is enabled, ActiveX controls must be disallowed to run in Protected Mode.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting prevents ActiveX controls from running in Protected Mode when Enhanced Protected Mode is enabled. When a user has an ActiveX control installed that is not compatible with Enhanced Protected Mode and a website attempts to load the control, Internet Explorer notifies the user and gives the option to run the website in regular Protected Mode. This policy setting disables this notification and forces all websites to run in Enhanced Protected Mode. Enhanced Protected Mode provides additional protection against malicious websites by using 64-bit processes on 64-bit versions of Windows. For computers running at least Windows 8, Enhanced Protected Mode also limits the locations Internet Explorer can read from in the registry and the file system. If you enable this policy setting, Internet Explorer will not give the user the option to disable Enhanced Protected Mode. All Protected Mode websites will run in Enhanced Protected Mode. If you disable or do not configure this policy setting, Internet Explorer notifies users and provides an option to run websites with incompatible ActiveX controls in regular Protected Mode.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5204,14 +5194,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24809r428995_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel-&gt; Advanced Page 'Do not allow ActiveX controls to run in Protected Mode when Enhanced Protected Mode is enabled' to 'Enabled'.</xccdf:fixtext>
           <xccdf:fix id="F-24809r428995_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:556" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:556" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-223149">
         <xccdf:title>SRG-APP-000039</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223149r428999_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223149r879534_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI990-IE11</xccdf:version>
           <xccdf:title>Dragging of content from different domains across windows must be disallowed (Internet zone).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting allows you to set options for dragging content from one domain to a different domain when the source and destination are in different windows. If you enable this policy setting, users can drag content from one domain to a different domain when the source and destination are in different windows. Users cannot change this setting. If you disable this policy setting, users cannot drag content from one domain to a different domain when both the source and destination are in different windows. Users cannot change this setting. If you do not configure this policy setting, users cannot drag content from one domain to a different domain when the source and destination are in different windows. Users can change this setting in the Internet Options dialog box.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5228,38 +5218,14 @@ Set the policy value for Computer Configuration &gt;&gt; Administrative Template
           <xccdf:fixtext fixref="F-24810r428998_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel-&gt; Security Page-&gt; Internet Zone 'Enable dragging of content from different domains across windows' to 'Enabled', and select 'Disabled' from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-24810r428998_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:547" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-223150">
-        <xccdf:title>SRG-APP-000233</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-223150r429002_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">DTBI995-IE11</xccdf:version>
-          <xccdf:title>Enhanced Protected Mode functionality must be enforced.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Enhanced Protected Mode provides additional protection against malicious websites by using 64-bit processes on 64-bit versions of Windows. For computers running at least Windows 8, Enhanced Protected Mode also limits the locations Internet Explorer can read from in the registry and the file system. If you enable this policy setting, Enhanced Protected Mode will be turned on. Any zone that has Protected Mode enabled will use Enhanced Protected Mode. Users will not be able to disable Enhanced Protected Mode. If you disable this policy setting, Enhanced Protected Mode will be turned off. Any zone that has Protected Mode enabled will use the version of Protected Mode introduced in Internet Explorer 7 for Windows Vista. If you do not configure this policy, users will be able to turn on or turn off Enhanced Protected Mode on the "Advanced" tab of the Internet Options dialog box.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Microsoft Internet Explorer 11</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Microsoft Internet Explorer 11</dc:subject>
-            <dc:identifier>4095</dc:identifier>
-          </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/legacy">SV-59853</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">V-46987</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-001084</xccdf:ident>
-          <xccdf:fixtext fixref="F-24811r429001_fix">Set the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Internet Explorer-&gt; Internet Control Panel-&gt; Advanced Page 'Turn on Enhanced Protected Mode' to 'Enabled'.</xccdf:fixtext>
-          <xccdf:fix id="F-24811r429001_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:551" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:547" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-250540">
         <xccdf:title>SRG-APP-000416</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-250540r804978_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-250540r879944_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI014-IE11</xccdf:version>
           <xccdf:title>Turn off Encryption Support must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This parameter ensures only DoD-approved ciphers and algorithms are enabled for use by the web browser by allowing you to turn on/off support for TLS and SSL. TLS is a protocol for protecting communications between the browser and the target server. When the browser attempts to set up a protected communication with the target server, the browser and server negotiate which protocol and version to use. The browser and server attempt to match each other's list of supported protocols and versions and pick the most preferred match.
@@ -5274,20 +5240,20 @@ Satisfies: SRG-APP-000514, SRG-APP-000555, SRG-APP-000625, SRG-APP-000630, SRG-A
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/legacy">SV-59337</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-46473</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002450</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002480</xccdf:ident>
           <xccdf:fixtext fixref="F-53929r804977_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Internet Control Panel &gt;&gt; Advanced Page &gt;&gt; "Turn off Encryption Support" to "Enabled".
 
 Select only "Only use TLS 1.2" from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-53929r804977_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:580" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:580" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-250541">
         <xccdf:title>SRG-APP-000416</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-250541r799949_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-250541r879944_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI1100-IE11</xccdf:version>
           <xccdf:title>Allow Fallback to SSL 3.0 (Internet Explorer) must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This parameter ensures only DoD-approved ciphers and algorithms are enabled for use by the web browser by blocking an insecure fallback to SSL when TLS 1.0 or greater fails.
@@ -5302,18 +5268,18 @@ Satisfies: SRG-APP-000514, SRG-APP-000555, SRG-APP-000625, SRG-APP-000630, SRG-A
           </xccdf:reference>
           <xccdf:ident system="http://cyber.mil/legacy">SV-79219</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-64729</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002450</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002480</xccdf:ident>
           <xccdf:fixtext fixref="F-53930r799948_fix">Set the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Internet Explorer &gt;&gt; Security Features &gt;&gt; "Allow fallback to SSL 3.0 (Internet Explorer)" to "Enabled", and select "No Sites" from the drop-down box.</xccdf:fixtext>
           <xccdf:fix id="F-53930r799948_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:581" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:581" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-252910">
         <xccdf:title>SRG-APP-000456</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-252910r836638_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-252910r891308_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">DTBI999-IE11</xccdf:version>
           <xccdf:title>The version of Internet Explorer running on the system must be a supported version.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Security flaws with software applications are discovered daily. Vendors are constantly updating and patching their products to address newly discovered security vulnerabilities. Organizations (including any contractor to the organization) are required to promptly install security-relevant software updates (e.g., patches, service packs, and hot fixes). Flaws discovered during security assessments, continuous monitoring, incident response activities, or information system error handling must also be addressed expeditiously.
@@ -5328,22 +5294,24 @@ This requirement will apply to software patch management solutions that are used
             <dc:subject>Microsoft Internet Explorer 11</dc:subject>
             <dc:identifier>4095</dc:identifier>
           </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002605</xccdf:ident>
-          <xccdf:fixtext fixref="F-56313r832315_fix">Upgrade to a supported browser.</xccdf:fixtext>
-          <xccdf:fix id="F-56313r832315_fix" />
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002635</xccdf:ident>
+          <xccdf:fixtext fixref="F-56313r891307_fix">For Windows 10 General Availability Channel, remove or disable the Internet Explorer 11 application.
+
+To disable Internet Explorer 11 as a standalone browser, set the policy value for "Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Disable Internet Explorer 11 as a standalone browser" to "Enabled" with the option value set to "Never" or "Once per user".</xccdf:fixtext>
+          <xccdf:fix id="F-56313r891307_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.ie:def:592" href="U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.win:def:252910" href="U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
     </xccdf:Benchmark>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2022-06-28T13:56:51">
+  <component id="scap_mil.disa.stig_comp_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2023-03-28T17:40:35">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-06-28T13:56:50</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:40:34</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.ie:def:417" version="1" class="compliance">
@@ -7197,23 +7165,6 @@ This requirement will apply to software patch management solutions that are used
             <criterion comment="Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Internet Control Panel/Security Page/Restricted Sites Zone/Enable dragging of content from different domains within a window" test_ref="oval:mil.disa.fso.ie:tst:55000" negate="false" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.ie:def:551" version="1" class="compliance">
-          <metadata>
-            <title>DTBI995-IE11 - Enhanced Protected Mode</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 7</platform>
-              <platform>Microsoft Windows Server 2008 R2</platform>
-              <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 8.1</platform>
-              <product>Microsoft Internet Explorer 11</product>
-            </affected>
-            <description>Enhanced Protected Mode provides additional protection against malicious websites by using 64-bit processes on 64-bit versions of Windows. For computers running at least Windows 8, Enhanced Protected Mode also limits the locations Internet Explorer can read from in the registry and the file system. If you enable this policy setting, Enhanced Protected Mode will be turned on. Any zone that has Protected Mode enabled will use Enhanced Protected Mode. Users will not be able to disable Enhanced Protected Mode. If you disable this policy setting, Enhanced Protected Mode will be turned off. Any zone that has Protected Mode enabled will use the version of Protected Mode introduced in Internet Explorer 7 for Windows Vista. If you do not configure this policy, users will be able to turn on or turn off Enhanced Protected Mode on the Advanced tab of the Internet Options dialog.</description>
-          </metadata>
-          <criteria operator="AND" comment="Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Internet Control Panel/Advanced Page/Turn on Enhanced Protected Mode" negate="false">
-            <criterion comment="Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Internet Control Panel/Advanced Page/Turn on Enhanced Protected Mode" test_ref="oval:mil.disa.fso.ie:tst:55100" negate="false" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.fso.ie:def:556" version="1" class="compliance">
           <metadata>
             <title>DTBI985-IE11 - ActiveX controls in enhanced protected mode</title>
@@ -7512,21 +7463,19 @@ This requirement will apply to software patch management solutions that are used
             <criterion test_ref="oval:mil.disa.fso.ie:tst:58500" comment="Check if HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Ext\RunThisTimeEnabled is set to 0." />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.ie:def:586" version="2" class="compliance">
+        <definition id="oval:mil.disa.fso.ie:def:586" version="3" class="compliance">
           <metadata>
-            <title>DTBI1110-IE11-Enabling outdated ActiveX controls for Internet Explorer must be blocked</title>
+            <title>DTBI1110-IE11 - Enabling outdated ActiveX controls for Internet Explorer must be blocked.</title>
             <affected family="windows">
-              <platform>Microsoft Windows Server 2008 R2</platform>
+              <platform>Microsoft Windows Server 2019</platform>
+              <platform>Microsoft Windows Server 2016</platform>
               <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows 7</platform>
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 8.1</platform>
               <platform>Microsoft Windows 10</platform>
               <product>Microsoft Internet Explorer 11</product>
             </affected>
-            <description>Enabling outdated ActiveX controls for Internet Explorer must be blocked.</description>
+            <description>This feature keeps ActiveX controls up to date and helps make them safer to use in Internet Explorer. Many ActiveX controls are not automatically updated as new versions are released. It is very important to keep ActiveX controls up to date because malicious or compromised webpages can target security flaws in out-of-date ActiveX controls.</description>
           </metadata>
-          <criteria operator="OR">
+          <criteria>
             <criterion test_ref="oval:mil.disa.fso.ie:tst:58600" comment="Block enabling outdated ActiveX controls for Internet Explorer" />
           </criteria>
         </definition>
@@ -7598,9 +7547,9 @@ This requirement will apply to software patch management solutions that are used
             <criterion test_ref="oval:mil.disa.fso.ie:tst:59100" comment="Verifies Developer Tools are disabled" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.ie:def:592" version="1" class="compliance">
+        <definition id="oval:mil.disa.stig.win:def:252910" version="2" class="compliance">
           <metadata>
-            <title>The version of Internet Explorer running on the system must be a supported version.</title>
+            <title>DTBI999-IE11 - The version of Internet Explorer running on the system must be a supported version.</title>
             <affected family="windows">
               <product>Microsoft Internet Explorer 11</product>
             </affected>
@@ -7610,8 +7559,17 @@ Organization-defined time periods for updating security-relevant software may va
 
 This requirement will apply to software patch management solutions that are used to install patches across the enclave and also to applications that are not part of that patch management solution. For example, many browsers today provide the capability to install their own patch software. Patch criticality, as well as system criticality, will vary. Therefore, the tactical situations regarding the patch management process will also vary. This means the time period used must be a configurable parameter. Time frames for application of security-relevant software updates may depend on the Information Assurance Vulnerability Management (IAVM) process.</description>
           </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.fso.ie:tst:59200" comment="Verify that Internet Explorer 11 is running on a supported version of Windows." negate="true" />
+          <criteria operator="OR">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25689300" comment="Internet Explorer 11 optional feature disabled or not installed" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:22070601" comment="The OS is Windows Enterprise LTSB/LTSC" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25291002" comment="The OS is Windows Server" />
+            <criteria comment="Internet Explorer 11 is disabled as a standalone browser with MS Edge installed">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25689301" comment="Internet Explorer 11 is disabled as a standalone browser" />
+              <criteria operator="OR" comment="Microsoft Edge is Installed">
+                <criterion test_ref="oval:mil.disa.stig.edge:tst:100" comment="64-bit Microsoft Edge is installed" negate="true" />
+                <criterion test_ref="oval:mil.disa.stig.edge:tst:101" comment="32-bit Microsoft Edge is installed" negate="true" />
+              </criteria>
+            </criteria>
           </criteria>
         </definition>
       </definitions>
@@ -8056,10 +8014,6 @@ This requirement will apply to software patch management solutions that are used
           <object object_ref="oval:mil.disa.fso.ie:obj:55000" />
           <state state_ref="oval:mil.disa.fso.ie:ste:55000" />
         </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.ie:tst:55100" version="1" check="all" comment="Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Internet Control Panel/Advanced Page/Turn on Enhanced Protected Mode" check_existence="at_least_one_exists">
-          <object object_ref="oval:mil.disa.fso.ie:obj:55100" />
-          <state state_ref="oval:mil.disa.fso.ie:ste:55100" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.ie:tst:55600" version="1" check="all" comment="Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Internet Control Panel/Advanced Page/Do not allow ActiveX controls to run in Protected Mode when Enhanced Protected Mode " check_existence="at_least_one_exists">
           <object object_ref="oval:mil.disa.fso.ie:obj:55600" />
           <state state_ref="oval:mil.disa.fso.ie:ste:55600" />
@@ -8171,9 +8125,29 @@ This requirement will apply to software patch management solutions that are used
           <object object_ref="oval:mil.disa.fso.ie:obj:59100" />
           <state state_ref="oval:mil.disa.fso.ie:ste:59100" />
         </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.ie:tst:59200" version="1" comment="Confirm that Internet Explorer 11 is running on a supported version of Windows." check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.fso.ie:obj:59200" />
-          <state state_ref="oval:mil.disa.fso.ie:ste:59200" />
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:tst:100" version="2" comment="64-bit Microsoft Edge is installed" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.edge:obj:102" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:tst:101" version="2" comment="32-bit Microsoft Edge is installed" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.edge:obj:103" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:22070601" version="2" comment="The OS is Windows Enterprise LTSC" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25325400" />
+          <state state_ref="oval:mil.disa.stig.win:ste:22070602" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25291002" version="1" comment="The OS is Windows Server" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:10000000" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25291000" />
+        </registry_test>
+        <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25689300" version="3" comment="Internet Explorer 11 optional feature disabled or not installed" check_existence="any_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25689300" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000020" />
+        </wmi57_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25689301" version="1" comment="Internet Explorer 11 is disabled as a standalone browser" check_existence="at_least_one_exists" check="all" state_operator="OR">
+          <object object_ref="oval:mil.disa.stig.win:obj:25689301" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000000" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000001" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000002" />
         </registry_test>
       </tests>
       <objects>
@@ -8727,11 +8701,6 @@ This requirement will apply to software patch management solutions that are used
           <key datatype="string" operation="equals">Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4</key>
           <name datatype="string" operation="equals">2708</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.ie:obj:55100" version="1" comment="Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Internet Control Panel/Advanced Page/Turn on Enhanced Protected Mode">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">Software\Policies\Microsoft\Internet Explorer\Main</key>
-          <name datatype="string" operation="equals">Isolation</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.ie:obj:55600" version="1" comment="Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Internet Control Panel/Advanced Page/Do not allow ActiveX controls to run in Protected Mode when Enhanced Protected Mode ">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">Software\Policies\Microsoft\Internet Explorer\Main</key>
@@ -8862,10 +8831,48 @@ This requirement will apply to software patch management solutions that are used
           <key datatype="string">Software\Policies\Microsoft\Internet Explorer\IEDevTools</key>
           <name datatype="string">Disabled</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.ie:obj:59200" version="1" comment="Registry value associated with the Windows Product Name.">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
-          <name datatype="string" operation="equals">ProductName</name>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:obj:100" version="1" comment="64-bit DisplayName registry value">
+          <behaviors max_depth="1" recurse_direction="down" />
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall</key>
+          <name datatype="string">DisplayName</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:obj:101" version="1" comment="32-bit DisplayName registry value">
+          <behaviors max_depth="1" recurse_direction="down" />
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall</key>
+          <name datatype="string">DisplayName</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:obj:102" version="1" comment="64-bit DisplayName equals Microsoft Edge">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.edge:obj:100</object_reference>
+            <filter action="include">oval:mil.disa.stig.edge:ste:100</filter>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:obj:103" version="1" comment="32-bit DisplayName equals Microsoft Edge">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.edge:obj:101</object_reference>
+            <filter action="include">oval:mil.disa.stig.edge:ste:100</filter>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:10000000" comment="ProductName registry entry" version="1">
+          <hive>HKEY_LOCAL_MACHINE</hive>
+          <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name>ProductName</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25325400" version="1">
+          <hive>HKEY_LOCAL_MACHINE</hive>
+          <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name operation="case insensitive equals">EditionId</name>
+        </registry_object>
+        <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25689300" version="1">
+          <namespace datatype="string">root\cimv2</namespace>
+          <wql datatype="string" operation="equals">SELECT installstate FROM win32_optionalfeature WHERE name = 'Internet-Explorer-Optional-amd64'</wql>
+        </wmi57_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25689301" version="1">
+          <hive>HKEY_LOCAL_MACHINE</hive>
+          <key>SOFTWARE\Policies\Microsoft\Internet Explorer\Main</key>
+          <name>NotifyDisableIEOptions</name>
         </registry_object>
       </objects>
       <states>
@@ -9309,10 +9316,6 @@ This requirement will apply to software patch management solutions that are used
           <type datatype="string" operation="equals" entity_check="all">reg_dword</type>
           <value datatype="int" operation="equals" entity_check="all">3</value>
         </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.ie:ste:55100" version="2" comment="Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Internet Control Panel/Advanced Page/Turn on Enhanced Protected Mode">
-          <type datatype="string" operation="equals" entity_check="all">reg_sz</type>
-          <value datatype="string" operation="equals" entity_check="all">PMEM</value>
-        </registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.ie:ste:55600" version="2" comment="Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Internet Control Panel/Advanced Page/Do not allow ActiveX controls to run in Protected Mode when Enhanced Protected Mode ">
           <type datatype="string" operation="equals" entity_check="all">reg_dword</type>
           <value datatype="int" operation="equals" entity_check="all">1</value>
@@ -9421,9 +9424,32 @@ This requirement will apply to software patch management solutions that are used
           <type>reg_dword</type>
           <value datatype="int" operation="equals">1</value>
         </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.ie:ste:59200" version="1" comment="Registry value corresponding with Windows Product Name value.">
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:ste:100" version="1" comment="registry value equals Microsoft Edge">
+          <value datatype="string">Microsoft Edge</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000000" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">0</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000001" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">1</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000002" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">2</value>
+        </registry_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000020" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="installstate" entity_check="at least one" datatype="string">2</field>
+          </result>
+        </wmi57_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:22070602" version="1">
           <type>reg_sz</type>
-          <value datatype="string" operation="equals">Windows 10 Enterprise</value>
+          <value datatype="string">EnterpriseS</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25291000" version="1">
+          <value operation="pattern match">^(?i)Windows Server .*$</value>
         </registry_state>
       </states>
       <variables>
@@ -9503,12 +9529,12 @@ This requirement will apply to software patch management solutions that are used
       </variables>
     </oval_definitions>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_IE11_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2022-06-28T13:56:51">
+  <component id="scap_mil.disa.stig_comp_U_MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2023-03-28T17:40:35">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-06-28T13:56:50</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:40:34</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.ie:def:18343" version="4" class="inventory">

--- a/scap/content/guides/disa/stig-win10.xml
+++ b/scap/content/guides/disa/stig-win10.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
-  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2022-06-28T15:53:43">
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
+  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2023-03-28T17:40:42">
     <dictionaries>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+          <cat:uri name="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
         </cat:catalog>
       </component-ref>
     </dictionaries>
     <checklists>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-xccdf.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-xccdf.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          <cat:uri name="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
         </cat:catalog>
       </component-ref>
     </checklists>
     <checks>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
     </checks>
   </data-stream>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2022-06-28T15:53:43">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2023-03-28T17:40:42">
     <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0">
       <cpe-item name="cpe:/o:microsoft:windows_10">
         <title>Microsoft Windows 10</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.windows:def:1</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.windows:def:1</check>
       </cpe-item>
     </cpe-list>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2022-06-28T15:53:43">
-    <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_Windows_10_STIG" xml:lang="en" style="SCAP_1.2">
-      <xccdf:status date="2022-04-08">accepted</xccdf:status>
-      <xccdf:title>Microsoft Windows 10 Security Technical Implementation Guide</xccdf:title>
-      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2023-03-28T17:40:42">
+    <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_MS_Windows_10_STIG" xml:lang="en" style="SCAP_1.2">
+      <xccdf:status date="2023-02-28">accepted</xccdf:status>
+      <xccdf:title>Microsoft Windows 10 STIG SCAP Benchmark</xccdf:title>
+      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
       <xccdf:notice id="terms-of-use" xml:lang="en" />
       <xccdf:front-matter xml:lang="en" />
       <xccdf:rear-matter xml:lang="en" />
@@ -40,11 +40,19 @@
         <dc:publisher>DISA</dc:publisher>
         <dc:source>STIG.DOD.MIL</dc:source>
       </xccdf:reference>
-      <xccdf:plain-text id="release-info">Release: 2.5 Benchmark Date: 27 Jul 2022</xccdf:plain-text>
-      <xccdf:plain-text id="generator">3.3.0.27375</xccdf:plain-text>
+      <xccdf:plain-text id="release-info">Release: 2.8 Benchmark Date: 11 May 2023</xccdf:plain-text>
+      <xccdf:plain-text id="generator">3.4.0.34222</xccdf:plain-text>
       <xccdf:plain-text id="conventionsVersion">1.10.0</xccdf:plain-text>
+      <cpe:platform-specification>
+        <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_MemberWorkstation">
+          <title>Windows Domain Member Workstation</title>
+          <logical-test negate="false" operator="AND">
+            <check-fact-ref id-ref="oval:mil.disa.stig.win:def:100002" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </logical-test>
+        </platform>
+      </cpe:platform-specification>
       <xccdf:platform idref="cpe:/o:microsoft:windows_10" />
-      <xccdf:version update="http://iase.disa.mil/stigs">002.005</xccdf:version>
+      <xccdf:version update="http://iase.disa.mil/stigs">002.008</xccdf:version>
       <xccdf:metadata>
         <dc:creator>DISA</dc:creator>
         <dc:publisher>DISA</dc:publisher>
@@ -134,6 +142,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220808" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220809" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220810" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220812" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220813" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220814" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220815" selected="true" />
@@ -229,6 +238,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220943" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220944" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220945" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220946" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220947" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220948" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220949" selected="true" />
@@ -264,6 +274,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220983" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250319" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252896" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-256894" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-1_Public">
         <xccdf:title>I - Mission Critical Public</xccdf:title>
@@ -348,6 +359,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220808" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220809" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220810" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220812" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220813" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220814" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220815" selected="true" />
@@ -443,6 +455,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220943" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220944" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220945" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220946" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220947" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220948" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220949" selected="true" />
@@ -478,6 +491,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220983" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250319" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252896" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-256894" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-1_Sensitive">
         <xccdf:title>I - Mission Critical Sensitive</xccdf:title>
@@ -562,6 +576,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220808" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220809" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220810" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220812" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220813" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220814" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220815" selected="true" />
@@ -657,6 +672,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220943" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220944" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220945" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220946" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220947" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220948" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220949" selected="true" />
@@ -692,6 +708,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220983" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250319" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252896" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-256894" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-2_Classified">
         <xccdf:title>II - Mission Support Classified</xccdf:title>
@@ -776,6 +793,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220808" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220809" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220810" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220812" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220813" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220814" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220815" selected="true" />
@@ -871,6 +889,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220943" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220944" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220945" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220946" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220947" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220948" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220949" selected="true" />
@@ -906,6 +925,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220983" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250319" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252896" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-256894" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-2_Public">
         <xccdf:title>II - Mission Support Public</xccdf:title>
@@ -990,6 +1010,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220808" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220809" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220810" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220812" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220813" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220814" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220815" selected="true" />
@@ -1085,6 +1106,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220943" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220944" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220945" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220946" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220947" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220948" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220949" selected="true" />
@@ -1120,6 +1142,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220983" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250319" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252896" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-256894" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-2_Sensitive">
         <xccdf:title>II - Mission Support Sensitive</xccdf:title>
@@ -1204,6 +1227,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220808" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220809" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220810" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220812" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220813" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220814" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220815" selected="true" />
@@ -1299,6 +1323,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220943" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220944" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220945" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220946" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220947" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220948" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220949" selected="true" />
@@ -1334,6 +1359,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220983" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250319" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252896" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-256894" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-3_Classified">
         <xccdf:title>III - Administrative Classified</xccdf:title>
@@ -1418,6 +1444,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220808" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220809" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220810" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220812" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220813" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220814" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220815" selected="true" />
@@ -1513,6 +1540,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220943" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220944" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220945" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220946" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220947" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220948" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220949" selected="true" />
@@ -1548,6 +1576,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220983" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250319" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252896" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-256894" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-3_Public">
         <xccdf:title>III - Administrative Public</xccdf:title>
@@ -1632,6 +1661,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220808" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220809" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220810" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220812" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220813" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220814" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220815" selected="true" />
@@ -1727,6 +1757,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220943" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220944" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220945" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220946" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220947" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220948" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220949" selected="true" />
@@ -1762,6 +1793,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220983" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250319" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252896" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-256894" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_MAC-3_Sensitive">
         <xccdf:title>III - Administrative Sensitive</xccdf:title>
@@ -1846,6 +1878,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220808" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220809" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220810" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220812" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220813" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220814" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220815" selected="true" />
@@ -1941,6 +1974,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220943" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220944" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220945" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-220946" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220947" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220948" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220949" selected="true" />
@@ -1976,41 +2010,41 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-220983" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-250319" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-252896" selected="true" />
+        <xccdf:select idref="xccdf_mil.disa.stig_group_V-256894" selected="true" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_Disable_Slow_Rules">
         <xccdf:title>Disable Slow Rules</xccdf:title>
         <xccdf:description>This profile disables rules known to have poor performance in some environments, such as systems with large numbers of user accounts.</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220909r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220912r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220956r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220956r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220957r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220958r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220958r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220959r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220960r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220961r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220962r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220963r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220964r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220965r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220966r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220967r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220973r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220974r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220975r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220976r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220977r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220978r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220979r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220980r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220981r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220982r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220983r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220960r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220961r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220962r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220963r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220964r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220965r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220966r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220967r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220973r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220974r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220975r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220976r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220977r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220978r852035_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220979r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220981r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220982r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220983r877392_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_CAT_I_Only">
         <xccdf:title>CAT I Only</xccdf:title>
         <xccdf:description>This profile only includes rules that are Severity Category I.</xccdf:description>
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220697r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220702r819651_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220697r857178_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220702r859296_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220716r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220719r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220720r569187_rule" selected="false" />
@@ -2021,9 +2055,9 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220730r793189_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220731r793191_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220732r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220739r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220739r851968_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220740r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220741r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220741r851969_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220742r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220743r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220744r569187_rule" selected="false" />
@@ -2031,10 +2065,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220746r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220748r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220749r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220750r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220751r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220752r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220754r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220750r851970_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220751r851971_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220752r851972_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220754r851974_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220755r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220757r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220758r569187_rule" selected="false" />
@@ -2045,20 +2079,20 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220763r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220764r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220767r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220768r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220768r851975_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220769r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220770r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220771r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220770r851976_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220771r851977_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220772r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220773r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220774r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220775r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220776r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220777r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220778r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220779r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220780r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220781r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220775r851978_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220776r851979_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220777r851980_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220778r851981_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220779r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220780r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220781r877391_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220782r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220783r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220784r569187_rule" selected="false" />
@@ -2072,13 +2106,13 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220795r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220796r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220797r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220798r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220798r851985_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220799r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220800r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220801r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220802r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220803r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220806r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220806r890427_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220807r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220808r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220809r569187_rule" selected="false" />
@@ -2088,12 +2122,12 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220815r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220816r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220817r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220818r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220818r857191_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220819r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220820r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220821r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220822r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220824r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220820r857194_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220821r851986_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220822r851987_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220824r877039_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220825r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220826r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220830r569187_rule" selected="false" />
@@ -2101,10 +2135,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220832r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220833r793250_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220834r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220835r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220835r857197_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220836r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220837r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220838r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220837r851992_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220838r851993_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220839r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220840r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220841r569187_rule" selected="false" />
@@ -2113,91 +2147,93 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220844r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220845r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220847r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220848r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220848r851994_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220849r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220850r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220851r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220852r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220850r851995_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220851r877394_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220852r877398_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220853r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220854r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220855r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220856r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220856r851997_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220858r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220859r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220859r877377_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220860r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220863r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220866r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220867r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220868r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220863r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220866r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220867r852001_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220868r877395_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220870r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220871r642141_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220902r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220903r819670_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220904r569312_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220905r819673_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220906r569316_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220903r894651_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220904r894652_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220905r890436_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220906r890439_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220908r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220909r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220910r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220911r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220912r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220913r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220914r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220915r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220916r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220914r852008_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220915r852009_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220916r852010_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220917r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220918r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220919r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220919r852011_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220920r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220923r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220924r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220925r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220926r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220927r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220925r852012_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220926r877396_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220927r852013_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220931r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220933r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220933r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220934r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220935r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220936r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220939r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220940r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220941r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220942r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220942r877466_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220943r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220944r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220944r852016_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220945r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220947r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220946r890441_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220947r852017_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220948r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220949r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220950r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220950r852018_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220951r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220956r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220956r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220957r569187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220959r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220960r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220961r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220962r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220964r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220965r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220966r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220960r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220961r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220962r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220964r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220965r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220966r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220968r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220969r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220970r569187_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220969r857200_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220970r857203_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220971r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220972r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220973r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220974r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220975r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220976r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220977r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220978r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220979r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220980r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220981r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220982r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220983r569187_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-250319r793300_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220972r852029_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220973r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220974r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220975r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220976r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220977r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220978r852035_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220979r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220980r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220981r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220982r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-220983r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-250319r857185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-252896r821863_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-256894r891287_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Value id="xccdf_mil.disa.stig_value_virtualize_write_failures_per_user_locations_var" type="number" operator="equals">
         <xccdf:title>Virtualize file and registry write failures to per-user locations</xccdf:title>
@@ -2340,16 +2376,6 @@
         <xccdf:value>0</xccdf:value>
         <xccdf:value selector="disabled">0</xccdf:value>
         <xccdf:value selector="enabled">1</xccdf:value>
-      </xccdf:Value>
-      <xccdf:Value id="xccdf_mil.disa.stig_value_password_minimum_length_var" type="number" operator="greater than or equal">
-        <xccdf:title>Minimum Password Length</xccdf:title>
-        <xccdf:description>The minimum number of characters required for a password</xccdf:description>
-        <xccdf:value>14</xccdf:value>
-        <xccdf:value selector="8_characters">8</xccdf:value>
-        <xccdf:value selector="9_characters">9</xccdf:value>
-        <xccdf:value selector="12_characters">12</xccdf:value>
-        <xccdf:value selector="14_characters">14</xccdf:value>
-        <xccdf:value selector="15_characters">15</xccdf:value>
       </xccdf:Value>
       <xccdf:Value id="xccdf_mil.disa.stig_value_password_minimum_age_var" type="number" operator="greater than or equal">
         <xccdf:title>Minimum Password Age</xccdf:title>
@@ -2674,10 +2700,10 @@
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220697">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220697r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220697r857178_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-00-000005</xccdf:version>
           <xccdf:title>Domain-joined systems must use Windows 10 Enterprise Edition 64-bit version.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Features such as Credential Guard use virtualization based security to protect information that could be used in credential theft attacks if compromised. There are a number of system requirements that must be met in order for Credential Guard to be configured and enabled properly. Virtualization based security and Credential Guard are only available with Windows 10 Enterprise 64-bit version.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:description>&lt;VulnDiscussion&gt;Features such as Credential Guard use virtualization-based security to protect information that could be used in credential theft attacks if compromised. A number of system requirements must be met for Credential Guard to be configured and enabled properly. Virtualization-based security and Credential Guard are only available with Windows 10 Enterprise 64-bit version.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows 10</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -2691,14 +2717,14 @@
           <xccdf:fixtext fixref="F-22401r554577_fix">Use Windows 10 Enterprise 64-bit version for domain-joined systems.</xccdf:fixtext>
           <xccdf:fix id="F-22401r554577_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:15" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:15" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220702">
         <xccdf:title>SRG-OS-000185-GPOS-00079</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220702r819651_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220702r859296_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-00-000030</xccdf:version>
           <xccdf:title>Windows 10 information systems must use BitLocker to encrypt all disks to protect the confidentiality and integrity of all information at rest.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;If data at rest is unencrypted, it is vulnerable to disclosure. Even if the operating system enforces permissions on data access, an adversary can remove non-volatile memory and read it directly, thereby circumventing operating system controls. Encrypting the data ensures that confidentiality is protected even when the operating system is not running.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2712,8 +2738,8 @@
           <xccdf:ident system="http://cyber.mil/legacy">SV-77827</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-63337</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001199</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002445</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002446</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002475</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002476</xccdf:ident>
           <xccdf:fixtext fixref="F-22406r554592_fix">Enable full disk encryption on all information systems (including SIPRNet) using BitLocker.
 
 BitLocker, included in Windows, can be enabled in the Control Panel under "BitLocker Drive Encryption" as well as other management tools.
@@ -2721,21 +2747,21 @@ BitLocker, included in Windows, can be enabled in the Control Panel under "BitLo
 NOTE: An alternate encryption application may be used in lieu of BitLocker providing it is configured for full disk encryption and satisfies the pre-boot authentication requirements (WN10-00-000031 and WN10-00-000032).</xccdf:fixtext>
           <xccdf:fix id="F-22406r554592_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:177" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:177" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220706">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220706r823104_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220706r857183_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-00-000040</xccdf:version>
           <xccdf:title>Windows 10 systems must be maintained at a supported servicing level.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Windows 10 is maintained by Microsoft at servicing levels for specific periods of time to support Windows as a Service. Systems at unsupported servicing levels or releases will not receive security updates for new vulnerabilities, which leaves them subject to exploitation.
 
-New versions with feature updates are planned to be released on a semi-annual basis with an estimated support timeframe of 18 to 30 months depending on the release. Support for previously released versions has been extended for Enterprise editions.
+New versions with feature updates are planned to be released on a semiannual basis with an estimated support timeframe of 18 to 30 months depending on the release. Support for previously released versions has been extended for Enterprise editions.
 
-A separate servicing branch intended for special purpose systems is the Long-Term Servicing Channel (LTSC, formerly Branch - LTSB), which will receive security updates for 10 years but excludes feature updates.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+A separate servicing branch intended for special-purpose systems is the Long-Term Servicing Channel (LTSC, formerly Branch - LTSB), which will receive security updates for 10 years but excludes feature updates.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows 10</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -2758,7 +2784,7 @@ v1809 (Build 17763)
 v21H2 (Build 19044)</xccdf:fixtext>
           <xccdf:fix id="F-22410r823103_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:109" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220706" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2782,7 +2808,7 @@ v21H2 (Build 19044)</xccdf:fixtext>
           <xccdf:fixtext fixref="F-22412r554610_fix">Format all local volumes to use NTFS.</xccdf:fixtext>
           <xccdf:fix id="F-22412r554610_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:30" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:30" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2810,7 +2836,7 @@ Double click each active account.
 Ensure "Password never expires" is not checked on all active accounts.</xccdf:fixtext>
           <xccdf:fix id="F-22420r554634_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:77" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:77" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2834,7 +2860,7 @@ Ensure "Password never expires" is not checked on all active accounts.</xccdf:fi
           <xccdf:fixtext fixref="F-22422r554640_fix">Uninstall "Internet Information Services" or "Internet Information Services Hostable Web Core" from the system.</xccdf:fixtext>
           <xccdf:fix id="F-22422r554640_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:35" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:35" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2862,7 +2888,7 @@ Select "Turn Windows Features on or off".
 De-select "Simple Network Management Protocol (SNMP)".</xccdf:fixtext>
           <xccdf:fix id="F-22423r554643_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:55" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:55" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2890,7 +2916,7 @@ Select "Turn Windows Features on or off".
 De-select "Simple TCPIP Services (i.e. echo, daytime etc)".</xccdf:fixtext>
           <xccdf:fix id="F-22424r554646_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:56" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:56" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2919,7 +2945,7 @@ Select "Turn Windows Features on or off".
 De-select "Telnet Client".</xccdf:fixtext>
           <xccdf:fix id="F-22425r554649_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3889" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3889" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2948,14 +2974,14 @@ Select "Turn Windows Features on or off".
 De-select "TFTP Client".</xccdf:fixtext>
           <xccdf:fix id="F-22426r554652_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3887" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3887" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220726">
         <xccdf:title>SRG-OS-000433-GPOS-00192</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220726r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220726r851966_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-00-000145</xccdf:version>
           <xccdf:title>Data Execution Prevention (DEP) must be configured to at least OptOut.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Attackers are constantly looking for vulnerabilities in systems and applications. Data Execution Prevention (DEP) prevents harmful code from running in protected memory locations reserved for Windows and other programs.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2986,14 +3012,14 @@ Select the "Data Execution Prevention" tab.
 Applications that are opted out are configured in the window below the selection "Turn on DEP for all programs and services except those I select:".</xccdf:fixtext>
           <xccdf:fix id="F-22430r554664_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:121" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:121" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220727">
         <xccdf:title>SRG-OS-000433-GPOS-00192</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220727r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220727r851967_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-00-000150</xccdf:version>
           <xccdf:title>Structured Exception Handling Overwrite Protection (SEHOP) must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Attackers are constantly looking for vulnerabilities in systems and applications. Structured Exception Handling Overwrite Protection (SEHOP) blocks exploits that use the Structured Exception Handling overwrite technique, a common buffer overflow attack.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3012,7 +3038,7 @@ Applications that are opted out are configured in the window below the selection
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-22431r554667_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:123" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:123" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3047,7 +3073,7 @@ Select "Turn Windows features on or off".
 De-select "Windows PowerShell 2.0".</xccdf:fixtext>
           <xccdf:fix id="F-22432r554670_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:140" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:140" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3085,7 +3111,7 @@ Select "Turn Windows features on or off".
 De-select "SMB 1.0/CIFS File Sharing Support".</xccdf:fixtext>
           <xccdf:fix id="F-22433r554673_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:141" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:141" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3110,12 +3136,12 @@ Disabling SMBv1 support may prevent access to file or print sharing resources wi
           <xccdf:ident system="http://cyber.mil/cci">CCI-000381</xccdf:ident>
           <xccdf:fixtext fixref="F-22434r554676_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; MS Security Guide &gt;&gt; "Configure SMBv1 Server" to "Disabled".
 
-This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.   
+This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.
 
 The system must be restarted for the change to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-22434r554676_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:166" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:166" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3140,12 +3166,12 @@ Disabling SMBv1 support may prevent access to file or print sharing resources wi
           <xccdf:ident system="http://cyber.mil/cci">CCI-000381</xccdf:ident>
           <xccdf:fixtext fixref="F-22435r554679_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; MS Security Guide &gt;&gt; "Configure SMBv1 client driver" to "Enabled" with "Disable driver (recommended)" selected for "Configure MrxSmb10 driver".
 
-This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.   
+This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.
 
 The system must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-22435r554679_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:167" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:167" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3169,14 +3195,14 @@ The system must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-22436r554682_fix">Configure the "Secondary Logon" service "Startup Type" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22436r554682_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:165" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:165" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220739">
         <xccdf:title>SRG-OS-000329-GPOS-00128</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220739r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220739r851968_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AC-000005</xccdf:version>
           <xccdf:title>Windows 10 account lockout duration must be configured to 15 minutes or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system.   This parameter specifies the amount of time that an account will remain locked after the specified number of failed logon attempts.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3195,7 +3221,7 @@ The system must be restarted for the changes to take effect.</xccdf:fixtext>
 A value of "0" is also acceptable, requiring an administrator to unlock the account.</xccdf:fixtext>
           <xccdf:fix id="F-22443r554703_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3931" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3931" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3220,14 +3246,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-22444r554706_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_threshold_var" export-name="oval:mil.disa.fso.windows:var:393200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3932" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3932" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220741">
         <xccdf:title>SRG-OS-000021-GPOS-00005</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220741r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220741r851969_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AC-000015</xccdf:version>
           <xccdf:title>The period of time before the bad logon counter is reset must be configured to 15 minutes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system.  This parameter specifies the period of time that must pass after failed logon attempts before the counter is reset to 0.  The smaller this value is, the less effective the account lockout feature will be in protecting the local system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3246,7 +3272,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-22445r554709_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_reset_counter_var" export-name="oval:mil.disa.fso.windows:var:393300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3933" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3933" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3271,7 +3297,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-22446r554712_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_enforce_history_var" export-name="oval:mil.disa.fso.windows:var:393400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3934" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3934" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3296,7 +3322,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-22447r554715_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_maximum_age_var" export-name="oval:mil.disa.fso.windows:var:393500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3935" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3935" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3321,7 +3347,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-22448r554718_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_age_var" export-name="oval:mil.disa.fso.windows:var:393600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3936" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3936" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3345,8 +3371,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fixtext fixref="F-22449r554721_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Password Policy &gt;&gt; "Minimum password length" to "14" characters.</xccdf:fixtext>
           <xccdf:fix id="F-22449r554721_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_length_var" export-name="oval:mil.disa.fso.windows:var:393700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3937" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220745" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3374,14 +3399,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-22450r554724_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_complexity_var" export-name="oval:mil.disa.fso.windows:var:393800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3938" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3938" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220747">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220747r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220747r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AC-000045</xccdf:version>
           <xccdf:title>Reversible password encryption must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storing passwords using reversible encryption is essentially the same as storing clear-text versions of the passwords. For this reason, this policy must never be enabled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3399,7 +3424,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-22451r554727_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_reversible_encryption_var" export-name="oval:mil.disa.fso.windows:var:393900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3939" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3939" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3425,7 +3450,7 @@ Credential validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-22452r554730_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Logon &gt;&gt; "Audit Credential Validation" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22452r554730_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3940" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3940" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3451,14 +3476,14 @@ Credential validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-22453r554733_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Logon &gt;&gt; "Audit Credential Validation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22453r554733_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3941" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3941" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220750">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220750r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220750r851970_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000030</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - Security Group Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3483,14 +3508,14 @@ Security Group Management records events such as creating, deleting or changing 
           <xccdf:fixtext fixref="F-22454r554736_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit Security Group Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22454r554736_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3945" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3945" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220751">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220751r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220751r851971_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000035</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - User Account Management failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3515,14 +3540,14 @@ User Account Management records events such as creating, changing, deleting, ren
           <xccdf:fixtext fixref="F-22455r554739_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit User Account Management" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22455r554739_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3946" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3946" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220752">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220752r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220752r851972_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000040</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - User Account Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3547,14 +3572,14 @@ User Account Management records events such as creating, changing, deleting, ren
           <xccdf:fixtext fixref="F-22456r554742_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit User Account Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22456r554742_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3947" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3947" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220754">
         <xccdf:title>SRG-OS-000365-GPOS-00152</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220754r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220754r851974_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000050</xccdf:version>
           <xccdf:title>The system must be configured to audit Detailed Tracking - Process Creation successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3574,7 +3599,7 @@ Process creation records events related to the creation of a process and the sou
           <xccdf:fixtext fixref="F-22458r554748_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Detailed Tracking &gt;&gt; "Audit Process Creation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22458r554748_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3948" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3948" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3600,7 +3625,7 @@ Account Lockout events can be used to identify potentially malicious logon attem
           <xccdf:fixtext fixref="F-22459r554751_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Account Lockout" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22459r554751_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:147" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:147" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3627,7 +3652,7 @@ Logoff records user logoffs. If this is an interactive logoff, it is recorded on
           <xccdf:fixtext fixref="F-22461r554757_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Logoff" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22461r554757_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3949" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3949" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3654,7 +3679,7 @@ Logon records user logons. If this is an interactive logon, it is recorded on th
           <xccdf:fixtext fixref="F-22462r554760_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Logon" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22462r554760_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3950" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3950" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3681,7 +3706,7 @@ Logon records user logons. If this is an interactive logon, it is recorded on th
           <xccdf:fixtext fixref="F-22463r554763_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22463r554763_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3951" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3951" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3707,7 +3732,7 @@ Special Logon records special logons which have administrative privileges and ca
           <xccdf:fixtext fixref="F-22464r554766_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Special Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22464r554766_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3952" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3952" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3734,7 +3759,7 @@ Auditing file shares records events related to connection to shares on a system 
           <xccdf:fixtext fixref="F-22465r554769_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Object Access &gt;&gt; "Audit File Share" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22465r554769_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:160" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:160" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3761,7 +3786,7 @@ Auditing file shares records events related to connection to shares on a system 
           <xccdf:fixtext fixref="F-22466r554772_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Object Access &gt;&gt; "Audit File Share" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22466r554772_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:159" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:159" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3788,7 +3813,7 @@ Auditing for other object access records events related to the management of tas
           <xccdf:fixtext fixref="F-22467r554775_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Object Access &gt;&gt; "Audit Other Object Access Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22467r554775_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:158" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:158" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3815,7 +3840,7 @@ Auditing for other object access records events related to the management of tas
           <xccdf:fixtext fixref="F-22468r554778_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Object Access &gt;&gt; "Audit Other Object Access Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22468r554778_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:157" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:157" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3841,14 +3866,14 @@ Audit Policy Change records events related to changes in audit policy.&lt;/VulnD
           <xccdf:fixtext fixref="F-22471r554787_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Audit Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22471r554787_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3958" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3958" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220768">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220768r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220768r851975_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000105</xccdf:version>
           <xccdf:title>The system must be configured to audit Policy Change - Authentication Policy Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3868,7 +3893,7 @@ Authentication Policy Change records events related to changes in authentication
           <xccdf:fixtext fixref="F-22472r554790_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Authentication Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22472r554790_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3959" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3959" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3894,14 +3919,14 @@ Authorization Policy Change records events related to changes in user rights, su
           <xccdf:fixtext fixref="F-22473r554793_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Authorization Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22473r554793_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:150" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:150" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220770">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220770r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220770r851976_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000110</xccdf:version>
           <xccdf:title>The system must be configured to audit Privilege Use - Sensitive Privilege Use failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3921,14 +3946,14 @@ Sensitive Privilege Use records events related to use of sensitive privileges, s
           <xccdf:fixtext fixref="F-22474r554796_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Privilege Use &gt;&gt; "Audit Sensitive Privilege Use" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22474r554796_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3960" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3960" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220771">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220771r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220771r851977_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000115</xccdf:version>
           <xccdf:title>The system must be configured to audit Privilege Use - Sensitive Privilege Use successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3948,7 +3973,7 @@ Sensitive Privilege Use records events related to use of sensitive privileges, s
           <xccdf:fixtext fixref="F-22475r554799_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Privilege Use &gt;&gt; "Audit Sensitive Privilege Use" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22475r554799_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3961" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3961" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3974,7 +3999,7 @@ IPSec Driver records events related to the IPSec Driver such as dropped packets.
           <xccdf:fixtext fixref="F-22476r554802_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit IPSec Driver" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22476r554802_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3962" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3962" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4000,7 +4025,7 @@ Audit Other System Events records information related to cryptographic key opera
           <xccdf:fixtext fixref="F-22477r554805_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22477r554805_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:118" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:118" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4026,14 +4051,14 @@ Audit Other System Events records information related to cryptographic key opera
           <xccdf:fixtext fixref="F-22478r554808_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22478r554808_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:117" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:117" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220775">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220775r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220775r851978_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000140</xccdf:version>
           <xccdf:title>The system must be configured to audit System - Security State Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4053,14 +4078,14 @@ Security State Change records events related to changes in the security state, s
           <xccdf:fixtext fixref="F-22479r554811_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Security State Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22479r554811_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3965" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3965" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220776">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220776r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220776r851979_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000150</xccdf:version>
           <xccdf:title>The system must be configured to audit System - Security System Extension successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4080,14 +4105,14 @@ Security System Extension records events related to extension code being loaded 
           <xccdf:fixtext fixref="F-22480r554814_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Security System Extension" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22480r554814_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3967" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3967" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220777">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220777r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220777r851980_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000155</xccdf:version>
           <xccdf:title>The system must be configured to audit System - System Integrity failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4107,14 +4132,14 @@ System Integrity records events related to violations of integrity to the securi
           <xccdf:fixtext fixref="F-22481r554817_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit System Integrity" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22481r554817_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3968" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3968" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220778">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220778r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220778r851981_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000160</xccdf:version>
           <xccdf:title>The system must be configured to audit System - System Integrity successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4134,14 +4159,14 @@ System Integrity records events related to violations of integrity to the securi
           <xccdf:fixtext fixref="F-22482r554820_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit System Integrity" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22482r554820_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3969" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3969" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220779">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220779r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220779r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000500</xccdf:version>
           <xccdf:title>The Application event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly.  This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4161,14 +4186,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fix id="F-22483r554823_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_application_log_size_var" export-name="oval:mil.disa.fso.windows:var:405400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4054" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4054" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220780">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220780r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220780r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000505</xccdf:version>
           <xccdf:title>The Security event log size must be configured to 1024000 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly.  This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4189,14 +4214,14 @@ If the system is configured to send audit records directly to an audit server, d
           <xccdf:fix id="F-22484r554826_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_security_log_size_var" export-name="oval:mil.disa.stig.windows:var:419900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4199" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4199" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220781">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220781r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220781r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-AU-000510</xccdf:version>
           <xccdf:title>The System event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly.  This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4216,7 +4241,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fix id="F-22485r554829_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_system_log_size_var" export-name="oval:mil.disa.fso.windows:var:405700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4057" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4057" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4250,7 +4275,7 @@ The default location is the "%SystemRoot%\SYSTEM32\WINEVT\LOGS" directory.
 If the location of the logs has been changed, when adding Eventlog to the permissions, it must be entered as "NT Service\Eventlog".</xccdf:fixtext>
           <xccdf:fix id="F-22486r554832_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:51" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:51" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4284,7 +4309,7 @@ The default location is the "%SystemRoot%\SYSTEM32\WINEVT\LOGS" directory.
 If the location of the logs has been changed, when adding Eventlog to the permissions, it must be entered as "NT Service\Eventlog".</xccdf:fixtext>
           <xccdf:fix id="F-22487r554835_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:52" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:52" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4318,7 +4343,7 @@ The default location is the "%SystemRoot%\SYSTEM32\WINEVT\LOGS" directory.
 If the location of the logs has been changed, when adding Eventlog to the permissions, it must be entered as "NT Service\Eventlog".</xccdf:fixtext>
           <xccdf:fix id="F-22488r554838_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:53" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:53" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4344,7 +4369,7 @@ Audit Other Policy Change Events contains events about EFS Data Recovery Agent p
           <xccdf:fixtext fixref="F-22490r554844_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change&gt;&gt; "Audit Other Policy Change Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22490r554844_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4210" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4210" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4370,7 +4395,7 @@ Audit Other Logon/Logoff Events determines whether Windows generates audit event
           <xccdf:fixtext fixref="F-22491r554847_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Other Logon/Logoff Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22491r554847_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4204" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4204" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4396,7 +4421,7 @@ Audit Other Logon/Logoff Events determines whether Windows generates audit event
           <xccdf:fixtext fixref="F-22492r554850_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Other Logon/Logoff Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22492r554850_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4205" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4205" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4424,7 +4449,7 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <xccdf:fixtext fixref="F-22493r819663_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Object Access &gt;&gt; “Audit Detailed File Share" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22493r819663_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4206" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4206" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4450,7 +4475,7 @@ Audit MPSSVC Rule-Level Policy Change determines whether the operating system ge
           <xccdf:fixtext fixref="F-22494r554856_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; “Audit MPSSVC Rule-Level Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22494r554856_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4207" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4207" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4476,7 +4501,7 @@ Audit MPSSVC Rule-Level Policy Change determines whether the operating system ge
           <xccdf:fixtext fixref="F-22495r554859_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; “Audit MPSSVC Rule-Level Policy Change" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22495r554859_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4208" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4208" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4500,7 +4525,7 @@ Audit MPSSVC Rule-Level Policy Change determines whether the operating system ge
           <xccdf:fixtext fixref="F-22498r554868_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Control Panel &gt;&gt; Personalization &gt;&gt; "Prevent enabling lock screen slide show" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22498r554868_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:69" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:69" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4527,7 +4552,7 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-22499r554871_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_MSS_IPv6_source_routing_protection_level_var" export-name="oval:mil.disa.fso.windows:var:417600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4176" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4176" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4554,7 +4579,7 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-22500r554874_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ip_source_routing_protection_level_var" export-name="oval:mil.disa.fso.windows:var:417700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4177" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4177" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4581,14 +4606,14 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-22501r554877_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_icmp_redirects_var" export-name="oval:mil.disa.fso.windows:var:417800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4178" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4178" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220798">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220798r569187_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220798r851985_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000035</xccdf:version>
           <xccdf:title>The system must be configured to ignore NetBIOS name release requests except from WINS servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring the system to ignore name release requests, except from WINS servers, prevents a denial of service (DoS) attack. The DoS consists of sending a NetBIOS name release request to the server for each entry in the server's cache, causing a response delay in the normal operation of the servers WINS resolution capability.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4608,7 +4633,7 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-22502r554880_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_no_name_release_on_demand_var" export-name="oval:mil.disa.fso.windows:var:418200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4182" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4182" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4636,7 +4661,7 @@ With User Account Control enabled, filtering the privileged token for built-in a
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package.  "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-22503r554883_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:17" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:17" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4664,7 +4689,7 @@ The patch referenced in the policy title is not required for Windows 10.
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package.  "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-22504r554886_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:148" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:148" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4690,7 +4715,7 @@ This policy setting requires the installation of the SecGuide custom templates i
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package.  "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-22505r554889_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:154" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:154" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4714,7 +4739,7 @@ This policy setting requires the installation of the SecGuide custom templates i
           <xccdf:fixtext fixref="F-22506r554892_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Network &gt;&gt; Lanman Workstation &gt;&gt; "Enable insecure guest logons" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22506r554892_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:85" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:85" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4738,17 +4763,17 @@ This policy setting requires the installation of the SecGuide custom templates i
           <xccdf:fixtext fixref="F-22507r554895_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Network &gt;&gt; Network Connections &gt;&gt; "Prohibit use of Internet Connection Sharing on your DNS domain network" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22507r554895_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:151" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:151" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220806">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220806r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220806r890427_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000055</xccdf:version>
-          <xccdf:title>Simultaneous connections to the Internet or a Windows domain must be limited.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Multiple network connections can provide additional attack vectors to a system and must be limited. The "Minimize the number of simultaneous connections to the Internet or a Windows Domain" setting prevents systems from automatically establishing multiple connections.  When both wired and wireless connections are available, for example, the less preferred connection (typically wireless) will be disconnected.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:title>Simultaneous connections to the internet or a Windows domain must be limited.</xccdf:title>
+          <xccdf:description>&lt;VulnDiscussion&gt;Multiple network connections can provide additional attack vectors to a system and must be limited. The "Minimize the number of simultaneous connections to the Internet or a Windows Domain" setting prevents systems from automatically establishing multiple connections. When both wired and wireless connections are available, for example, the less-preferred connection (typically wireless) will be disconnected.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows 10</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -4759,12 +4784,14 @@ This policy setting requires the installation of the SecGuide custom templates i
           <xccdf:ident system="http://cyber.mil/legacy">SV-78071</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-63581</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22510r554904_fix">The default behavior for "Minimize the number of simultaneous connections to the Internet or a Windows Domain" is "Enabled".
+          <xccdf:fixtext fixref="F-22510r857187_fix">The default behavior for "Minimize the number of simultaneous connections to the Internet or a Windows Domain" is "Enabled".
 
-If this needs to be corrected, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Network &gt;&gt; Windows Connection Manager &gt;&gt; "Minimize the number of simultaneous connections to the Internet or a Windows Domain" to "Enabled".</xccdf:fixtext>
-          <xccdf:fix id="F-22510r554904_fix" />
+If this must be corrected, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Network &gt;&gt; Windows Connection Manager &gt;&gt; "Minimize the number of simultaneous connections to the Internet or a Windows Domain" to "Enabled".
+
+Under "Options", set "Minimize Policy Options" to "3 = Prevent Wi-Fi When on Ethernet".</xccdf:fixtext>
+          <xccdf:fix id="F-22510r857187_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:95" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220806" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4788,7 +4815,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-22511r554907_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Network &gt;&gt; Windows Connection Manager &gt;&gt; "Prohibit connection to non-domain networks when connected to domain authenticated network" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22511r554907_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3985" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:3985" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4809,12 +4836,12 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:ident system="http://cyber.mil/legacy">V-63591</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78081</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22512r554910_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Network &gt;&gt; WLAN Service &gt;&gt; WLAN Settings&gt;&gt; "Allow Windows to automatically connect to suggested open hotspots, to networks shared by contacts, and to hotspots offering paid services" to "Disabled".   
+          <xccdf:fixtext fixref="F-22512r554910_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Network &gt;&gt; WLAN Service &gt;&gt; WLAN Settings&gt;&gt; "Allow Windows to automatically connect to suggested open hotspots, to networks shared by contacts, and to hotspots offering paid services" to "Disabled".
 
 v1507 LTSB does not include this group policy setting.  It may be configured through other means such as using group policy from a later version of Windows 10 or a registry update.</xccdf:fixtext>
           <xccdf:fix id="F-22512r554910_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:23" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:23" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4841,7 +4868,7 @@ Enabling "Include command line data for process creation events" will record the
           <xccdf:fixtext fixref="F-22513r554913_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Audit Process Creation &gt;&gt; "Include command line in process creation events" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22513r554913_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:139" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:139" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4865,7 +4892,44 @@ Enabling "Include command line data for process creation events" will record the
           <xccdf:fixtext fixref="F-22514r554916_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Credentials Delegation &gt;&gt; "Remote host allows delegation of non-exportable credentials" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22514r554916_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:162" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:162" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </xccdf:check>
+        </xccdf:Rule>
+      </xccdf:Group>
+      <xccdf:Group id="xccdf_mil.disa.stig_group_V-220812">
+        <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
+        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220812r890430_rule" weight="10.0" severity="high">
+          <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000075</xccdf:version>
+          <xccdf:title>Credential Guard must be running on Windows 10 domain-joined systems.</xccdf:title>
+          <xccdf:description>&lt;VulnDiscussion&gt;Credential Guard uses virtualization based security to protect information that could be used in credential theft attacks if compromised. This authentication information, which was stored in the Local Security Authority (LSA) in previous versions of Windows, is isolated from the rest of operating system and can only be accessed by privileged system software.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:reference>
+            <dc:title>DPMS Target Microsoft Windows 10</dc:title>
+            <dc:publisher>DISA</dc:publisher>
+            <dc:type>DPMS Target</dc:type>
+            <dc:subject>Microsoft Windows 10</dc:subject>
+            <dc:identifier>4072</dc:identifier>
+          </xccdf:reference>
+          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_MemberWorkstation" />
+          <xccdf:ident system="http://cyber.mil/legacy">SV-78089</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/legacy">V-63599</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
+          <xccdf:fixtext fixref="F-22516r890429_fix">Virtualization based security, including Credential Guard, currently cannot be implemented in VDIs due to specific supporting requirements including a TPM, UEFI with Secure Boot, and the capability to run the Hyper-V feature within the virtual desktop.
+
+For VDIs where the virtual desktop instance is deleted or refreshed upon logoff, this is Not Applicable.
+
+For VDIs with persistent desktops, this may be downgraded to a CAT II only where administrators have specific tokens for the VDI. Administrator accounts on virtual desktops must only be used on systems in the VDI; they may not have administrative privileges on any other systems such as servers and physical workstations.
+
+Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Device Guard &gt;&gt; "Turn On Virtualization Based Security" to "Enabled" with "Enabled with UEFI lock" selected for "Credential Guard Configuration:".
+
+v1507 LTSB does not include selection options; select "Enable Credential Guard".
+
+A Microsoft TechNet article on Credential Guard, including system requirement details, can be found at the following link:
+
+https://docs.microsoft.com/en-us/windows/access-protection/credential-guard/credential-guard</xccdf:fixtext>
+          <xccdf:fix id="F-22516r890429_fix" />
+          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:220812" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4891,7 +4955,7 @@ Enabling "Include command line data for process creation events" will record the
 If this needs to be corrected configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Early Launch Antimalware &gt;&gt; "Boot-Start Driver Initialization Policy" to "Enabled” with "Good, unknown and bad but critical" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22517r554925_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:97" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:97" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4915,7 +4979,7 @@ If this needs to be corrected configure the policy value for Computer Configurat
           <xccdf:fixtext fixref="F-22518r554928_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Group Policy &gt;&gt; "Configure registry policy processing" to "Enabled" and select the option "Process even if the Group Policy objects have not changed".</xccdf:fixtext>
           <xccdf:fix id="F-22518r554928_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:98" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:98" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4940,7 +5004,7 @@ If this needs to be corrected configure the policy value for Computer Configurat
           <xccdf:fix id="F-22519r554931_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_downloading_of_print_drivers_over_http_var" export-name="oval:mil.disa.fso.windows:var:400200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4002" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4002" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4965,7 +5029,7 @@ If this needs to be corrected configure the policy value for Computer Configurat
           <xccdf:fix id="F-22520r554934_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_internet_download_for_web_publishing_and_online_ordering_wizards_var" export-name="oval:mil.disa.fso.windows:var:400700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4007" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4007" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4990,14 +5054,14 @@ If this needs to be corrected configure the policy value for Computer Configurat
           <xccdf:fix id="F-22521r554937_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_printing_over_http_var" export-name="oval:mil.disa.fso.windows:var:400900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4009" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4009" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220818">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220818r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220818r857191_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000115</xccdf:version>
           <xccdf:title>Systems must at least attempt device authentication using certificates.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Using certificates to authenticate devices to the domain provides increased security over passwords.  By default systems will attempt to authenticate using certificates and fall back to passwords if the domain controller does not support certificates for devices.  This may also be configured to always use certificates for device authentication.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5011,14 +5075,14 @@ If this needs to be corrected configure the policy value for Computer Configurat
           <xccdf:ident system="http://cyber.mil/legacy">V-63627</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78117</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22522r554940_fix">This requirement is applicable to domain-joined systems, for standalone systems this is NA.
+          <xccdf:fixtext fixref="F-22522r857190_fix">This requirement is applicable to domain-joined systems. For standalone or nondomain-joined systems, this is NA.
 
 The default behavior for "Support device authentication using certificate" is "Automatic".
 
-If this needs to be corrected, configured the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Kerberos &gt;&gt; "Support device authentication using certificate" to "Not Configured or "Enabled" with either option selected in "Device authentication behavior using certificate:".</xccdf:fixtext>
-          <xccdf:fix id="F-22522r554940_fix" />
+If this needs to be corrected, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Kerberos &gt;&gt; "Support device authentication using certificate" to "Not Configured or "Enabled" with either option selected in "Device authentication behavior using certificate:".</xccdf:fixtext>
+          <xccdf:fix id="F-22522r857190_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:21" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:21" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5042,17 +5106,17 @@ If this needs to be corrected, configured the policy value for Computer Configur
           <xccdf:fixtext fixref="F-22523r554943_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Logon &gt;&gt; "Do not display network selection UI" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22523r554943_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:66" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:66" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220820">
         <xccdf:title>SRG-OS-000095-GPOS-00049</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220820r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220820r857194_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000130</xccdf:version>
           <xccdf:title>Local users on domain-joined computers must not be enumerated.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;The username is one part of logon credentials that could be used to gain access to a system.  Preventing the enumeration of users limits this information to authorized personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:description>&lt;VulnDiscussion&gt;The username is one part of logon credentials that could be used to gain access to a system. Preventing the enumeration of users limits this information to authorized personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows 10</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -5063,19 +5127,19 @@ If this needs to be corrected, configured the policy value for Computer Configur
           <xccdf:ident system="http://cyber.mil/legacy">SV-78123</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-63633</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000381</xccdf:ident>
-          <xccdf:fixtext fixref="F-22524r554946_fix">This requirement is applicable to domain-joined systems, for standalone systems this is NA.
+          <xccdf:fixtext fixref="F-22524r857193_fix">This requirement is applicable to domain-joined systems. For standalone or nondomain-joined systems, this is NA.
 
 Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Logon &gt;&gt; "Enumerate local users on domain-joined computers" to "Disabled".</xccdf:fixtext>
-          <xccdf:fix id="F-22524r554946_fix" />
+          <xccdf:fix id="F-22524r857193_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:108" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:108" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220821">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220821r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220821r851986_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000145</xccdf:version>
           <xccdf:title>Users must be prompted for a password on resume from sleep (on battery).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Authentication must always be required when accessing a system.  This setting ensures the user is prompted for a password on resume from sleep (on battery).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5093,14 +5157,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fix id="F-22525r554949_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_on_battery_var" export-name="oval:mil.disa.fso.windows:var:402400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4024" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4024" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220822">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220822r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220822r851987_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000150</xccdf:version>
           <xccdf:title>The user must be prompted for a password on resume from sleep (plugged in).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Authentication must always be required when accessing a system.  This setting ensures the user is prompted for a password on resume from sleep (plugged in).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5118,7 +5182,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fix id="F-22526r554952_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_plugged_var" export-name="oval:mil.disa.fso.windows:var:402500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4025" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4025" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5143,14 +5207,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fix id="F-22527r554955_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_solicited_remote_assistance_var" export-name="oval:mil.disa.stig.windows:var:402900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4029" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4029" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220824">
         <xccdf:title>SRG-OS-000379-GPOS-00164</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220824r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220824r877039_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000165</xccdf:version>
           <xccdf:title>Unauthenticated RPC clients must be restricted from connecting to the RPC server.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring RPC to restrict unauthenticated RPC clients from connecting to the RPC server will prevent anonymous connections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5168,7 +5232,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fix id="F-22528r554958_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_restrictions_for_unauthenticated_rpc_clients_var" export-name="oval:mil.disa.fso.windows:var:403400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4034" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4034" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5192,7 +5256,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fixtext fixref="F-22529r554961_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; App Runtime &gt;&gt; "Allow Microsoft accounts to be optional" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22529r554961_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:67" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:67" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5217,14 +5281,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fix id="F-22530r554964_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_program_inventory_var" export-name="oval:mil.disa.fso.windows:var:404100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4041" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4041" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220827">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220827r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220827r851989_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000180</xccdf:version>
           <xccdf:title>Autoplay must be turned off for non-volume devices.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing autoplay to execute may introduce malicious code to a system.  Autoplay begins reading from a drive as soon as you insert media in the drive.  As a result, the setup file of programs or music on audio media may start.  This setting will disable autoplay for non-volume devices (such as Media Transfer Protocol (MTP) devices).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5242,14 +5306,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fix id="F-22531r554967_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_autoplay_for_non_volume_devices_var" export-name="oval:mil.disa.fso.windows:var:404200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4042" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4042" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220828">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220828r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220828r851990_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000185</xccdf:version>
           <xccdf:title>The default autorun behavior must be configured to prevent autorun commands.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing autorun commands to execute may introduce malicious code to a system.  Configuring this setting prevents autorun commands from executing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5267,14 +5331,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fix id="F-22532r554970_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_default_behavior_for_autorun_var" export-name="oval:mil.disa.fso.windows:var:404300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4043" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4043" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220829">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220829r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220829r851991_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000190</xccdf:version>
           <xccdf:title>Autoplay must be disabled for all drives.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing autoplay to execute may introduce malicious code to a system.  Autoplay begins reading from a drive as soon as you insert media in the drive.  As a result, the setup file of programs or music on audio media may start.  By default, autoplay is disabled on removable drives, such as the floppy disk drive (but not the CD-ROM drive) and on network drives.  If you enable this policy, you can also disable autoplay on all drives.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5291,7 +5355,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:fixtext fixref="F-22533r554973_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; AutoPlay Policies &gt;&gt; "Turn off AutoPlay" to "Enabled:All Drives".</xccdf:fixtext>
           <xccdf:fix id="F-22533r554973_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4044" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4044" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5312,13 +5376,13 @@ Configure the policy value for Computer Configuration &gt;&gt; Administrative Te
           <xccdf:ident system="http://cyber.mil/legacy">SV-78167</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-63677</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22534r554976_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Biometrics &gt;&gt; Facial Features &gt;&gt; "Configure enhanced anti-spoofing" to "Enabled". 
+          <xccdf:fixtext fixref="F-22534r554976_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Biometrics &gt;&gt; Facial Features &gt;&gt; "Configure enhanced anti-spoofing" to "Enabled".
 
 v1607:
 The policy name is "Use enhanced anti-spoofing when available".</xccdf:fixtext>
           <xccdf:fix id="F-22534r554976_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:86" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:86" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5342,7 +5406,7 @@ The policy name is "Use enhanced anti-spoofing when available".</xccdf:fixtext>
           <xccdf:fixtext fixref="F-22535r554979_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Cloud Content &gt;&gt; "Turn off Microsoft consumer experiences" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22535r554979_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:153" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:153" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5367,7 +5431,7 @@ The policy name is "Use enhanced anti-spoofing when available".</xccdf:fixtext>
           <xccdf:fix id="F-22536r554982_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_enumerate_administrator_accounts_on_elevation_var" export-name="oval:mil.disa.fso.windows:var:404700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4047" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4047" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5391,7 +5455,7 @@ The policy name is "Use enhanced anti-spoofing when available".</xccdf:fixtext>
           <xccdf:fixtext fixref="F-22537r554985_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Data Collection and Preview Builds &gt;&gt; "Limit Enhanced diagnostic data to the minimum required by Windows Analytics" to "Enabled" with "Enable Windows Analytics collection" selected in "Options:".</xccdf:fixtext>
           <xccdf:fix id="F-22537r554985_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:176" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:176" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5412,22 +5476,22 @@ The policy name is "Use enhanced anti-spoofing when available".</xccdf:fixtext>
           <xccdf:ident system="http://cyber.mil/legacy">V-63683</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78173</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22538r554988_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Data Collection and Preview Builds &gt;&gt; "Allow Telemetry" to "Enabled" with "0 - Security [Enterprise Only]" or "1 - Basic" selected in "Options:".   
+          <xccdf:fixtext fixref="F-22538r554988_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Data Collection and Preview Builds &gt;&gt; "Allow Telemetry" to "Enabled" with "0 - Security [Enterprise Only]" or "1 - Basic" selected in "Options:".
 
 If an organization is using v1709 or later of Windows 10 this may be configured to "2 - Enhanced" to support Windows Analytics. V-82145 must also be configured to limit the Enhanced diagnostic data to the minimum required by Windows Analytics.</xccdf:fixtext>
           <xccdf:fix id="F-22538r554988_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:175" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220834" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220835">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220835r569187_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220835r857197_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000206</xccdf:version>
-          <xccdf:title>Windows Update must not obtain updates from other PCs on the Internet.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Windows 10 allows Windows Update to obtain updates from additional sources instead of Microsoft. In addition to Microsoft, updates can be obtained from and sent to PCs on the local network as well as on the Internet. This is part of the Windows Update trusted process, however to minimize outside exposure, obtaining updates from or sending to systems on the Internet must be prevented.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:title>Windows Update must not obtain updates from other PCs on the internet.</xccdf:title>
+          <xccdf:description>&lt;VulnDiscussion&gt;Windows 10 allows Windows Update to obtain updates from additional sources instead of Microsoft. In addition to Microsoft, updates can be obtained from and sent to PCs on the local network as well as on the internet. This is part of the Windows Update trusted process; however, to minimize outside exposure, obtaining updates from or sending to systems on the internet must be prevented.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows 10</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -5438,7 +5502,7 @@ If an organization is using v1709 or later of Windows 10 this may be configured 
           <xccdf:ident system="http://cyber.mil/legacy">SV-80171</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-65681</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22539r554991_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Delivery Optimization &gt;&gt; "Download Mode" to "Enabled" with any option except "Internet" selected.
+          <xccdf:fixtext fixref="F-22539r857196_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Delivery Optimization &gt;&gt; "Download Mode" to "Enabled" with any option except "Internet" selected.
 
 Acceptable selections include:
 Bypass (100)
@@ -5447,10 +5511,12 @@ HTTP only (0)
 LAN (1)
 Simple (99)
 
-v1507 (LTSB) does not include this group policy setting locally. For domain joined systems, configure through domain group policy as "HTTP only (0)" or "Lan (1)". Standalone systems configure using Settings &gt;&gt; Update &amp; Security &gt;&gt; Windows Update &gt;&gt; Advanced Options &gt;&gt; "Choose how updates are delivered" with either "Off" or "PCs on my local network" selected.</xccdf:fixtext>
-          <xccdf:fix id="F-22539r554991_fix" />
+v1507 (LTSB) does not include this group policy setting locally. For domain-joined systems, configure through domain group policy as "HTTP only (0)" or "Lan (1)".
+
+For standalone or nondomain-joined systems, configure using Settings &gt;&gt; Update &amp; Security &gt;&gt; Windows Update &gt;&gt; Advanced Options &gt;&gt; "Choose how updates are delivered" with either "Off" or "PCs on my local network" selected.</xccdf:fixtext>
+          <xccdf:fix id="F-22539r857196_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4985" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220835" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5471,7 +5537,7 @@ v1507 (LTSB) does not include this group policy setting locally. For domain join
           <xccdf:ident system="http://cyber.mil/legacy">V-63685</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78175</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000381</xccdf:ident>
-          <xccdf:fixtext fixref="F-22540r554994_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; File Explorer &gt;&gt; "Configure Windows Defender SmartScreen" to "Enabled" with "Warn and prevent bypass" selected. 
+          <xccdf:fixtext fixref="F-22540r554994_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; File Explorer &gt;&gt; "Configure Windows Defender SmartScreen" to "Enabled" with "Warn and prevent bypass" selected.
 
 Windows 10 includes duplicate policies for this setting. It can also be configured under Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Defender SmartScreen &gt;&gt; Explorer.
 
@@ -5482,14 +5548,14 @@ v1507 LTSB:
 Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; File Explorer &gt;&gt; "Configure Windows SmartScreen" to "Enabled" with "Require approval from an administrator before running downloaded unknown software" selected.</xccdf:fixtext>
           <xccdf:fix id="F-22540r554994_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:99" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:99" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220837">
         <xccdf:title>SRG-OS-000433-GPOS-00192</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220837r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220837r851992_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000215</xccdf:version>
           <xccdf:title>Explorer Data Execution Prevention must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Data Execution Prevention (DEP) provides additional protection by performing  checks on memory to help prevent malicious code from running.  This setting will prevent Data Execution Prevention from being turned off for File Explorer.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5509,14 +5575,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-22541r554997_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_data_execution_prevention_for_explorer_var" export-name="oval:mil.disa.fso.windows:var:405900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:104" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:104" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220838">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220838r569187_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220838r851993_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000220</xccdf:version>
           <xccdf:title>Turning off File Explorer heap termination on corruption must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Legacy plug-in applications may continue to function when a File Explorer session has become corrupt.  Disabling this feature will prevent this.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5536,7 +5602,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-22542r555000_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_heap_termination_corruption_var" export-name="oval:mil.disa.fso.windows:var:406000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4060" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4060" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5562,7 +5628,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
 If this needs to be corrected, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; File Explorer &gt;&gt; "Turn off shell protocol protected mode" to "Not Configured" or "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22543r555003_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:101" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:101" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5583,12 +5649,12 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:ident system="http://cyber.mil/legacy">V-63699</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78189</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22544r555006_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Microsoft Edge &gt;&gt; "Prevent bypassing Windows Defender SmartScreen prompts for sites" to "Enabled". 
+          <xccdf:fixtext fixref="F-22544r555006_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Microsoft Edge &gt;&gt; "Prevent bypassing Windows Defender SmartScreen prompts for sites" to "Enabled".
 
 Windows 10 includes duplicate policies for this setting. It can also be configured under Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Defender SmartScreen &gt;&gt; Microsoft Edge.</xccdf:fixtext>
           <xccdf:fix id="F-22544r555006_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:87" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:87" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5609,12 +5675,12 @@ Windows 10 includes duplicate policies for this setting. It can also be configur
           <xccdf:ident system="http://cyber.mil/legacy">SV-78191</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-63701</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22545r555009_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Microsoft Edge &gt;&gt; "Prevent bypassing Windows Defender SmartScreen prompts for files" to "Enabled". 
+          <xccdf:fixtext fixref="F-22545r555009_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Microsoft Edge &gt;&gt; "Prevent bypassing Windows Defender SmartScreen prompts for files" to "Enabled".
 
 Windows 10 includes duplicate policies for this setting. It can also be configured under Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Defender SmartScreen &gt;&gt; Microsoft Edge.</xccdf:fixtext>
           <xccdf:fix id="F-22545r555009_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:88" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:88" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5638,7 +5704,7 @@ Windows 10 includes duplicate policies for this setting. It can also be configur
           <xccdf:fixtext fixref="F-22546r555012_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Microsoft Edge &gt;&gt; "Prevent certificate error overrides" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22546r555012_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:174" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:174" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5662,7 +5728,7 @@ Windows 10 includes duplicate policies for this setting. It can also be configur
           <xccdf:fixtext fixref="F-22547r555015_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Microsoft Edge &gt;&gt; "Configure Password Manager" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22547r555015_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:25" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:25" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5683,12 +5749,12 @@ Windows 10 includes duplicate policies for this setting. It can also be configur
           <xccdf:ident system="http://cyber.mil/legacy">SV-78203</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-63713</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22548r555018_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Microsoft Edge &gt;&gt; "Configure Windows Defender SmartScreen" to "Enabled". 
+          <xccdf:fixtext fixref="F-22548r555018_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Microsoft Edge &gt;&gt; "Configure Windows Defender SmartScreen" to "Enabled".
 
 Windows 10 includes duplicate policies for this setting. It can also be configured under Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Defender SmartScreen &gt;&gt; Microsoft Edge.</xccdf:fixtext>
           <xccdf:fix id="F-22548r555018_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:90" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:90" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5712,7 +5778,7 @@ Windows 10 includes duplicate policies for this setting. It can also be configur
           <xccdf:fixtext fixref="F-22549r555021_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Game Recording and Broadcasting &gt;&gt; "Enables or disables Windows Game Recording and Broadcasting" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22549r555021_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:164" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:164" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5733,7 +5799,7 @@ Windows 10 includes duplicate policies for this setting. It can also be configur
           <xccdf:ident system="http://cyber.mil/legacy">SV-78211</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-63721</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-22551r555027_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; PIN Complexity &gt;&gt; "Minimum PIN length" to "6" or greater. 
+          <xccdf:fixtext fixref="F-22551r555027_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; PIN Complexity &gt;&gt; "Minimum PIN length" to "6" or greater.
 
 v1607 LTSB:
 The policy path is Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Hello for Business &gt;&gt; Pin Complexity.
@@ -5742,14 +5808,14 @@ v1507 LTSB:
 The policy path is Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Microsoft Passport for Work &gt;&gt; Pin Complexity.</xccdf:fixtext>
           <xccdf:fix id="F-22551r555027_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:27" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:27" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220848">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220848r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220848r851994_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000270</xccdf:version>
           <xccdf:title>Passwords must not be saved in the Remote Desktop Client.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Saving passwords in the Remote Desktop Client could allow an unauthorized user to establish a remote desktop session to another system.  The system must be configured to prevent users from saving passwords in the Remote Desktop Client.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5767,7 +5833,7 @@ The policy path is Computer Configuration &gt;&gt; Administrative Templates &gt;
           <xccdf:fix id="F-22552r555030_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_passwords_to_be_saved_var" export-name="oval:mil.disa.fso.windows:var:406600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4066" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4066" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5792,14 +5858,14 @@ The policy path is Computer Configuration &gt;&gt; Administrative Templates &gt;
           <xccdf:fix id="F-22553r555033_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_drive_redirection_var" export-name="oval:mil.disa.fso.windows:var:406800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4068" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4068" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220850">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220850r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220850r851995_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000280</xccdf:version>
           <xccdf:title>Remote Desktop Services must always prompt a client for passwords upon connection.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting controls the ability of users to supply passwords automatically as part of their remote desktop connection.  Disabling this setting would allow anyone to use the stored credentials in a connection item to connect to the terminal server.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5817,14 +5883,14 @@ The policy path is Computer Configuration &gt;&gt; Administrative Templates &gt;
           <xccdf:fix id="F-22554r555036_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_always_prompt_for_password_upon_connection_var" export-name="oval:mil.disa.fso.windows:var:406900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4069" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4069" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220851">
         <xccdf:title>SRG-OS-000250-GPOS-00093</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220851r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220851r877394_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000285</xccdf:version>
           <xccdf:title>The Remote Desktop Session Host must require secure RPC communications.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing unsecure RPC communication exposes the system to man in the middle attacks and data disclosure attacks. A man in the middle attack occurs when an intruder captures packets between a client and server and modifies them before allowing the packets to be exchanged. Usually the attacker will modify the information in the packets in an attempt to cause either the client or server to reveal sensitive information.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5841,14 +5907,14 @@ The policy path is Computer Configuration &gt;&gt; Administrative Templates &gt;
           <xccdf:fixtext fixref="F-22555r555039_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Remote Desktop Services &gt;&gt; Remote Desktop Session Host &gt;&gt; Security "Require secure RPC communication" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22555r555039_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4099" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4099" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220852">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220852r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220852r877398_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000290</xccdf:version>
           <xccdf:title>Remote Desktop Services must be configured with the client connection encryption set to the required level.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Remote connections must be encrypted to prevent interception of data or sensitive information. Selecting "High Level" will ensure encryption of Remote Desktop Services sessions in both directions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5867,7 +5933,7 @@ The policy path is Computer Configuration &gt;&gt; Administrative Templates &gt;
           <xccdf:fix id="F-22556r555042_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_set_client_connection_encryption_level_var" export-name="oval:mil.disa.fso.windows:var:407000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4070" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4070" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5891,7 +5957,7 @@ The policy path is Computer Configuration &gt;&gt; Administrative Templates &gt;
           <xccdf:fixtext fixref="F-22557r555045_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; RSS Feeds &gt;&gt; "Prevent downloading of enclosures" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22557r555045_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4075" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4075" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5917,7 +5983,7 @@ The policy path is Computer Configuration &gt;&gt; Administrative Templates &gt;
 If this needs to be corrected, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; RSS Feeds &gt;&gt; "Turn on Basic feed authentication over HTTP" to "Not Configured" or "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22558r555048_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:100" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:100" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5942,14 +6008,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-22559r555051_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_indexing_of_encrypted_files_var" export-name="oval:mil.disa.fso.windows:var:407700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4077" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4077" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220856">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220856r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220856r851997_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000310</xccdf:version>
           <xccdf:title>Users must be prevented from changing installation options.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Installation options for applications are typically controlled by administrators.  This setting prevents users from changing installation options that may bypass security features.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5966,14 +6032,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-22560r555054_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Installer &gt;&gt; "Allow user control over installs" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22560r555054_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4084" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4084" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220857">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220857r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220857r851998_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000315</xccdf:version>
           <xccdf:title>The Windows Installer Always install with elevated privileges must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Standard user accounts must not be granted elevated privileges.  Enabling Windows Installer to elevate privileges when installing applications can allow malicious persons and applications to gain full control of a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5990,7 +6056,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-22561r555057_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Installer &gt;&gt; "Always install with elevated privileges" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22561r555057_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4085" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4085" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6016,14 +6082,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
 If this needs to be corrected, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Installer &gt;&gt; "Prevent Internet Explorer security prompt for Windows Installer scripts" to "Not Configured" or "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22562r555060_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:113" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:113" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220859">
         <xccdf:title>SRG-OS-000480-GPOS-00229</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220859r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220859r877377_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000325</xccdf:version>
           <xccdf:title>Automatically signing in the last interactive user after a system-initiated restart must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Windows can be configured to automatically sign the user back in after a Windows Update restart.  Some protections are in place to help ensure this is done in a secure fashion; however, disabling this will prevent the caching of credentials for this purpose and also ensure the user is aware of the restart.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6040,7 +6106,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-22563r555063_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Logon Options &gt;&gt; "Sign-in last interactive user automatically after a system-initiated restart" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22563r555063_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:65" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:65" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6066,14 +6132,14 @@ Enabling PowerShell script block logging will record detailed information from t
           <xccdf:fixtext fixref="F-22564r555066_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows PowerShell &gt;&gt; "Turn on PowerShell Script Block Logging" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22564r555066_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:137" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:137" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220862">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220862r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220862r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000330</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain text passwords that could be used to compromise a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6090,14 +6156,14 @@ Enabling PowerShell script block logging will record detailed information from t
           <xccdf:fixtext fixref="F-22566r555072_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Client &gt;&gt; "Allow Basic authentication" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22566r555072_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4092" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4092" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220863">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220863r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220863r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000335</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised.  Windows remote management connections must be encrypted to prevent this.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6115,14 +6181,14 @@ Enabling PowerShell script block logging will record detailed information from t
           <xccdf:fixtext fixref="F-22567r555075_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Client &gt;&gt; "Allow unencrypted traffic" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22567r555075_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4093" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4093" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220865">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220865r654974_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220865r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000345</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain text passwords that could be used to compromise a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6138,23 +6204,23 @@ Enabling PowerShell script block logging will record detailed information from t
           <xccdf:ident system="http://cyber.mil/cci">CCI-000877</xccdf:ident>
           <xccdf:fixtext fixref="F-22569r654973_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Service &gt;&gt; "Allow Basic authentication" to "Disabled".
 
-Severity Override Guidance: The AO can allow the severity override if they have reviewed the overall protection. This would only be allowed temporarily for implementation as documented and approved. 
+Severity Override Guidance: The AO can allow the severity override if they have reviewed the overall protection. This would only be allowed temporarily for implementation as documented and approved.
 ….
 Allowing Basic authentication to be used for the sole creation of Office 365 DoD tenants.
 ….
-A documented mechanism and or script that can disable Basic authentication once administration completes. 
+A documented mechanism and or script that can disable Basic authentication once administration completes.
 ….
 Use of a Privileged Access Workstation (PAW) and adherence to the Clean Source principle for administration.</xccdf:fixtext>
           <xccdf:fix id="F-22569r654973_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4095" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4095" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220866">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220866r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220866r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000350</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised.  Windows remote management connections must be encrypted to prevent this.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6172,14 +6238,14 @@ Use of a Privileged Access Workstation (PAW) and adherence to the Clean Source p
           <xccdf:fixtext fixref="F-22570r555084_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Service &gt;&gt; "Allow unencrypted traffic" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-22570r555084_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4096" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4096" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220867">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220867r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220867r852001_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000355</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not store RunAs credentials.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storage of administrative credentials could allow unauthorized access.  Disallowing the storage of RunAs credentials for Windows Remote Management will prevent them from being used with plug-ins.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6196,14 +6262,14 @@ Use of a Privileged Access Workstation (PAW) and adherence to the Clean Source p
           <xccdf:fixtext fixref="F-22571r555087_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Service &gt;&gt; "Disallow WinRM from storing RunAs credentials" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22571r555087_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4097" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4097" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220868">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220868r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220868r877395_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000360</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not use Digest authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Digest authentication is not as strong as other options and may be subject to man-in-the-middle attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6220,7 +6286,7 @@ Use of a Privileged Access Workstation (PAW) and adherence to the Clean Source p
           <xccdf:fixtext fixref="F-22572r555090_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Client &gt;&gt; "Disallow Digest authentication" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-22572r555090_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4094" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4094" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6241,12 +6307,12 @@ Use of a Privileged Access Workstation (PAW) and adherence to the Clean Source p
           <xccdf:ident system="http://cyber.mil/legacy">V-99559</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-108663</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000381</xccdf:ident>
-          <xccdf:fixtext fixref="F-22574r555096_fix">Disable the convenience PIN sign-in. 
+          <xccdf:fixtext fixref="F-22574r555096_fix">Disable the convenience PIN sign-in.
 
 If this needs to be corrected configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Logon &gt;&gt; Set "Turn on convenience PIN sign-in" to "Disabled”.</xccdf:fixtext>
           <xccdf:fix id="F-22574r555096_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4212" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4212" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6267,12 +6333,12 @@ If this needs to be corrected configure the policy value for Computer Configurat
           <xccdf:ident system="http://cyber.mil/legacy">SV-108665</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-99561</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000381</xccdf:ident>
-          <xccdf:fixtext fixref="F-22575r642140_fix">Disable the convenience PIN sign-in. 
+          <xccdf:fixtext fixref="F-22575r642140_fix">Disable the convenience PIN sign-in.
 
 If this needs to be corrected, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Ink Workspace &gt;&gt; Set "Allow Windows Ink Workspace" to "Enabled” and set Options "On, but disallow access above lock".</xccdf:fixtext>
           <xccdf:fix id="F-22575r642140_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4213" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4213" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6296,17 +6362,17 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-22606r555192_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Kernel DMA Protection &gt;&gt; "Enumeration policy for external devices incompatible with Kernel DMA Protection" to "Enabled" with "Enumeration Policy" set to "Block All".</xccdf:fixtext>
           <xccdf:fix id="F-22606r555192_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4211" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4211" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220903">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220903r819670_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220903r894651_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-PK-000005</xccdf:version>
           <xccdf:title>The DoD Root CA certificates must be installed in the Trusted Root Store.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure  the trust chain is established for server certificates issued from the DoD CAs.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:description>&lt;VulnDiscussion&gt;To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure the trust chain is established for server certificates issued from the DoD CAs.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows 10</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -6317,23 +6383,23 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:ident system="http://cyber.mil/legacy">V-63579</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78069</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-22607r819669_fix">Install the DoD Root CA certificates:
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
+          <xccdf:fixtext fixref="F-22607r894324_fix">Install the DoD Root CA certificates:
 DoD Root CA 3
 DoD Root CA 4
 DoD Root CA 5
 
-The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-22607r819669_fix" />
+The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. Certificate bundles published by the PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-22607r894324_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:136" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220903" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220904">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220904r569312_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220904r894652_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-PK-000010</xccdf:version>
           <xccdf:title>The External Root CA certificates must be installed in the Trusted Root Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure secure websites protected with External Certificate Authority (ECA) server certificates are properly validated, the system must trust the ECA Root CAs. The ECA root certificates will ensure the trust chain is established for server certificates issued from the External CAs. This requirement only applies to unclassified systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6347,21 +6413,20 @@ The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke
           <xccdf:ident system="http://cyber.mil/legacy">V-63583</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78073</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:fixtext fixref="F-22608r603230_fix">Install the ECA Root CA certificates on unclassified systems.
-ECA Root CA 2
+          <xccdf:fixtext fixref="F-22608r894327_fix">Install the ECA Root CA certificate on unclassified systems.
 ECA Root CA 4
 
-The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-22608r603230_fix" />
+The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. Certificate bundles published by the PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-22608r894327_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:135" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220904" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220905">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220905r819673_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220905r890436_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-PK-000015</xccdf:version>
           <xccdf:title>The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6375,26 +6440,24 @@ The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke
           <xccdf:ident system="http://cyber.mil/legacy">V-63587</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78077</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-22609r819672_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
+          <xccdf:fixtext fixref="F-22609r890435_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
 
 Issued To - Issued By - Thumbprint
 
-DoD Root CA 3 - DoD Interoperability Root CA 2 - AC06108CA348CC03B53795C64BF84403C1DBD341
+DoD Root CA 3 - DoD Interoperability Root CA 2 - 49CBE933151872E17C8EAE7F0ABA97FB610F6477
 
-DoD Root CA 3 - DoD Interoperability Root CA 2 - 49CBE933151872E17C8EAE7F0ABA97FB610F6477 
-                  
-The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-22609r819672_fix" />
+The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-22609r890435_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:134" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220905" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220906">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220906r569316_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220906r890439_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-PK-000020</xccdf:version>
           <xccdf:title>The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6409,15 +6472,15 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:ident system="http://cyber.mil/legacy">V-63589</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
-          <xccdf:fixtext fixref="F-22610r603234_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
+          <xccdf:fixtext fixref="F-22610r890438_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
 
 Issued To - Issued By - Thumbprint
-DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2 - AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9
+DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2  9B74964506C7ED9138070D08D5F8B969866560C8
 
-The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-22610r603234_fix" />
+The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-22610r890438_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:133" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220906" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6443,7 +6506,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-22612r555210_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_admin_account_status_var" export-name="oval:mil.disa.stig.windows:var:12900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:129" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:129" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6469,7 +6532,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-22613r555213_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_guest_account_status_var" export-name="oval:mil.disa.stig.windows:var:13000" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:130" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:130" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6494,7 +6557,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-22614r555216_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_limit_blank_password_use_var" export-name="oval:mil.disa.fso.windows:var:414300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4143" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4143" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6519,7 +6582,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fixtext fixref="F-22615r555219_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Accounts: Rename administrator account" to a name other than "Administrator".</xccdf:fixtext>
           <xccdf:fix id="F-22615r555219_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:131" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:131" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6544,7 +6607,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fixtext fixref="F-22616r555222_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Accounts: Rename guest account" to a name other than "Guest".</xccdf:fixtext>
           <xccdf:fix id="F-22616r555222_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:132" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:132" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6569,14 +6632,14 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-22617r555225_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_override_audit_policy_settings_var" export-name="oval:mil.disa.fso.windows:var:414800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4148" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4148" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220914">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220914r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220914r852008_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000035</xccdf:version>
           <xccdf:title>Outgoing secure channel traffic must be encrypted or signed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted.  If this policy is enabled, outgoing secure channel traffic will be encrypted and signed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6595,14 +6658,14 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-22618r555228_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_encrypt_or_sign_secure_channel_data_always_var" export-name="oval:mil.disa.fso.windows:var:415100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4151" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4151" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220915">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220915r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220915r852009_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000040</xccdf:version>
           <xccdf:title>Outgoing secure channel traffic must be encrypted when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted.  If this policy is enabled, outgoing secure channel traffic will be encrypted.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6621,14 +6684,14 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-22619r555231_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_encrypt_secure_channel_data_when_possible_var" export-name="oval:mil.disa.fso.windows:var:415200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4152" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4152" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220916">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220916r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220916r852010_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000045</xccdf:version>
           <xccdf:title>Outgoing secure channel traffic must be signed when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but the channel is not integrity checked.  If this policy is enabled, outgoing secure channel traffic will be signed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6647,7 +6710,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-22620r555234_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_secure_channel_data_when_possible_var" export-name="oval:mil.disa.fso.windows:var:415300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4153" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4153" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6672,7 +6735,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-22621r555237_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_disable_machine_account_password_changes_var" export-name="oval:mil.disa.fso.windows:var:415400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4154" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4154" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6699,14 +6762,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-22622r555240_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_machine_account_password_age_var" export-name="oval:mil.disa.fso.windows:var:415500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4155" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4155" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220919">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220919r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220919r852011_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000060</xccdf:version>
           <xccdf:title>The system must be configured to require a strong session key.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A computer connecting to a domain controller will establish a secure channel.  Requiring strong session keys enforces 128-bit encryption between systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6725,7 +6788,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-22623r555243_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_strong_session_key_var" export-name="oval:mil.disa.fso.windows:var:415600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4156" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4156" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6743,14 +6806,13 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
             <dc:subject>Microsoft Windows 10</dc:subject>
             <dc:identifier>4072</dc:identifier>
           </xccdf:reference>
-          <xccdf:ident system="http://cce.mitre.org">CCE-47830-5</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78159</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-63669</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
           <xccdf:fixtext fixref="F-22624r555246_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive logon: Machine inactivity limit" to "900" seconds" or less, excluding "0" which is effectively disabled.</xccdf:fixtext>
           <xccdf:fix id="F-22624r555246_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4730" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220920" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6778,7 +6840,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
 This setting only applies to domain-joined systems, however, it is configured by default on all systems.</xccdf:fixtext>
           <xccdf:fix id="F-22627r555255_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:114" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:114" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6802,14 +6864,14 @@ This setting only applies to domain-joined systems, however, it is configured by
           <xccdf:fixtext fixref="F-22628r555258_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive logon: Smart card removal behavior" to  "Lock Workstation" or "Force Logoff".</xccdf:fixtext>
           <xccdf:fix id="F-22628r555258_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4166" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4166" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220925">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220925r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220925r852012_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000100</xccdf:version>
           <xccdf:title>The Windows SMB client must be configured to always perform SMB packet signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.  Digitally signed SMB packets aid in preventing man-in-the-middle attacks.  If this policy is enabled, the SMB client will only communicate with an SMB server that performs SMB packet signing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6828,14 +6890,14 @@ This setting only applies to domain-joined systems, however, it is configured by
           <xccdf:fix id="F-22629r555261_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_client_always_var" export-name="oval:mil.disa.fso.windows:var:416700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4167" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4167" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220926">
         <xccdf:title>SRG-OS-000074-GPOS-00042</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220926r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220926r877396_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000110</xccdf:version>
           <xccdf:title>Unencrypted passwords must not be sent to third-party SMB Servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Some non-Microsoft SMB servers only support unencrypted (plain text) password authentication.  Sending plain text passwords across the network, when authenticating to an SMB server, reduces the overall security of the environment.  Check with the vendor of the SMB server to see if there is a way to support encrypted password authentication.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6853,14 +6915,14 @@ This setting only applies to domain-joined systems, however, it is configured by
           <xccdf:fix id="F-22630r555264_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_send_unencrypted_password_to_third_party_smb_servers_var" export-name="oval:mil.disa.fso.windows:var:416900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4169" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4169" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220927">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220927r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220927r852013_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000120</xccdf:version>
           <xccdf:title>The Windows SMB server must be configured to always perform SMB packet signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.  Digitally signed SMB packets aid in preventing man-in-the-middle attacks.  If this policy is enabled, the SMB server will only communicate with an SMB client that performs SMB packet signing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6879,7 +6941,7 @@ This setting only applies to domain-joined systems, however, it is configured by
           <xccdf:fix id="F-22631r555267_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_server_always_var" export-name="oval:mil.disa.fso.windows:var:417100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4171" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4171" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6904,7 +6966,7 @@ This setting only applies to domain-joined systems, however, it is configured by
           <xccdf:fix id="F-22633r555273_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_anonymous_enumeration_sam_var" export-name="oval:mil.disa.fso.windows:var:419000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4190" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4190" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6929,7 +6991,7 @@ This setting only applies to domain-joined systems, however, it is configured by
           <xccdf:fix id="F-22634r555276_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_anonymous_enumeration_sam_accounts_shares_var" export-name="oval:mil.disa.fso.windows:var:419100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4191" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4191" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6954,7 +7016,7 @@ This setting only applies to domain-joined systems, however, it is configured by
           <xccdf:fix id="F-22635r555279_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_let_everyone_permissions_apply_to_anonymous_users_var" export-name="oval:mil.disa.fso.windows:var:419300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4193" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4193" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6979,14 +7041,14 @@ This setting only applies to domain-joined systems, however, it is configured by
           <xccdf:fix id="F-22636r555282_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_restrict_anonymous_access_to_named_pipes_and_shares_var" export-name="oval:mil.disa.fso.windows:var:419700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4197" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4197" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220933">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220933r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220933r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000167</xccdf:version>
           <xccdf:title>Remote calls to the Security Account Manager (SAM) must be restricted to Administrators.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The Windows Security Account Manager (SAM) stores users' passwords.  Restricting remote rpc connections to the SAM to Administrators helps protect those credentials.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7015,7 +7077,7 @@ Click "OK".
 The "Security descriptor:" must be populated with "O:BAG:BAD:(A;;RC;;;BA) for the policy to be enforced.</xccdf:fixtext>
           <xccdf:fix id="F-22637r555285_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:152" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:152" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7040,7 +7102,7 @@ The "Security descriptor:" must be populated with "O:BAG:BAD:(A;;RC;;;BA) for th
           <xccdf:fix id="F-22638r555288_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_Network_security_Allow_LocalSystem_NULL_session_fallback_var" export-name="oval:mil.disa.fso.windows:var:420100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4201" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4201" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7065,7 +7127,7 @@ The "Security descriptor:" must be populated with "O:BAG:BAD:(A;;RC;;;BA) for th
           <xccdf:fix id="F-22639r555291_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_Network_Security_Allow_PKU2U_authentication_requests_to_this_computer_to_use_online_identities_var" export-name="oval:mil.disa.fso.windows:var:420200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4202" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4202" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7094,14 +7156,14 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22640r555294_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_Network_Security_Configure_encryption_types_allowed_for_Kerberos_var" export-name="oval:mil.disa.fso.windows:var:420300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4203" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4203" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220937">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220937r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220937r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000195</xccdf:version>
           <xccdf:title>The system must be configured to prevent the storage of the LAN Manager hash of passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The LAN Manager hash uses a weak encryption algorithm and there are several tools available that use this hash to retrieve account passwords.  This setting controls whether or not a LAN Manager hash of the password is stored in the SAM the next time the password is changed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7119,7 +7181,7 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22641r555297_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_store_lan_manager_hash_value_on_next_password_change_var" export-name="oval:mil.disa.fso.windows:var:420400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4204" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4204" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7144,7 +7206,7 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22642r555300_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_lan_manager_authentication_level_var" export-name="oval:mil.disa.fso.windows:var:420600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4206" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4206" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7169,7 +7231,7 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22643r555303_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ldap_client_signing_requirements_var" export-name="oval:mil.disa.fso.windows:var:420700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4207" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4207" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7193,7 +7255,7 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fixtext fixref="F-22644r555306_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) clients" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-22644r555306_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4208" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4208" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7217,14 +7279,14 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fixtext fixref="F-22645r555309_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) servers" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-22645r555309_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4209" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4209" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220942">
         <xccdf:title>SRG-OS-000478-GPOS-00223</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220942r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220942r877466_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000230</xccdf:version>
           <xccdf:title>The system must be configured to use FIPS-compliant algorithms for encryption, hashing, and signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting ensures that the system uses algorithms that are FIPS-compliant for encryption, hashing, and signing.  FIPS-compliant algorithms meet specific standards established by the U.S. Government and must be the algorithms used for all OS encryption functions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7242,7 +7304,7 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22646r555312_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_system_cryptography_use_fips_compliant_alorithm_var" export-name="oval:mil.disa.fso.windows:var:421300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4213" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4213" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7267,14 +7329,14 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22647r555315_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_system_objects_strengthen_default_permissions_internal_system_objects_var" export-name="oval:mil.disa.fso.windows:var:421500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4215" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4215" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220944">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220944r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220944r852016_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000245</xccdf:version>
           <xccdf:title>User Account Control approval mode for the built-in Administrator must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized.  This setting configures the built-in Administrator account so that it runs in Admin Approval Mode.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7292,7 +7354,7 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22648r555318_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_admin_approval_mode_var" export-name="oval:mil.disa.fso.windows:var:421600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4216" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4216" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7317,14 +7379,61 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22649r555321_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_behavior_elevation_prompt_administrators_var" export-name="oval:mil.disa.fso.windows:var:421700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4217" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4217" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </xccdf:check>
+        </xccdf:Rule>
+      </xccdf:Group>
+      <xccdf:Group id="xccdf_mil.disa.stig_group_V-220946">
+        <xccdf:title>SRG-OS-000105-GPOS-00052</xccdf:title>
+        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220946r890441_rule" weight="10.0" severity="medium">
+          <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000251</xccdf:version>
+          <xccdf:title>Windows 10 must use multifactor authentication for local and network access to privileged and nonprivileged accounts.</xccdf:title>
+          <xccdf:description>&lt;VulnDiscussion&gt;Without the use of multifactor authentication, the ease of access to privileged and nonprivileged functions is greatly increased.
+
+All domain accounts must be enabled for multifactor authentication with the exception of local emergency accounts.
+
+Multifactor authentication requires using two or more factors to achieve authentication.
+
+Factors include:
+
+1) Something a user knows (e.g., password/PIN);
+
+2) Something a user has (e.g., cryptographic identification device, token); and
+
+3) Something a user is (e.g., biometric).
+
+A privileged account is defined as an information system account with authorizations of a privileged user.
+
+Network access is defined as access to an information system by a user (or a process acting on behalf of a user) communicating through a network (e.g., local area network, wide area network, or the internet).
+
+Local access is defined as access to an organizational information system by a user (or process acting on behalf of a user) communicating through a direct connection without the use of a network.
+
+The DoD CAC with DoD-approved PKI is an example of multifactor authentication.
+
+Satisfies: SRG-OS-000106-GPOS-00053, SRG-OS-000107-GPOS-00054, SRG-OS-000108-GPOS-00055&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:reference>
+            <dc:title>DPMS Target Microsoft Windows 10</dc:title>
+            <dc:publisher>DISA</dc:publisher>
+            <dc:type>DPMS Target</dc:type>
+            <dc:subject>Microsoft Windows 10</dc:subject>
+            <dc:identifier>4072</dc:identifier>
+          </xccdf:reference>
+          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_MemberWorkstation" />
+          <xccdf:ident system="http://cyber.mil/legacy">SV-111577</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/legacy">V-102627</xccdf:ident>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-000765</xccdf:ident>
+          <xccdf:fixtext fixref="F-22650r819675_fix">For non-domain joined systems, configuring Windows Hello for sign-on options is suggested based on the organization's needs and capabilities.</xccdf:fixtext>
+          <xccdf:fix id="F-22650r819675_fix" />
+          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220946" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220947">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220947r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220947r852017_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000255</xccdf:version>
           <xccdf:title>User Account Control must automatically deny elevation requests for standard users.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized.  Denying elevation requests from standard user accounts requires tasks that need elevation to be initiated by accounts with administrative privileges.  This ensures correct accounts are used on the system for privileged tasks to help mitigate credential theft.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7341,7 +7450,7 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fixtext fixref="F-22651r555327_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Behavior of the elevation prompt for standard users" to "Automatically deny elevation requests".</xccdf:fixtext>
           <xccdf:fix id="F-22651r555327_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:115" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:115" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7366,7 +7475,7 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22652r555330_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_detect_application_installations_prompt_elevation_var" export-name="oval:mil.disa.fso.windows:var:421900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4219" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4219" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7391,14 +7500,14 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22653r555333_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_only_elevate_uiaccess_applications_var" export-name="oval:mil.disa.fso.windows:var:422100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4221" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4221" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220950">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220950r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220950r852018_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-SO-000270</xccdf:version>
           <xccdf:title>User Account Control must run all administrators in Admin Approval Mode, enabling UAC.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized.  This setting enables UAC.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7416,7 +7525,7 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22654r555336_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_run_administrators_admin_approval_mode_var" export-name="oval:mil.disa.fso.windows:var:422200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4222" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4222" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7441,14 +7550,14 @@ Future encryption types</xccdf:fixtext>
           <xccdf:fix id="F-22655r555339_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_virtualize_write_failures_per_user_locations_var" export-name="oval:mil.disa.fso.windows:var:422400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4224" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4224" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220956">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220956r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220956r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000005</xccdf:version>
           <xccdf:title>The Access Credential Manager as a trusted caller user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7467,7 +7576,7 @@ Accounts with the "Access Credential Manager as a trusted caller" user right may
           <xccdf:fixtext fixref="F-22660r555354_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Access Credential Manager as a trusted caller" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-22660r555354_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4740" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4740" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7492,18 +7601,18 @@ Accounts with the "Access this computer from the network" user right may access 
           <xccdf:ident system="http://cyber.mil/cci">CCI-000213</xccdf:ident>
           <xccdf:fixtext fixref="F-22661r555357_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Access this computer from the network" to only include the following groups or accounts:
 
-Administrators   
+Administrators
 Remote Desktop Users</xccdf:fixtext>
           <xccdf:fix id="F-22661r555357_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4849" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4849" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220958">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220958r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220958r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000015</xccdf:version>
           <xccdf:title>The Act as part of the operating system user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7522,7 +7631,7 @@ Accounts with the "Act as part of the operating system" user right can assume th
           <xccdf:fixtext fixref="F-22662r555360_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Act as part of the operating system" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-22662r555360_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4240" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4240" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7551,14 +7660,14 @@ Administrators
 Users</xccdf:fixtext>
           <xccdf:fix id="F-22663r555363_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4851" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4851" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220960">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220960r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220960r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000030</xccdf:version>
           <xccdf:title>The Back up files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7579,14 +7688,14 @@ Accounts with the "Back up files and directories" user right can circumvent file
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22664r555366_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4852" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4852" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220961">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220961r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220961r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000035</xccdf:version>
           <xccdf:title>The Change the system time user right must only be assigned to Administrators and Local Service and NT SERVICE\autotimesvc.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7611,14 +7720,14 @@ LOCAL SERVICE
 NT SERVICE\autotimesvc is added in v1909 cumulative update.</xccdf:fixtext>
           <xccdf:fix id="F-22665r555369_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4854" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4854" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220962">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220962r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220962r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000040</xccdf:version>
           <xccdf:title>The Create a pagefile user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7639,14 +7748,14 @@ Accounts with the "Create a pagefile" user right can change the size of a pagefi
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22666r555372_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4856" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4856" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220963">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220963r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220963r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000045</xccdf:version>
           <xccdf:title>The Create a token object user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7665,14 +7774,14 @@ The "Create a token object" user right allows a process to create an access toke
           <xccdf:fixtext fixref="F-22667r555375_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create a token object" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-22667r555375_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4249" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4249" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220964">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220964r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220964r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000050</xccdf:version>
           <xccdf:title>The Create global objects user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7696,14 +7805,14 @@ NETWORK SERVICE
 SERVICE</xccdf:fixtext>
           <xccdf:fix id="F-22668r555378_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4857" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4857" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220965">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220965r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220965r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000055</xccdf:version>
           <xccdf:title>The Create permanent shared objects user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7722,14 +7831,14 @@ Accounts with the "Create permanent shared objects" user right could expose sens
           <xccdf:fixtext fixref="F-22669r555381_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create permanent shared objects" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-22669r555381_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4251" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4251" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220966">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220966r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220966r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000060</xccdf:version>
           <xccdf:title>The Create symbolic links user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7750,14 +7859,14 @@ Accounts with the "Create symbolic links" user right can create pointers to othe
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22670r555384_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4858" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4858" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220967">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220967r569187_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220967r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000065</xccdf:version>
           <xccdf:title>The Debug programs user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7778,7 +7887,7 @@ Accounts with the "Debug Programs" user right can attach a debugger to any proce
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22671r555387_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4253" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4253" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7822,21 +7931,21 @@ Privileged Access Workstations (PAWs) dedicated to the management of Active Dire
 Note: "Local account" is a built-in security group used to assign user rights and permissions to all local accounts.</xccdf:fixtext>
           <xccdf:fix id="F-22672r555390_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4775" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4775" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220969">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220969r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220969r857200_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000075</xccdf:version>
-          <xccdf:title>The Deny log on as a batch job user right on domain-joined workstations must be configured to prevent access from highly privileged domain accounts.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
+          <xccdf:title>The "Deny log on as a batch job" user right on domain-joined workstations must be configured to prevent access from highly privileged domain accounts.</xccdf:title>
+          <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Deny log on as a batch job" right defines accounts that are prevented from logging on to the system as a batch job, such as Task Scheduler.
 
-In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower trust systems helps mitigate the risk of privilege escalation from credential theft attacks which could lead to the compromise of an entire domain.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower-trust systems helps mitigate the risk of privilege escalation from credential theft attacks that could lead to the compromise of an entire domain.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows 10</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -7847,23 +7956,23 @@ In an Active Directory Domain, denying logons to the Enterprise Admins and Domai
           <xccdf:ident system="http://cyber.mil/legacy">SV-78363</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-63873</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000213</xccdf:ident>
-          <xccdf:fixtext fixref="F-22673r555393_fix">This requirement is applicable to domain-joined systems, for standalone systems this is NA.
+          <xccdf:fixtext fixref="F-22673r857199_fix">This requirement is applicable to domain-joined systems. For standalone or nondomain-joined systems, this is NA.
 
-Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Deny log on as a batch job" to include the following.
+Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Deny log on as a batch job" to include the following:
 
 Domain Systems Only:
 Enterprise Admin Group
 Domain Admin Group</xccdf:fixtext>
-          <xccdf:fix id="F-22673r555393_fix" />
+          <xccdf:fix id="F-22673r857199_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:155" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:155" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220970">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220970r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220970r857203_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000080</xccdf:version>
           <xccdf:title>The Deny log on as a service user right on Windows 10 domain-joined workstations must be configured to prevent access from highly privileged domain accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -7880,19 +7989,20 @@ Incorrect configurations could prevent services from starting and result in a Do
             <dc:subject>Microsoft Windows 10</dc:subject>
             <dc:identifier>4072</dc:identifier>
           </xccdf:reference>
+          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_MemberWorkstation" />
           <xccdf:ident system="http://cyber.mil/legacy">V-63875</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-78365</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000213</xccdf:ident>
-          <xccdf:fixtext fixref="F-22674r555396_fix">This requirement is applicable to domain-joined systems, for standalone systems this is NA.
+          <xccdf:fixtext fixref="F-22674r857202_fix">This requirement is applicable to domain-joined systems. For standalone or nondomain-joined systems, this is NA.
 
-Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Deny log on as a service" to include the following.
+Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Deny log on as a service" to include the following:
 
 Domain Systems Only:
 Enterprise Admins Group
 Domain Admins Group</xccdf:fixtext>
-          <xccdf:fix id="F-22674r555396_fix" />
+          <xccdf:fix id="F-22674r857202_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4372" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220970" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7931,14 +8041,14 @@ All Systems:
 Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-22675r555399_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4375" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4375" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220972">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220972r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220972r852029_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000090</xccdf:version>
           <xccdf:title>The Deny log on through Remote Desktop Services user right on Windows 10 workstations must at a minimum be configured to prevent access from highly privileged domain accounts and local accounts on domain systems and unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7980,14 +8090,14 @@ Privileged Access Workstations (PAWs) dedicated to the management of Active Dire
 Note: "Local account" is a built-in security group used to assign user rights and permissions to all local accounts.</xccdf:fixtext>
           <xccdf:fix id="F-22676r555402_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4778" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4778" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220973">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220973r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220973r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000095</xccdf:version>
           <xccdf:title>The Enable computer and user accounts to be trusted for delegation user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8006,14 +8116,14 @@ The "Enable computer and user accounts to be trusted for delegation" user right 
           <xccdf:fixtext fixref="F-22677r555405_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Enable computer and user accounts to be trusted for delegation" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-22677r555405_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4259" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4259" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220974">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220974r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220974r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000100</xccdf:version>
           <xccdf:title>The Force shutdown from a remote system user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8034,14 +8144,14 @@ Accounts with the "Force shutdown from a remote system" user right can remotely 
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22678r555408_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4859" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4859" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220975">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220975r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220975r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000110</xccdf:version>
           <xccdf:title>The Impersonate a client after authentication user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8065,14 +8175,14 @@ NETWORK SERVICE
 SERVICE</xccdf:fixtext>
           <xccdf:fix id="F-22679r555411_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4861" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4861" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220976">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220976r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220976r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000120</xccdf:version>
           <xccdf:title>The Load and unload device drivers user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8093,14 +8203,14 @@ The "Load and unload device drivers" user right allows device drivers to dynamic
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22680r555414_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4864" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4864" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220977">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220977r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220977r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000125</xccdf:version>
           <xccdf:title>The Lock pages in memory user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8119,14 +8229,14 @@ The "Lock pages in memory" user right allows physical memory to be assigned to p
           <xccdf:fixtext fixref="F-22681r555417_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Lock pages in memory" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-22681r555417_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4266" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4266" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220978">
         <xccdf:title>SRG-OS-000057-GPOS-00027</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220978r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220978r852035_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000130</xccdf:version>
           <xccdf:title>The Manage auditing and security log user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8151,14 +8261,14 @@ Accounts with the "Manage auditing and security log" user right can manage the s
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22682r555420_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4865" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4865" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220979">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220979r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220979r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000140</xccdf:version>
           <xccdf:title>The Modify firmware environment values user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8179,14 +8289,14 @@ Accounts with the "Modify firmware environment values" user right can change har
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22683r555423_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4866" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4866" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220980">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220980r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220980r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000145</xccdf:version>
           <xccdf:title>The Perform volume maintenance tasks user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8207,14 +8317,14 @@ Accounts with the "Perform volume maintenance tasks" user right can manage volum
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22684r555426_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4867" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:220980" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220981">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220981r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220981r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000150</xccdf:version>
           <xccdf:title>The Profile single process user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8235,14 +8345,14 @@ Accounts with the "Profile single process" user right can monitor non-system pro
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22685r555429_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4868" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4868" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220982">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220982r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220982r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000160</xccdf:version>
           <xccdf:title>The Restore files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8263,14 +8373,14 @@ Accounts with the "Restore files and directories" user right can circumvent file
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22686r555432_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4871" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4871" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-220983">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220983r569187_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-220983r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-UR-000165</xccdf:version>
           <xccdf:title>The Take ownership of files or other objects user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
@@ -8291,17 +8401,17 @@ Accounts with the "Take ownership of files or other objects" user right can take
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-22687r555435_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4873" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4873" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-250319">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-250319r793300_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-250319r857185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000050</xccdf:version>
-          <xccdf:title>Hardened UNC Paths must be defined to require mutual authentication and integrity for at least the \\*\SYSVOL and \\*\NETLOGON shares.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Additional security requirements are applied to Universal Naming Convention (UNC) paths specified in Hardened UNC paths before allowing access them. This aids in preventing tampering with or spoofing of connections to these paths.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:title>Hardened UNC paths must be defined to require mutual authentication and integrity for at least the \\*\SYSVOL and \\*\NETLOGON shares.</xccdf:title>
+          <xccdf:description>&lt;VulnDiscussion&gt;Additional security requirements are applied to Universal Naming Convention (UNC) paths specified in Hardened UNC paths before allowing access to them. This aids in preventing tampering with or spoofing of connections to these paths.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows 10</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -8321,7 +8431,7 @@ Value Name: \\*\NETLOGON
 Value: RequireMutualAuthentication=1, RequireIntegrity=1</xccdf:fixtext>
           <xccdf:fix id="F-53708r793297_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:19" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:19" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8348,18 +8458,44 @@ Enabling PowerShell Transcription will record detailed information from the proc
 Specify the Transcript output directory to point to a Central Log Server or another secure location to prevent user access.</xccdf:fixtext>
           <xccdf:fix id="F-56302r821862_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4214" href="U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:4214" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </xccdf:check>
+        </xccdf:Rule>
+      </xccdf:Group>
+      <xccdf:Group id="xccdf_mil.disa.stig_group_V-256894">
+        <xccdf:title>SRG-OS-000185-GPOS-00079</xccdf:title>
+        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-256894r891287_rule" weight="10.0" severity="medium">
+          <xccdf:version update="http://iase.disa.mil/stigs">WN10-CC-000391</xccdf:version>
+          <xccdf:title>Internet Explorer must be disabled for Windows 10.</xccdf:title>
+          <xccdf:description>&lt;VulnDiscussion&gt;Internet Explorer 11 (IE11) is no longer supported on Windows 10 semi-annual channel. &lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:reference>
+            <dc:title>DPMS Target Microsoft Windows 10</dc:title>
+            <dc:publisher>DISA</dc:publisher>
+            <dc:type>DPMS Target</dc:type>
+            <dc:subject>Microsoft Windows 10</dc:subject>
+            <dc:identifier>4072</dc:identifier>
+          </xccdf:reference>
+          <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
+          <xccdf:fixtext fixref="F-60512r891284_fix">For Windows 10 semi-annual channel, remove or disable the IE11 application.
+
+To disable IE11 as a standalone browser:
+
+Set the policy value for "Computer Configuration/Administrative Templates/Windows Components/Internet Explorer/Disable Internet Explorer 11 as a standalone browser" to "Enabled" with the option value set to "Never".</xccdf:fixtext>
+          <xccdf:fix id="F-60512r891284_fix" />
+          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows10:def:256894" href="U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
     </xccdf:Benchmark>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2022-06-28T15:53:43">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2023-03-28T17:40:42">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-06-28T15:53:43</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:40:42</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.windows:def:3887" version="6" class="compliance">
@@ -8476,19 +8612,6 @@ Specify the Transcript output directory to point to a Central Log Server or anot
           </metadata>
           <criteria operator="AND">
             <criterion test_ref="oval:mil.disa.fso.windows:tst:393600" comment="Verifies 'Minimum Password Age' is set to at least '1' day" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.fso.windows:def:3937" version="3" class="compliance">
-          <metadata>
-            <title>Minimum Password Length</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>Passwords must, at a minimum, be 14 characters.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:393700" comment="Verifies 'Minimum password length' is set to at least '14' characters" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.fso.windows:def:3938" version="3" class="compliance">
@@ -9758,48 +9881,6 @@ Specify the Transcript output directory to point to a Central Log Server or anot
             <criterion test_ref="oval:mil.disa.fso.windows:tst:426600" comment="Lock pages in memory - None" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4372" version="4" class="compliance">
-          <metadata>
-            <title>UR: Deny log on as a service</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The Deny log on as a service user right on workstations must be configured to prevent access from highly privileged domain accounts on domain systems.  No other groups or accounts must be assigned this right.</description>
-          </metadata>
-          <criteria operator="OR">
-            <extend_definition definition_ref="oval:mil.disa.fso.windows:def:4373" comment="Deny log on as a service - Non-Domain Systems" />
-            <extend_definition definition_ref="oval:mil.disa.fso.windows:def:4374" comment="Deny log on as a service - Domain Joined Systems" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4373" version="5" class="compliance">
-          <metadata>
-            <title>UR: Deny log on as a service - Non-Domain Systems</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-            </affected>
-            <reference source="DISA" ref_id="26484" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <description>The Deny log on as a service user right on workstations must be configured to prevent access from highly privileged domain accounts on domain systems.  No other groups or accounts must be assigned this right.</description>
-          </metadata>
-          <criteria operator="AND">
-            <extend_definition definition_ref="oval:mil.disa.fso.windows:def:4982" comment="System is not a member of a domain" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4374" version="4" class="compliance">
-          <metadata>
-            <title>UR: Deny log on as a service - Domain Systems</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-            </affected>
-            <reference source="DISA" ref_id="26484" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <description>The Deny log on as a service user right on workstations must be configured to prevent access from highly privileged domain accounts on domain systems.  No other groups or accounts must be assigned this right.</description>
-          </metadata>
-          <criteria operator="AND">
-            <extend_definition comment="System is not a member of a domain" definition_ref="oval:mil.disa.fso.windows:def:4982" negate="true" />
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:437400" comment="Deny log on as a service - Domain Admins" />
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:437401" comment="Deny log on as a service - Enterprise Admins" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.fso.windows:def:4375" version="4" class="compliance">
           <metadata>
             <title>UR: Deny log on locally</title>
@@ -9842,19 +9923,6 @@ Specify the Transcript output directory to point to a Central Log Server or anot
             <criterion test_ref="oval:mil.disa.fso.windows:tst:437600" comment="Deny log on locally - Guests" />
             <criterion test_ref="oval:mil.disa.fso.windows:tst:437700" comment="Deny log on locally - Domain Admins" />
             <criterion test_ref="oval:mil.disa.fso.windows:tst:437701" comment="Deny log on locally - Enterprise Admins" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4730" version="3" class="compliance">
-          <metadata>
-            <title>WN10-SO-000070</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <reference ref_id="CCE-47830-5" source="http://cce.mitre.org" />
-            <description>The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:4202" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.fso.windows:def:4740" version="2" class="compliance">
@@ -10140,19 +10208,6 @@ Accounts with the "Change the system time" user right can change the system time
             <criterion test_ref="oval:mil.disa.fso.windows:tst:486600" comment="Modify firmware environment values - Administrators" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4867" version="2" class="compliance">
-          <metadata>
-            <title>UR: Perform volume maintenance tasks</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>Unauthorized accounts must not have the Perform volume maintenance tasks user right.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:486700" comment="Perform volume maintenance tasks - Administrators" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.fso.windows:def:4868" version="2" class="compliance">
           <metadata>
             <title>UR: Profile single process</title>
@@ -10192,29 +10247,6 @@ Accounts with the "Change the system time" user right can change the system time
             <criterion test_ref="oval:mil.disa.fso.windows:tst:487300" comment="Take ownership of files or other objects - Administrators" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4875" version="4" class="compliance">
-          <metadata>
-            <title>WINPK-000002 External CA Root Certificate</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-            </affected>
-            <description>The External CA Root Certificate must be installed into the Trusted Root Store.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criteria operator="OR">
-              <criterion test_ref="oval:mil.disa.fso.windows:tst:487500" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -C3" />
-              <criterion test_ref="oval:mil.disa.fso.windows:tst:487501" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -C3" />
-              <criterion test_ref="oval:mil.disa.fso.windows:tst:487502" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -C3" />
-              <criterion test_ref="oval:mil.disa.fso.windows:tst:487503" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -C3" />
-            </criteria>
-            <criteria operator="OR">
-              <criterion test_ref="oval:mil.disa.fso.windows:tst:487504" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -73" />
-              <criterion test_ref="oval:mil.disa.fso.windows:tst:487505" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -73" />
-              <criterion test_ref="oval:mil.disa.fso.windows:tst:487506" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -73" />
-              <criterion test_ref="oval:mil.disa.fso.windows:tst:487507" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -73" />
-            </criteria>
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.fso.windows:def:4982" version="1" class="compliance">
           <metadata>
             <title>Standalone Workstation/Server System</title>
@@ -10227,21 +10259,187 @@ Accounts with the "Change the system time" user right can change the system time
             <criterion test_ref="oval:mil.disa.fso.windows:tst:498200" comment="System is not a member of a domain" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4985" version="6" class="compliance">
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:220706" version="2">
           <metadata>
-            <title>Windows Update must not obtain updates from other PCs on the Internet</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>Windows 10 allows Windows Update to obtain updates from additional sources instead of Microsoft.  In addition to Microsoft, updates can be obtained from and sent to PCs on the local network as well as on the Internet.  This is part of the Windows Update trusted process, however to minimize outside exposure, obtaining updates from or sending to systems on the Internet must be prevented.</description>
+            <title>Windows systems must be maintained at a supported servicing level.</title>
+            <description />
           </metadata>
           <criteria operator="OR">
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:498501" comment="'DownloadMode' is set to 'Enabled' with 'HTTP only, LAN, Group, Simple or Bypass' selected." />
-            <criteria operator="AND" comment="Missing SmartScreen setting on Windows 10 LTSB v1507">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:10902" comment="Verify the OS is Windows 10 Enterprise LTSB" />
-              <criterion test_ref="oval:mil.disa.fso.windows:tst:498502" negate="true" comment="Verifies the OS Build is equal to or greater than 14393" />
+            <criteria operator="AND" comment="Windows 10 General Availability Channel (GAC) is v21H2 or later">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25326300" comment="Verifies the OS Version is equal to or greater than 6.3" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:22070600" comment="Verifies the OS Build is equal to or greater than 19044.0 but not equal to 19043.0" />
             </criteria>
+            <criteria operator="AND" comment="Windows 10 Long-Term Servicing Channel (LTSC) is v1507 or later">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:22070601" comment="Verify the OS is Windows 10 Enterprise LTSC" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:22070602" comment="Verifies the OS Build is equal to or greater than 10240 for Windows 10 Enterprise LTSC" />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:220835" version="2">
+          <metadata>
+            <title>Windows Update for workstations must not obtain updates from other PCs on the internet or be running Windows 10 LTSB v1507.</title>
+            <description />
+          </metadata>
+          <criteria operator="OR">
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253394" comment="'DownloadMode' is set to 'Enabled' with 'HTTP only, LAN, Group, Simple, or Bypass' selected." />
+            <criteria operator="AND" comment="Missing SmartScreen setting on Windows 10 LTSB v1507">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:22083500" comment="Verify the OS is Windows 10 Enterprise LTSB" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:22083501" comment="Verifies the OS Build is equal to 10240" />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253303" version="2">
+          <metadata>
+            <title>Passwords must, at a minimum, be 14 characters.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25330300" comment="Verifies 'Minimum password length' is set to at least '14' characters" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253364" version="2">
+          <metadata>
+            <title>Simultaneous connections to the internet or a Windows domain must be limited.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25336400" comment="Simultaneous connections to the internet or a Windows domain are limited" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253393" version="2">
+          <metadata>
+            <title>Windows Telemetry must not be configured to Full.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25339300" comment="Verifies 'Allow Diagnostic Data' is set to 'Diagnostic Data Off (Not recommended)' or 'Send Required Diagnostic Data' selected in 'Options:'" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253394" version="3">
+          <metadata>
+            <title>Windows Update for workstations must not obtain updates from other PCs on the internet.</title>
+            <description />
+          </metadata>
+          <criteria operator="OR">
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254357" comment="'DownloadMode' is set to 'Enabled' with 'HTTP only, LAN, Group, Simple, or Bypass' selected." />
+            <criteria operator="AND" comment="Standalone version of Windows and Download mode is configured through the Settings App">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25339402" comment="Standalone Windows system" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25339403" comment="'DownloadMode' is set to 'Enabled' with 'HTTP only, or LAN' selected." />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253427" version="1">
+          <metadata>
+            <title>The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342700" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342701" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342702" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253428" version="2">
+          <metadata>
+            <title>The External Root CA certificates must be installed in the Trusted Root Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342800" comment="ECA Root CA 4 certificate expiring 12/30/2029 is installed in the Trusted Root Store" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253429" version="3">
+          <metadata>
+            <title>The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342900" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253430" version="2">
+          <metadata>
+            <title>The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25343000" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253444" version="1">
+          <metadata>
+            <title>The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.windows:tst:25344400" comment="The machine inactivity limit is set to 15 minutes or less" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253470" version="1">
+          <metadata>
+            <title>Windows must use multifactor authentication for local and network access to privileged and non-privileged accounts.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25347000" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25347001" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253493" version="2">
+          <metadata>
+            <title>The "Deny log on as a service" user right on Windows domain-joined workstations must be configured to prevent access from highly privileged domain accounts.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25349300" comment="Deny log on as a service - Domain Admins" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25349301" comment="Deny log on as a service - Enterprise Admins" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253503" version="1">
+          <metadata>
+            <title>The "Perform volume maintenance tasks" user right must only be assigned to the Administrators group.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25350300" comment="Perform volume maintenance tasks - Administrators" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254357" version="1">
+          <metadata>
+            <title>Windows Update must not obtain updates from other PCs on the internet.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25339401" comment="'DownloadMode' is set to 'Enabled' with 'HTTP only, LAN, Group, Simple, or Bypass' selected." />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:256893" version="1">
+          <metadata>
+            <title>Internet Explorer must be disabled for Windows.</title>
+            <description />
+          </metadata>
+          <criteria operator="OR">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25689300" comment="Internet Explorer 11 optional feature disabled or not installed" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:22070601" comment="The OS is Windows Enterprise LTSB/LTSC" />
+            <criteria comment="Internet Explorer 11 is disabled as a standalone browser with MS Edge installed">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25689301" comment="Internet Explorer 11 is disabled as a standalone browser" />
+              <criteria operator="OR" comment="Microsoft Edge is Installed">
+                <criterion test_ref="oval:mil.disa.stig.edge:tst:100" comment="64-bit Microsoft Edge is installed" negate="true" />
+                <criterion test_ref="oval:mil.disa.stig.edge:tst:101" comment="32-bit Microsoft Edge is installed" negate="true" />
+              </criteria>
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="inventory" id="oval:mil.disa.stig.win:def:100002" version="2">
+          <metadata>
+            <title>The system is a Windows Domain Member Workstation</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Workstation</platform>
+            </affected>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:10000200" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:15" version="4" class="compliance">
@@ -10634,19 +10832,6 @@ If the "SNMP" application exists, this is a finding.</description>
             <criterion test_ref="oval:mil.disa.stig.windows:tst:9001" comment="Windows 10 Enterprise LTSB is installed, thus Microsoft Edge is not installed" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:95" version="1" class="compliance">
-          <metadata>
-            <title>WN10-CC-000055</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>Simultaneous connections to the Internet or a Windows domain must be limited.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:9500" comment="Verifies 'Minimize the number of simultaneous connections to the Internet or a Windows Domain' is set to 'Enabled'" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:97" version="5" class="compliance">
           <metadata>
             <title>Early Launch Antimalware, Boot-Start Driver Initialization Policy must prevent boot drivers identified.</title>
@@ -10751,29 +10936,6 @@ If the "SNMP" application exists, this is a finding.</description>
           <criteria operator="OR">
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:82" comment="non-domain system" />
             <criterion test_ref="oval:mil.disa.fso.windows:tst:402100" comment="Verifies 'Enumerate local users on domain-joined computers' is set to 'Disabled'" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:109" version="11" class="compliance">
-          <metadata>
-            <title>WN10-00-000040 - Windows 10 systems must be maintained at a supported servicing level</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>Windows 10 is maintained by Microsoft at servicing levels for specific periods of time to support Windows as a Service. Systems at unsupported servicing levels or releases will not receive security updates for new vulnerabilities which leaves them subject to exploitation.
-
-New versions with feature updates are planned to be released on a semi-annual basis with an estimated support timeframe of 18 to 30 months depending on the release. Support for previously released versions has been extended for Enterprise editions.
-
-A separate servicing branch intended for special purpose systems is the Long-Term Servicing Channel (LTSC, formerly Branch - LTSB) which will receive security updates for 10 years but excludes feature updates.</description>
-          </metadata>
-          <criteria operator="OR">
-            <criteria operator="AND" comment="Windows 10 Semi-Annual Channel (SAC) is v1803 or later">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:10900" comment="Verifies the OS Version is equal to or greater than 6.3" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:10901" comment="Verifies the OS Build is equal to or greater than 19042.0" />
-            </criteria>
-            <criteria operator="AND" comment="Windows 10 Long-Term Servicing Channel (LTSC) is v1507 or later">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:10902" comment="Verify the OS is Windows 10 Enterprise LTSC" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:10903" comment="Verifies the OS Build is equal to or greater than 10240 for Windows 10 Enterprise LTSC" />
-            </criteria>
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:113" version="1" class="compliance">
@@ -10935,55 +11097,6 @@ A separate servicing branch intended for special purpose systems is the Long-Ter
           <criteria operator="AND">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:13200" comment="Verifies 'Accounts: Rename guest account' is not set to 'Guest'" />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:13201" comment="Verifies 'Accounts: Rename guest account' is not set to 'localdomain\Guest'" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:133" version="3" class="compliance">
-          <metadata>
-            <title>WN10-PK-000020</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store on unclassified systems.</description>
-          </metadata>
-          <criteria>
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:13300" comment="Verifies US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:134" version="4" class="compliance">
-          <metadata>
-            <title>WN10-PK-000015 - The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:13400" comment="Verifies DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:13401" comment="Verifies DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:135" version="1" class="compliance">
-          <metadata>
-            <title>WINPK-000002 External CA Root Certificate - Win10</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The External CA Root Certificate must be installed into the Trusted Root Store.</description>
-          </metadata>
-          <criteria operator="AND">
-            <extend_definition definition_ref="oval:mil.disa.fso.windows:def:4875" comment="The External CA Root Certificate must be installed into the Trusted Root Store." />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:136" version="3" class="compliance">
-          <metadata>
-            <title>WN10-PK-000005 - The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.</description>
-          </metadata>
-          <criteria operator="AND">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:4200" comment="Verifies the DoD Root CA certificates are installed in the Trusted Root Store." />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:137" version="3" class="compliance">
@@ -11402,22 +11515,6 @@ A separate servicing branch intended for special purpose systems is the Long-Ter
             </criteria>
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:175" version="1" class="compliance">
-          <metadata>
-            <title>WN10-CC-000205</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>Windows Telemetry must not be configured to Full.</description>
-          </metadata>
-          <criteria operator="OR">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:17500" comment="Verifies 'Allow Telemetry' is set to 'Enabled' with '0 - Security [Enterprise Only]' or '1 - Basic' selected in 'Options:'" />
-            <criteria operator="AND">
-              <extend_definition definition_ref="oval:mil.disa.stig.windows:def:172" comment="Verifies Windows 10 is v1709 or later" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:17501" comment="Verifies 'Allow Telemetry' is set to 'Enabled' with '2 - Enhanced' selected in 'Options:'" />
-            </criteria>
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:176" version="2" class="compliance">
           <metadata>
             <title>WN10-CC-000204</title>
@@ -11471,36 +11568,6 @@ A separate servicing branch intended for special purpose systems is the Long-Ter
           </metadata>
           <criteria operator="AND">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:419900" comment="Verifies 'Specify the maximum log size (KB)' is set to 'Enabled' with a 'Maximum Log Size' of '1024000' or greater" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:4200" version="2" class="compliance">
-          <metadata>
-            <title>DoD Root CA Certificates</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The DoD Root CA certificates must be installed in the Trusted Root Store.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420001" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420002" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420003" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:4202" version="1" class="compliance">
-          <metadata>
-            <title>Machine Inactivity Limit</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420200" comment="Verifies 'Interactive logon: Machine inactivity limit' is set to '900' seconds or less" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:4203" version="1" class="compliance">
@@ -11642,11 +11709,229 @@ The Detailed File Share setting logs an event every time a file or folder is acc
               <platform>Microsoft Windows 10</platform>
             </affected>
             <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
-		
+
 		Enabling PowerShell Transcription will record detailed information from the processing of PowerShell commands and scripts. This can provide additional detail when malware has run on a system</description>
           </metadata>
           <criteria>
             <criterion test_ref="oval:mil.disa.stig.windows:tst:421400" comment="PowerShell Transcription is enabled on Windows 10" />
+          </criteria>
+        </definition>
+        <definition id="oval:mil.disa.stig.windows:def:220812" version="3" class="compliance">
+          <metadata>
+            <title>WN10-CC-000075 - Credential Guard must be running on Windows 10 domain-joined systems.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Credential Guard uses virtualization based security to protect information that could be used in credential theft attacks if compromised. This authentication information, which was stored in the Local Security Authority (LSA) in previous versions of Windows, is isolated from the rest of operating system and can only be accessed by privileged system software.</description>
+          </metadata>
+          <criteria operator="XOR" negate="true" comment="return unknown if value is not an array format, otherwise compliance state">
+            <criteria operator="OR" comment="known or unknown">
+              <criterion test_ref="oval:mil.disa.stig.windows:tst:22081200" comment="DeviceGuard SecurityServicesRunning has integer array format." />
+              <criterion test_ref="oval:mil.disa.stig.windows:tst:22081202" comment="unknown" />
+            </criteria>
+            <criterion test_ref="oval:mil.disa.stig.windows:tst:22081201" comment="DeviceGuard SecurityServicesRunning contains '1' as a formatted array element" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220706" version="1">
+          <metadata>
+            <title>WN10-00-000040 - Windows 10 systems must be maintained at a supported servicing level.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Windows 10 is maintained by Microsoft at servicing levels for specific periods of time to support Windows as a Service. Systems at unsupported servicing levels or releases will not receive security updates for new vulnerabilities, which leaves them subject to exploitation.
+
+New versions with feature updates are planned to be released on a semiannual basis with an estimated support timeframe of 18 to 30 months depending on the release. Support for previously released versions has been extended for Enterprise editions.
+
+A separate servicing branch intended for special-purpose systems is the Long-Term Servicing Channel (LTSC, formerly Branch - LTSB), which will receive security updates for 10 years but excludes feature updates.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:220706" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220745" version="1">
+          <metadata>
+            <title>WN10-AC-000035 - Passwords must, at a minimum, be 14 characters.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Information systems not protected with strong password schemes (including passwords of minimum length) provide the opportunity for anyone to crack the password, thus gaining access to the system and compromising the device, information, or the local network.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253303" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220806" version="1">
+          <metadata>
+            <title>WN10-CC-000055 - Simultaneous connections to the internet or a Windows domain must be limited.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Multiple network connections can provide additional attack vectors to a system and must be limited. The "Minimize the number of simultaneous connections to the Internet or a Windows Domain" setting prevents systems from automatically establishing multiple connections.  When both wired and wireless connections are available, for example, the less-preferred connection (typically wireless) will be disconnected.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253364" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220834" version="1">
+          <metadata>
+            <title>WN10-CC-000205 - Windows Telemetry must not be configured to Full.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Some features may communicate with the vendor, sending system information or downloading data or components for the feature. Limiting this capability will prevent potentially sensitive information from being sent outside the enterprise. The "Security" option for Telemetry configures the lowest amount of data, effectively none outside of the Malicious Software Removal Tool (MSRT), Defender and telemetry client settings. "Basic" sends basic diagnostic and usage data and may be required to support some Microsoft services. "Enhanced" includes additional information on how Windows and apps are used and advanced reliability data. Windows Analytics can use a "limited enhanced" level to provide information such as health data for devices.  This requires the configuration of an additional setting available with v1709 and later of Windows 10.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253393" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220835" version="2">
+          <metadata>
+            <title>WN10-CC-000206 - Windows Update must not obtain updates from other PCs on the internet.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Windows 10 allows Windows Update to obtain updates from additional sources instead of Microsoft. In addition to Microsoft, updates can be obtained from and sent to PCs on the local network as well as on the internet. This is part of the Windows Update trusted process; however, to minimize outside exposure, obtaining updates from or sending to systems on the internet must be prevented.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:220835" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220903" version="1">
+          <metadata>
+            <title>WN10-PK-000005 - The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure  the trust chain is established for server certificates issued from the DoD CAs.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253427" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220904" version="1">
+          <metadata>
+            <title>WN10-PK-000010 - The External Root CA certificates must be installed in the Trusted Root Store on unclassified systems.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>To ensure secure websites protected with External Certificate Authority (ECA) server certificates are properly validated, the system must trust the ECA Root CAs. The ECA root certificates will ensure the trust chain is established for server certificates issued from the External CAs. This requirement only applies to unclassified systems.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253428" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220905" version="1">
+          <metadata>
+            <title>WN10-PK-000015 - The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253429" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220906" version="1">
+          <metadata>
+            <title>WN10-PK-000020 - The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253430" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220920" version="1">
+          <metadata>
+            <title>WN10-SO-000070 - The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Unattended systems are susceptible to unauthorized use and should be locked when unattended.  The screen saver should be set at a maximum of 15 minutes and be password protected.  This protects critical and sensitive data from exposure to unauthorized personnel with physical access to the computer.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253444" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220946" version="1">
+          <metadata>
+            <title>WN10-SO-000251 - Windows 10 must use multifactor authentication for local and network access to privileged and non-privileged accounts.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Without the use of multifactor authentication, the ease of access to privileged and non-privileged functions is greatly increased.
+
+All domain accounts must be enabled for multifactor authentication with the exception of local emergency accounts.
+
+Multifactor authentication requires using two or more factors to achieve authentication.
+
+Factors include:
+
+1) Something a user knows (e.g., password/PIN);
+
+2) Something a user has (e.g., cryptographic identification device, token); and
+
+3) Something a user is (e.g., biometric).
+
+A privileged account is defined as an information system account with authorizations of a privileged user.
+
+Network access is defined as access to an information system by a user (or a process acting on behalf of a user) communicating through a network (e.g., local area network, wide area network, or the internet).
+
+Local access is defined as access to an organizational information system by a user (or process acting on behalf of a user) communicating through a direct connection without the use of a network.
+
+The DoD CAC with DoD-approved PKI is an example of multifactor authentication.
+
+Satisfies: SRG-OS-000106-GPOS-00053, SRG-OS-000107-GPOS-00054, SRG-OS-000108-GPOS-00055</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253470" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220970" version="1">
+          <metadata>
+            <title>WN10-UR-000080 - The Deny log on as a service user right on Windows 10 domain-joined workstations must be configured to prevent access from highly privileged domain accounts.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
+
+The "Deny log on as a service" right defines accounts that are denied log on as a service.
+
+In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower trust systems helps mitigate the risk of privilege escalation from credential theft attacks which could lead to the compromise of an entire domain.
+
+Incorrect configurations could prevent services from starting and result in a DoS.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253493" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:220980" version="1">
+          <metadata>
+            <title>WN10-UR-000145 - The Perform volume maintenance tasks user right must only be assigned to the Administrators group.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Inappropriate granting of user rights can provide system, administrative, and other high level capabilities.
+
+Accounts with the "Perform volume maintenance tasks" user right can manage volume and disk configurations. They could potentially delete volumes, resulting in, data loss or a DoS.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253503" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows10:def:256894" version="1">
+          <metadata>
+            <title>WN10-CC-000391 - Internet Explorer must be disabled for Windows 10.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows 10</platform>
+            </affected>
+            <description>Internet Explorer 11 (IE11) is not supported on Windows 10 semi-annual channel.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:256893" />
           </criteria>
         </definition>
       </definitions>
@@ -11695,10 +11980,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
         <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:393600" version="2" comment="'Minimum Password Age' is set to at least '1' day" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:393500" />
           <state state_ref="oval:mil.disa.fso.windows:ste:393600" />
-        </passwordpolicy_test>
-        <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:393700" version="2" comment="'Minimum password length' is set to at least '14' characters" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:393500" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:393700" />
         </passwordpolicy_test>
         <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:393800" version="2" comment="'Password must meet complexity requirements' is set to 'Enabled'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:393500" />
@@ -12160,14 +12441,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <object object_ref="oval:mil.disa.fso.windows:obj:424000" />
           <state state_ref="oval:mil.disa.fso.windows:ste:426600" />
         </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:437400" version="3" comment="Deny log on as a service - Domain Admins" check="at least one">
-          <object object_ref="oval:mil.disa.fso.windows:obj:477500" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:437200" />
-        </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:437401" version="3" comment="Deny log on as a service - Enterprise Admins" check="at least one">
-          <object object_ref="oval:mil.disa.fso.windows:obj:477501" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:437200" />
-        </accesstoken_test>
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:437600" version="2" comment="Deny log on locally - Guests" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:437001" />
           <state state_ref="oval:mil.disa.fso.windows:ste:437500" />
@@ -12280,10 +12553,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <object object_ref="oval:mil.disa.fso.windows:obj:425301" />
           <state state_ref="oval:mil.disa.fso.windows:ste:486600" />
         </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:486700" version="1" comment="Perform volume maintenance tasks - Administrators" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:425301" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:486700" />
-        </accesstoken_test>
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:486800" version="1" comment="Profile single process - Administrators" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:425301" />
           <state state_ref="oval:mil.disa.fso.windows:ste:486800" />
@@ -12296,46 +12565,125 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <object object_ref="oval:mil.disa.fso.windows:obj:425301" />
           <state state_ref="oval:mil.disa.fso.windows:ste:487300" />
         </accesstoken_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:487500" version="3" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -C3" check_existence="all_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:487500" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:487501" version="3" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -C3" check_existence="all_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:487501" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:487502" version="3" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -C3" check_existence="all_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:487502" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:487503" version="3" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -C3" check_existence="all_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:487503" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:487504" version="1" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -73" check_existence="all_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:487504" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:487505" version="1" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -73" check_existence="all_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:487505" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:487506" version="1" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -73" check_existence="all_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:487506" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:487507" version="1" comment="Verifies the External CA Root Certificate is installed into the Trusted Root Store. -73" check_existence="all_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:487507" />
-        </registry_test>
         <wmi_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:498200" state_operator="OR" version="1" comment="System is not a member of a domain" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:498200" />
           <state state_ref="oval:mil.disa.fso.windows:ste:498200" />
           <state state_ref="oval:mil.disa.fso.windows:ste:498203" />
         </wmi_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:498501" version="1" comment="'DownloadMode' is set to 'Enabled' with 'HTTP only, LAN, Group, Simple or Bypass' selected." state_operator="OR" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:498500" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:498500" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:498501" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:498502" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:498503" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:498504" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:498502" version="2" comment="The OS Build is equal to or greater than 14393" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:498501" />
           <state state_ref="oval:mil.disa.fso.windows:ste:498505" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:tst:100" version="2" comment="64-bit Microsoft Edge is installed" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.edge:obj:102" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:tst:101" version="2" comment="32-bit Microsoft Edge is installed" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.edge:obj:103" />
+        </registry_test>
+        <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" id="oval:mil.disa.stig.win:tst:10000200" comment="The system is a Windows Domain Member Workstation" version="1">
+          <object object_ref="oval:mil.disa.stig.win:obj:10000100" />
+          <state state_ref="oval:mil.disa.stig.win:ste:10000200" />
+        </wmi57_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:22070600" version="2" comment="The OS Build is equal to or greater than 19044.0" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25326301" />
+          <state state_ref="oval:mil.disa.stig.win:ste:22070600" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:22070601" version="2" comment="The OS is Windows Enterprise LTSC" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25325400" />
+          <state state_ref="oval:mil.disa.stig.win:ste:22070602" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:22070602" version="1" comment="The OS Build is equal to or greater than 10240" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25326301" />
+          <state state_ref="oval:mil.disa.stig.win:ste:22070603" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:22083500" version="2" comment="The OS is Windows 10 Enterprise LTSB" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000017" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000018" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:22083501" version="2" comment="The OS Build is equal to 10240" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:10000001" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000019" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25326300" version="1" comment="The OS Version is equal to or greater than 6.3" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25326300" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25326300" />
+        </registry_test>
+        <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25330300" version="2" comment="'Minimum password length' is set to at least '14' characters" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000002" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25330300" />
+        </passwordpolicy_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" comment="Simultaneous connections to the internet or a Windows domain are limited" check_existence="any_exist" id="oval:mil.disa.stig.win:tst:25336400" version="4">
+          <object object_ref="oval:mil.disa.stig.win:obj:25336400" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000003" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25339300" version="2" comment="'Allow Diagnostic Data' is set to 'Enabled' with 'Diagnostic Data Off (Not recommended)' or 'Send Required Diagnostic Data' selected in 'Options:'" check_existence="at_least_one_exists" check="all" state_operator="OR">
+          <object object_ref="oval:mil.disa.stig.win:obj:25339300" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000000" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000001" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25339401" version="1" comment="'DownloadMode' is set to 'Enabled' with 'HTTP only, LAN, Group, Simple or Bypass' selected." state_operator="OR" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25339400" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000000" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000001" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000002" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25339400" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25339401" />
+        </registry_test>
+        <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" id="oval:mil.disa.stig.win:tst:25339402" comment="The system is a Windows Standalone Workstation or Server" version="2" state_operator="OR">
+          <object object_ref="oval:mil.disa.stig.win:obj:10000100" />
+          <state state_ref="oval:mil.disa.stig.win:ste:10000100" />
+          <state state_ref="oval:mil.disa.stig.win:ste:10000300" />
+        </wmi57_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25339403" version="2" comment="'DownloadMode' is set to 'Enabled' with 'HTTP only or LAN' selected." state_operator="OR" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25339401" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000000" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000001" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342700" version="2" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342700" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342701" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342705" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342702" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342710" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342800" version="2" comment="ECA Root CA 4 certificate expiring 12/30/2029 is installed in the Trusted Root Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342800" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342900" version="2" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342900" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25343000" version="2" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25343000" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="HKLM\SOFTWARE\Microsoft\Cryptography\Calais\Readers exists and contains at least one key." check="all" id="oval:mil.disa.stig.win:tst:25347000" version="4">
+          <object object_ref="oval:mil.disa.stig.win:obj:25347000" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="HKLM\SOFTWARE\Microsoft\Cryptography\Calais\SmartCards exists and contains at least one key." check="all" id="oval:mil.disa.stig.win:tst:25347001" version="4">
+          <object object_ref="oval:mil.disa.stig.win:obj:25347001" />
+        </registry_test>
+        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25349300" version="1" comment="Deny log on as a service - Domain Admins" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000003" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25349300" />
+        </accesstoken_test>
+        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25349301" version="1" comment="Deny log on as a service - Enterprise Admins" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000004" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25349300" />
+        </accesstoken_test>
+        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25350300" version="1" comment="Perform volume maintenance tasks - Administrators" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000009" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25350300" />
+        </accesstoken_test>
+        <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25689300" version="3" comment="Internet Explorer 11 optional feature disabled or not installed" check_existence="any_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25689300" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000020" />
+        </wmi57_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25689301" version="1" comment="Internet Explorer 11 is disabled as a standalone browser" check_existence="at_least_one_exists" check="all" state_operator="OR">
+          <object object_ref="oval:mil.disa.stig.win:obj:25689301" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000000" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000001" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000002" />
         </registry_test>
         <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:1500" version="1" comment="OSArchitecture is 64-bit" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:1500" />
@@ -12488,10 +12836,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <object object_ref="oval:mil.disa.stig.windows:obj:8300" />
           <state state_ref="oval:mil.disa.stig.windows:ste:8301" />
         </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:9500" version="1" comment="'Minimize the number of simultaneous connections to the Internet or a Windows Domain' is set to 'Enabled'" check_existence="any_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:398400" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:398400" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:9700" version="3" comment="'Boot-Start Driver Initialization Policy' is not set to 'All'" check="at least one" state_operator="OR">
           <object object_ref="oval:mil.disa.stig.windows:obj:9700" />
           <state state_ref="oval:mil.disa.stig.windows:ste:9700" />
@@ -12534,17 +12878,9 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <object object_ref="oval:mil.disa.stig.windows:obj:10900" />
           <state state_ref="oval:mil.disa.stig.windows:ste:10900" />
         </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:10901" version="9" comment="The OS Build is equal to or greater than 19042.0" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:10901" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:10901" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:10902" version="1" comment="The OS is Windows 10 Enterprise LTSB" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:8300" />
           <state state_ref="oval:mil.disa.stig.windows:ste:8301" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:10903" version="1" comment="The OS Build is equal to or greater than 10240" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:10901" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:10902" />
         </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11300" version="1" comment="'SafeForScripting' is set to 'Disabled' or 'Not Configured'" check_existence="any_exist" check="none satisfy">
           <object object_ref="oval:mil.disa.fso.windows:obj:408600" />
@@ -12614,15 +12950,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <object object_ref="oval:mil.disa.stig.windows:obj:13200" />
           <state state_ref="oval:mil.disa.stig.windows:ste:13201" />
         </sid_sid_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:13300" version="1" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:13300" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:13400" version="2" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:13400" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:13401" version="1" comment="DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:13405" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:13700" version="1" comment="Check if PowerShell Script Block Logging is set to enabled in the registry" check_existence="all_exist" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:13700" />
           <state state_ref="oval:mil.disa.stig.windows:ste:13700" />
@@ -12751,11 +13078,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <object object_ref="oval:mil.disa.fso.windows:obj:498501" />
           <state state_ref="oval:mil.disa.stig.windows:ste:17401" />
         </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:17500" version="1" comment="'Allow Telemetry' is set to 'Enabled' with '0 - Security [Enterprise Only]' or '1 - Basic' selected in 'Options:'" check_existence="at_least_one_exists" check="all" state_operator="OR">
-          <object object_ref="oval:mil.disa.stig.windows:obj:17500" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:17500" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:17501" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:17501" version="1" comment="'Allow Telemetry' is set to 'Enabled' with '2 - Enhanced' selected in 'Options:'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:17500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:17502" />
@@ -12775,20 +13097,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:419900" version="1" comment="'Specify the maximum log size (KB)' is set to 'Enabled' with a 'Maximum Log Size' of '1024000' or greater" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:419900" />
           <state state_ref="oval:mil.disa.stig.windows:ste:419900" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420001" version="1" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420005" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420002" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420010" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420003" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420015" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420200" version="1" comment="'Interactive logon: Machine inactivity limit' is set to '900' seconds or less" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420200" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:420200" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:420201" />
         </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420300" version="1" comment="'Enable insecure guest logons' is set to 'Disabled'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:420300" />
@@ -12854,6 +13162,20 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <object object_ref="oval:mil.disa.stig.windows:obj:421400" />
           <state state_ref="oval:mil.disa.stig.windows:ste:421400" />
         </registry_test>
+        <cmdlet_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:22081200" version="1" check="all" check_existence="at_least_one_exists" comment="DeviceGuard SecurityServicesRunning has integer array format.">
+          <object object_ref="oval:mil.disa.stig.windows:obj:22081200" />
+          <state state_ref="oval:mil.disa.stig.windows:ste:22081200" />
+        </cmdlet_test>
+        <cmdlet_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:22081201" version="1" check="all" check_existence="at_least_one_exists" comment="DeviceGuard SecurityServicesRunning contains '1' as a formatted array element">
+          <object object_ref="oval:mil.disa.stig.windows:obj:22081200" />
+          <state state_ref="oval:mil.disa.stig.windows:ste:22081201" />
+        </cmdlet_test>
+        <unknown_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" id="oval:mil.disa.stig.windows:tst:22081202" version="1" check="at least one" comment="unknown result" />
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:25344400" version="1" comment="The machine inactivity limit is set to 15 minutes or less" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.windows:obj:25344400" />
+          <state state_ref="oval:mil.disa.stig.windows:ste:25344400" />
+          <state state_ref="oval:mil.disa.stig.windows:ste:25344401" />
+        </registry_test>
       </tests>
       <objects>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:388601" version="2" comment="System Root Directory Registry Object">
@@ -12872,11 +13194,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
         <lockoutpolicy_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:393200" version="5" comment="Lockout policy" />
         <passwordpolicy_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:393500" version="1" comment="Password policy" />
         <auditeventpolicysubcategories_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:394100" version="1" comment="Audit event subcategories policy" />
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:398400" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">Software\Policies\Microsoft\Windows\WcmSvc\GroupPolicy\</key>
-          <name datatype="string" operation="equals">fMinimizeConnections</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:398500" version="2">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">Software\Policies\Microsoft\Windows\WcmSvc\GroupPolicy\</key>
@@ -13370,59 +13687,284 @@ The Detailed File Share setting logs an event every time a file or folder is acc
             <filter>oval:mil.disa.fso.windows:ste:485002</filter>
           </set>
         </accesstoken_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:487500" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\C313F919A6ED4E0E8451AFA930FB419A20F181E4</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:487501" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\C313F919A6ED4E0E8451AFA930FB419A20F181E4</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:487502" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\C313F919A6ED4E0E8451AFA930FB419A20F181E4</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:487503" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\EnterpriseCertificates\Root\Certificates\C313F919A6ED4E0E8451AFA930FB419A20F181E4</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:487504" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\73E8BB08E337D6A5A6AEF90CFFDD97D9176CB582</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:487505" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\73E8BB08E337D6A5A6AEF90CFFDD97D9176CB582</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:487506" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\73E8BB08E337D6A5A6AEF90CFFDD97D9176CB582</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:487507" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\EnterpriseCertificates\Root\Certificates\73E8BB08E337D6A5A6AEF90CFFDD97D9176CB582</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
         <wmi_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:498200" version="1" comment="DomainRole property">
           <namespace datatype="string">root\cimv2</namespace>
           <wql datatype="string" operation="equals">SELECT DomainRole FROM win32_computersystem</wql>
         </wmi_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:498500" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">Software\Policies\Microsoft\Windows\DeliveryOptimization</key>
-          <name datatype="string" operation="equals">DODownloadMode</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:498501" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">Software\Microsoft\Windows NT\CurrentVersion</key>
           <name datatype="string" operation="equals">CurrentBuildNumber</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:obj:100" version="1" comment="64-bit DisplayName registry value">
+          <behaviors max_depth="1" recurse_direction="down" />
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall</key>
+          <name datatype="string">DisplayName</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:obj:101" version="1" comment="32-bit DisplayName registry value">
+          <behaviors max_depth="1" recurse_direction="down" />
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall</key>
+          <name datatype="string">DisplayName</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:obj:102" version="1" comment="64-bit DisplayName equals Microsoft Edge">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.edge:obj:100</object_reference>
+            <filter action="include">oval:mil.disa.stig.edge:ste:100</filter>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:obj:103" version="1" comment="32-bit DisplayName equals Microsoft Edge">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.edge:obj:101</object_reference>
+            <filter action="include">oval:mil.disa.stig.edge:ste:100</filter>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:10000001" comment="CurrentBuildNumber registry entry" version="1">
+          <hive>HKEY_LOCAL_MACHINE</hive>
+          <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name>CurrentBuildNumber</name>
+        </registry_object>
+        <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:10000100" version="1">
+          <namespace>root\cimv2</namespace>
+          <wql>SELECT DomainRole FROM win32_computersystem</wql>
+        </wmi57_object>
+        <passwordpolicy_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000002" version="1" />
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000003" version="1">
+          <security_principle datatype="string" operation="pattern match">^(?i)(.+\\)?Domain Admins$</security_principle>
+        </accesstoken_object>
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000004" version="1">
+          <security_principle datatype="string" operation="pattern match">^(?i)(.+\\)?Enterprise Admins$</security_principle>
+        </accesstoken_object>
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000008" version="1" comment="All security principles">
+          <security_principle operation="pattern match">.+</security_principle>
+        </accesstoken_object>
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000009" version="1" comment="Administrators">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.win:obj:20000008</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000005</filter>
+          </set>
+        </accesstoken_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000017" version="1" comment="EditionID">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name datatype="string">EditionId</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25325400" version="1">
+          <hive>HKEY_LOCAL_MACHINE</hive>
+          <key>SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name operation="case insensitive equals">EditionId</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25326300" version="1" comment="Windows Current Version, e.g. 6.3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name datatype="string" operation="equals">CurrentVersion</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25326301" version="1" comment="Windows Current Build Number, e.g. 22000">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name datatype="string" operation="equals">CurrentBuildNumber</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25336400" version="1">
+          <hive>HKEY_LOCAL_MACHINE</hive>
+          <key>SOFTWARE\Policies\Microsoft\Windows\WcmSvc\GroupPolicy</key>
+          <name>fMinimizeConnections</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25339300" version="1">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\DataCollection</key>
+          <name datatype="string">AllowTelemetry</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25339400" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">Software\Policies\Microsoft\Windows\DeliveryOptimization</key>
+          <name datatype="string" operation="equals">DODownloadMode</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25339401" version="1" comment="DownloadMode set through the Settings App">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config</key>
+          <name datatype="string" operation="equals">DODownloadMode</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342700" version="2">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342701</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342702</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342701" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342703</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342704</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342702" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342703" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342704" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342705" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342706</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342707</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342706" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342708</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342709</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342707" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342708" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342709" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342710" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342711</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342712</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342711" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342713</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342714</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342712" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342713" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342714" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342800" version="2">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342801</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342804</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342801" version="2">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342802</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342803</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342802" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\73E8BB08E337D6A5A6AEF90CFFDD97D9176CB582</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342803" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\73E8BB08E337D6A5A6AEF90CFFDD97D9176CB582</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342804" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\73E8BB08E337D6A5A6AEF90CFFDD97D9176CB582</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342900" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342901</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342904</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342901" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342902</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342903</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342902" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342903" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342904" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343000" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343001</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343004</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343001" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343002</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343003</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343002" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343003" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343004" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25347000" version="5">
+          <hive>HKEY_LOCAL_MACHINE</hive>
+          <key operation="pattern match">SOFTWARE\\Microsoft\\Cryptography\\Calais\\Readers\\\S+</key>
+          <name xsi:nil="true" />
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25347001" version="5">
+          <hive>HKEY_LOCAL_MACHINE</hive>
+          <key operation="pattern match">SOFTWARE\\Microsoft\\Cryptography\\Calais\\SmartCards\\\S+</key>
+          <name xsi:nil="true" />
+        </registry_object>
+        <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25689300" version="1">
+          <namespace datatype="string">root\cimv2</namespace>
+          <wql datatype="string" operation="equals">SELECT installstate FROM win32_optionalfeature WHERE name = 'Internet-Explorer-Optional-amd64'</wql>
+        </wmi57_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25689301" version="1">
+          <hive>HKEY_LOCAL_MACHINE</hive>
+          <key>SOFTWARE\Policies\Microsoft\Internet Explorer\Main</key>
+          <name>NotifyDisableIEOptions</name>
         </registry_object>
         <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:1500" version="1" comment="Win32_OperatingSystem/OSArchitecture">
           <namespace>root\cimv2</namespace>
@@ -13687,87 +14229,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
         <sid_sid_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13200" version="1" comment="Built-in Guest SID">
           <trustee_sid operation="pattern match">^S-1-5-[0-9-]+-501$</trustee_sid>
         </sid_sid_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13300" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:13301</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:13304</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13301" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:13302</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:13303</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13302" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13303" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13304" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13400" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:13401</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:13404</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13401" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:13402</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:13403</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13402" version="3">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13403" version="3">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13404" version="3">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13405" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:13406</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:13409</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13406" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:13407</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:13408</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13407" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13408" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13409" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:13700" version="2" comment="Check the value at HKLM\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging\EnableScriptBlockLogging">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging</key>
@@ -13889,92 +14350,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\EventLog\Security</key>
           <name datatype="string">MaxSize</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420005" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420006</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420009</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420006" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420007</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420008</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420007" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420008" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420009" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420010" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420011</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420014</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420011" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420012</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420013</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420012" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420013" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420014" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420015" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420016</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420019</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420016" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420017</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420018</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420017" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420018" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420019" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420200" version="1">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">Software\Microsoft\Windows\CurrentVersion\Policies\System</key>
-          <name datatype="string">InactivityTimeoutSecs</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420300" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation</key>
@@ -14004,6 +14379,25 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription</key>
           <name datatype="string" operation="equals">EnableTranscripting</name>
+        </registry_object>
+        <cmdlet_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:22081200" version="1" comment="DeviceGuard SecurityServicesRunning">
+          <module_name operation="equals">CimCmdlets</module_name>
+          <module_id xsi:nil="true" />
+          <module_version datatype="version">1.0.0.0</module_version>
+          <verb>Get</verb>
+          <noun>CimInstance</noun>
+          <parameters datatype="record">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="classname">Win32_DeviceGuard</field>
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="namespace">root\Microsoft\Windows\DeviceGuard</field>
+          </parameters>
+          <select datatype="record">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="property">SecurityServicesRunning</field>
+          </select>
+        </cmdlet_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:25344400" version="1">
+          <hive datatype="string" operation="case insensitive equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="case insensitive equals">Software\Microsoft\Windows\CurrentVersion\Policies\System</key>
+          <name datatype="string" operation="case insensitive equals">InactivityTimeoutSecs</name>
         </registry_object>
       </objects>
       <states>
@@ -14046,9 +14440,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
         </passwordpolicy_state>
         <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:393600" version="1" comment="Minimum Password Age is greater than or equal to variable">
           <min_passwd_age datatype="int" operation="greater than or equal" var_ref="oval:mil.disa.fso.windows:var:393600" />
-        </passwordpolicy_state>
-        <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:393700" version="1" comment="Minimum Password Length is greater than or equal to variable">
-          <min_passwd_len operation="greater than or equal" datatype="int" var_ref="oval:mil.disa.fso.windows:var:393700" />
         </passwordpolicy_state>
         <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:393800" version="1" comment="Password Complexity equals variable">
           <password_complexity datatype="boolean" var_ref="oval:mil.disa.fso.windows:var:393800" />
@@ -14416,9 +14807,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:426600" version="3" comment="Lock pages in memory">
           <selockmemoryprivilege datatype="boolean" operation="equals">0</selockmemoryprivilege>
         </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:437200" version="3" comment="Deny log on as a service">
-          <sedenyservicelogonright datatype="boolean" operation="equals">1</sedenyservicelogonright>
-        </accesstoken_state>
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:437500" version="3" comment="Deny log on locally">
           <sedenyinteractivelogonright datatype="boolean" operation="equals">1</sedenyinteractivelogonright>
         </accesstoken_state>
@@ -14493,9 +14881,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:486600" version="1" comment="Modify firmware environment values">
           <sesystemenvironmentprivilege datatype="boolean">0</sesystemenvironmentprivilege>
         </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:486700" version="1" comment="Perform volume maintenance tasks">
-          <semanagevolumeprivilege datatype="boolean">0</semanagevolumeprivilege>
-        </accesstoken_state>
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:486800" version="1" comment="Profile single process">
           <seprofilesingleprocessprivilege datatype="boolean">0</seprofilesingleprocessprivilege>
         </accesstoken_state>
@@ -14511,30 +14896,93 @@ The Detailed File Share setting logs an event every time a file or folder is acc
         <wmi_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498203" version="1" comment="Standalone Server is 2">
           <result datatype="int" operation="equals">2</result>
         </wmi_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498500" version="3" comment="Reg_Dword type and value equals 0">
-          <type>reg_dword</type>
-          <value datatype="int" operation="equals">0</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498501" version="3" comment="Reg_Dword type and value equals 1">
-          <type>reg_dword</type>
-          <value datatype="int" operation="equals">1</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498502" version="3" comment="Reg_Dword type and value equals 2">
-          <type>reg_dword</type>
-          <value datatype="int" operation="equals">2</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498503" version="1" comment="Reg_Dword type and value equals 99">
-          <type>reg_dword</type>
-          <value datatype="int" operation="equals">99</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498504" version="1" comment="Reg_Dword type and value equals 100">
-          <type>reg_dword</type>
-          <value datatype="int" operation="equals">100</value>
-        </registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498505" version="2" comment="Reg_Sz type and value is greater than or equal to 14393">
           <type>reg_sz</type>
           <value datatype="version" operation="greater than or equal">14393</value>
         </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.edge:ste:100" version="1" comment="registry value equals Microsoft Edge">
+          <value datatype="string">Microsoft Edge</value>
+        </registry_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:10000100" comment="Standalone Workstation" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="domainrole">0</field>
+          </result>
+        </wmi57_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:10000200" comment="Domain Member Workstation" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="domainrole">1</field>
+          </result>
+        </wmi57_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:10000300" comment="Standalone Server" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="domainrole">2</field>
+          </result>
+        </wmi57_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000000" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">0</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000001" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">1</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000002" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">2</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000003" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">3</value>
+        </registry_state>
+        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000005" version="1">
+          <security_principle datatype="string" operation="case insensitive equals">Administrators</security_principle>
+        </accesstoken_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000018" version="2" comment="EditionID = EnterpriseS (reg_sz)">
+          <type>reg_sz</type>
+          <value datatype="string">EnterpriseS</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000019" version="1" comment="Reg_Sz type and value is equal to 10240">
+          <type>reg_sz</type>
+          <value datatype="string">10240</value>
+        </registry_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000020" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="installstate" entity_check="at least one" datatype="string">2</field>
+          </result>
+        </wmi57_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:22070600" version="2">
+          <type>reg_sz</type>
+          <value datatype="version" operation="greater than or equal">19044.0</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:22070602" version="1">
+          <type>reg_sz</type>
+          <value datatype="string">EnterpriseS</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:22070603" version="1">
+          <type>reg_sz</type>
+          <value datatype="version" operation="greater than or equal">10240</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25326300" version="1" comment="Reg_Sz type and value is greater than or equal to 6.3">
+          <type>reg_sz</type>
+          <value datatype="version" operation="greater than or equal">6.3</value>
+        </registry_state>
+        <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25330300" version="2" comment="Minimum Password Length is greater than or equal to 14">
+          <min_passwd_len operation="greater than or equal" datatype="int">14</min_passwd_len>
+        </passwordpolicy_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25339400" version="1" comment="Reg_Dword type and value equals 99">
+          <type>reg_dword</type>
+          <value datatype="int" operation="equals">99</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25339401" version="1" comment="Reg_Dword type and value equals 100">
+          <type>reg_dword</type>
+          <value datatype="int" operation="equals">100</value>
+        </registry_state>
+        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25349300" version="1" comment="Deny log on as a service">
+          <sedenyservicelogonright datatype="boolean" operation="equals">1</sedenyservicelogonright>
+        </accesstoken_state>
+        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25350300" version="1" comment="Perform volume maintenance tasks">
+          <semanagevolumeprivilege datatype="boolean">0</semanagevolumeprivilege>
+        </accesstoken_state>
         <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:1500" version="2" comment="OSArchitecture is 64-bit">
           <result datatype="record" operation="equals">
             <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="osarchitecture" entity_check="at least one" datatype="string">64-bit</field>
@@ -14698,14 +15146,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <type>reg_sz</type>
           <value datatype="version" operation="greater than or equal">6.3</value>
         </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:10901" version="9" comment="Reg_Sz type and value is greater than or equal to 19042.0">
-          <type>reg_sz</type>
-          <value datatype="version" operation="greater than or equal">19042.0</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:10902" version="1" comment="Reg_Sz type and value is greater than or equal to 10240">
-          <type>reg_sz</type>
-          <value datatype="version" operation="greater than or equal">10240</value>
-        </registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11300" version="1" comment="Reg_Dword value of 1">
           <type>reg_dword</type>
           <value datatype="int" operation="equals">1</value>
@@ -14865,14 +15305,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <type>reg_sz</type>
           <value datatype="version" operation="greater than or equal">17763</value>
         </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:17500" version="1" comment="Reg_Dword type and value equals 0">
-          <type>reg_dword</type>
-          <value datatype="int" operation="equals">0</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:17501" version="1" comment="Reg_Dword type and value equals 1">
-          <type>reg_dword</type>
-          <value datatype="int" operation="equals">1</value>
-        </registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:17502" version="1" comment="Reg_Dword type and value equals 2">
           <type>reg_dword</type>
           <value datatype="int" operation="equals">2</value>
@@ -14893,14 +15325,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:419900" version="1" comment="Reg_Dword type and value equals or is greater than variable">
           <type>reg_dword</type>
           <value datatype="int" operation="greater than or equal" var_ref="oval:mil.disa.stig.windows:var:419900" />
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:420200" version="1" comment="Reg_Dword type and value is less than or equals 900">
-          <type>reg_dword</type>
-          <value datatype="int" operation="less than or equal">900</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:420201" version="1" comment="Reg_Dword type and value is greater than 0">
-          <type>reg_dword</type>
-          <value datatype="int" operation="greater than">0</value>
         </registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:420300" version="1" comment="Reg_Dword type and value is 0">
           <type>reg_dword</type>
@@ -14956,6 +15380,24 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <type>reg_dword</type>
           <value datatype="int" operation="equals">1</value>
         </registry_state>
+        <cmdlet_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:22081200" version="1" comment="has integer array format">
+          <value datatype="record">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="securityservicesrunning" operation="pattern match">^[{][0-9,\s]*[}]$</field>
+          </value>
+        </cmdlet_state>
+        <cmdlet_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:22081201" version="1" comment="contains '1' as formatted array element">
+          <value datatype="record">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="securityservicesrunning" operation="pattern match">[{,]\s*1\s*[,}]</field>
+          </value>
+        </cmdlet_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:25344400" version="1">
+          <type>reg_dword</type>
+          <value datatype="int" operation="less than or equal">900</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:25344401" version="1">
+          <type>reg_dword</type>
+          <value datatype="int" operation="greater than">0</value>
+        </registry_state>
       </states>
       <variables>
         <external_variable id="oval:mil.disa.fso.windows:var:393200" version="1" datatype="int" comment="Account Lockout Threshold">
@@ -14981,13 +15423,6 @@ The Detailed File Share setting logs an event every time a file or folder is acc
           <possible_value hint="86400_seconds">86400</possible_value>
           <possible_value hint="172800_seconds">172800</possible_value>
           <possible_value hint="432000_seconds">432000</possible_value>
-        </external_variable>
-        <external_variable id="oval:mil.disa.fso.windows:var:393700" version="1" datatype="int" comment="Minimum Password Length">
-          <possible_value hint="8_characters">8</possible_value>
-          <possible_value hint="9_characters">9</possible_value>
-          <possible_value hint="12_characters">12</possible_value>
-          <possible_value hint="14_characters">14</possible_value>
-          <possible_value hint="15_characters">15</possible_value>
         </external_variable>
         <external_variable id="oval:mil.disa.fso.windows:var:393800" version="1" datatype="boolean" comment="Enforce Password Complexity">
           <possible_value hint="disabled">0</possible_value>
@@ -15301,12 +15736,12 @@ The Detailed File Share setting logs an event every time a file or folder is acc
       </variables>
     </oval_definitions>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_10_V2R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2022-06-28T15:53:43">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2023-03-28T17:40:42">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-06-28T15:53:43</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:40:42</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.stig.windows:def:1" version="3" class="inventory">

--- a/scap/content/guides/disa/stig-ws2012-dc.xml
+++ b/scap/content/guides/disa/stig-ws2012-dc.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
-  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2022-05-01T21:44:56">
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
+  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2023-03-28T17:41:17">
     <dictionaries>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+          <cat:uri name="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
         </cat:catalog>
       </component-ref>
     </dictionaries>
     <checklists>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-xccdf.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-xccdf.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          <cat:uri name="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
         </cat:catalog>
       </component-ref>
     </checklists>
     <checks>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
     </checks>
   </data-stream>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2022-05-01T21:44:56">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2023-03-28T17:41:17">
     <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0">
       <cpe-item name="cpe:/o:microsoft:windows_server_2012:-">
         <title>Microsoft Windows Server 2012</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.windows:def:4398</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.windows:def:4398</check>
       </cpe-item>
       <cpe-item name="cpe:/o:microsoft:windows_server_2012:r2">
         <title>Microsoft Windows Server 2012</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.windows:def:4968</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.windows:def:4968</check>
       </cpe-item>
     </cpe-list>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2022-05-01T21:44:56">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2023-03-28T17:41:17">
     <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_Windows_2012_DC_STIG" xml:lang="en" style="SCAP_1.2">
-      <xccdf:status date="2022-03-01">accepted</xccdf:status>
-      <xccdf:title>Microsoft Windows Server 2012/2012 R2 Domain Controller Security Technical Implementation Guide</xccdf:title>
-      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
+      <xccdf:status date="2023-02-27">accepted</xccdf:status>
+      <xccdf:title>Microsoft Windows Server 2012/2012 R2 Domain Controller STIG SCAP Benchmark</xccdf:title>
+      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
       <xccdf:notice id="terms-of-use" xml:lang="en" />
       <xccdf:front-matter xml:lang="en" />
       <xccdf:rear-matter xml:lang="en" />
@@ -44,12 +44,12 @@
         <dc:publisher>DISA</dc:publisher>
         <dc:source>STIG.DOD.MIL</dc:source>
       </xccdf:reference>
-      <xccdf:plain-text id="release-info">Release: 3.3 Benchmark Date: 31 May 2022</xccdf:plain-text>
-      <xccdf:plain-text id="generator">3.3.0.27375</xccdf:plain-text>
+      <xccdf:plain-text id="release-info">Release: 3.5 Benchmark Date: 11 May 2023</xccdf:plain-text>
+      <xccdf:plain-text id="generator">3.4.0.34222</xccdf:plain-text>
       <xccdf:plain-text id="conventionsVersion">1.10.0</xccdf:plain-text>
       <xccdf:platform idref="cpe:/o:microsoft:windows_server_2012:r2" />
       <xccdf:platform idref="cpe:/o:microsoft:windows_server_2012:-" />
-      <xccdf:version update="http://iase.disa.mil/stigs">003.003</xccdf:version>
+      <xccdf:version update="http://iase.disa.mil/stigs">003.005</xccdf:version>
       <xccdf:metadata>
         <dc:creator>DISA</dc:creator>
         <dc:publisher>DISA</dc:publisher>
@@ -86,12 +86,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226090" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226091" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226092" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226093" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226094" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226095" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226096" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226097" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226098" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226099" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226100" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226101" selected="true" />
@@ -351,12 +349,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226090" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226091" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226092" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226093" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226094" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226095" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226096" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226097" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226098" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226099" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226100" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226101" selected="true" />
@@ -616,12 +612,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226090" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226091" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226092" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226093" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226094" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226095" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226096" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226097" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226098" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226099" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226100" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226101" selected="true" />
@@ -881,12 +875,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226090" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226091" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226092" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226093" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226094" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226095" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226096" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226097" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226098" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226099" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226100" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226101" selected="true" />
@@ -1146,12 +1138,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226090" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226091" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226092" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226093" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226094" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226095" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226096" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226097" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226098" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226099" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226100" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226101" selected="true" />
@@ -1411,12 +1401,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226090" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226091" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226092" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226093" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226094" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226095" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226096" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226097" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226098" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226099" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226100" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226101" selected="true" />
@@ -1676,12 +1664,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226090" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226091" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226092" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226093" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226094" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226095" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226096" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226097" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226098" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226099" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226100" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226101" selected="true" />
@@ -1941,12 +1927,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226090" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226091" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226092" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226093" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226094" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226095" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226096" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226097" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226098" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226099" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226100" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226101" selected="true" />
@@ -2206,12 +2190,10 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226090" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226091" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226092" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226093" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226094" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226095" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226096" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226097" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-226098" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226099" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226100" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-226101" selected="true" />
@@ -2447,32 +2429,32 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226271r794540_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226273r794581_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226274r794582_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226370r794649_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226370r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226371r794624_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226372r794650_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226372r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226373r794625_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226374r794651_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226375r794652_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226376r794653_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226377r794654_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226378r794655_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226379r794656_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226380r794657_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226374r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226375r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226376r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226377r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226378r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226379r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226380r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226383r794628_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226386r794658_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226387r794659_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226388r794660_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226389r794661_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226390r794662_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226391r794663_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226392r794664_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226393r794621_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226394r794665_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226395r794666_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226396r794667_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226397r794668_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226398r794669_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226399r794670_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226386r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226387r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226388r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226389r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226390r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226391r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226392r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226393r852172_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226394r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226395r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226396r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226397r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226398r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226399r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226400r794631_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_CAT_I_Only">
@@ -2482,9 +2464,9 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226050r794701_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226051r794766_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226055r794768_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226056r794778_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226056r852054_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226057r794277_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226058r794278_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226058r852055_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226059r794296_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226060r794295_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226061r794294_rule" selected="false" />
@@ -2494,39 +2476,37 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226066r794792_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226067r794794_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226068r794388_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226069r794309_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226069r852056_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226085r794339_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226086r794340_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226087r794341_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226088r794342_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226089r794274_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226090r794275_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226091r794276_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226087r852064_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226088r852065_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226089r852066_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226090r852067_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226091r852068_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226092r794343_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226093r794360_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226094r794361_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226095r794782_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226096r794784_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226097r794786_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226098r794788_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226095r852069_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226096r852070_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226097r852071_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226099r794279_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226100r794280_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226101r794281_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226102r794335_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226107r794336_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226108r794352_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226109r794353_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226108r852073_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226109r852074_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226110r794366_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226111r794354_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226112r794355_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226111r852075_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226112r852076_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226113r794367_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226114r794368_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226115r794290_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226116r794291_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226117r794356_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226118r794357_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226119r794358_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226120r794359_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226115r852077_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226116r852078_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226117r852079_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226118r852080_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226119r852081_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226120r852082_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226134r794458_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226135r794411_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226136r794412_rule" selected="false" />
@@ -2537,16 +2517,16 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226145r794495_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226146r794417_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226147r794418_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226148r794467_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226149r794468_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226148r852091_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226149r852092_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226150r794419_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226151r794420_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226152r794496_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226153r794421_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226154r794422_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226155r794469_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226156r794470_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226157r794471_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226155r852093_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226156r852094_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226157r852095_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226158r794497_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226159r794498_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226160r794499_rule" selected="false" />
@@ -2557,12 +2537,12 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226165r794427_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226166r794428_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226167r794429_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226168r794472_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226168r852096_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226169r794430_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226170r794431_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226171r794432_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226172r794480_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226173r794481_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226172r852097_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226173r852098_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226174r794454_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226176r794500_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226177r794433_rule" selected="false" />
@@ -2574,42 +2554,42 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226187r794439_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226188r794410_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226189r794453_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226190r794463_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226191r794464_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226192r794465_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226193r794466_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226190r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226191r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226192r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226193r877391_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226194r794440_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226195r794488_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226196r794487_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226195r852107_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226196r852108_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226197r794501_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226198r794441_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226199r794482_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226199r852109_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226200r794456_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226201r794483_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226202r794408_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226201r852110_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226202r877398_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226203r794502_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226204r794503_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226205r794504_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226206r794442_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226209r794473_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226209r852112_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226211r794505_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226212r794475_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226212r852114_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226213r794445_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226214r794506_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226215r794476_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226217r794485_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226218r794450_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226220r794486_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226221r794484_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226222r794457_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226224r794459_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226225r794460_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226226r794461_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226227r794462_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226215r852115_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226217r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226218r877395_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226220r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226221r852118_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226222r877394_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226224r852119_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226225r852120_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226226r852121_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226227r852122_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226230r794409_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226261r819682_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226262r819685_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226263r794522_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226261r890480_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226262r890483_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226263r894351_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226271r794540_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226273r794581_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226274r794582_rule" selected="false" />
@@ -2617,39 +2597,39 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226276r794552_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226277r794513_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226278r794583_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226279r794566_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226280r794567_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226281r794568_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226279r852134_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226280r852135_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226281r852136_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226282r794584_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226283r794585_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226284r794569_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226284r852137_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226285r794586_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226286r794587_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226287r794511_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226290r794588_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226291r794589_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226292r794590_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226293r794570_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226294r794571_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226295r794528_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226296r794608_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226297r794572_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226298r794573_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226293r852138_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226294r852139_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226295r877396_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226296r852140_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226297r852141_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226298r852142_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226299r794609_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226300r794591_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226301r794593_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226302r794594_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226303r794595_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226304r794596_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226305r794561_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226305r852143_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226306r794597_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226307r794562_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226308r794563_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226307r852144_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226308r852145_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226309r794598_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226310r794599_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226311r794564_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226312r794565_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226313r794512_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226311r852146_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226312r852147_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226313r852148_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226317r794602_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226323r794550_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226324r794537_rule" selected="false" />
@@ -2661,22 +2641,22 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226332r794678_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226333r794679_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226334r794680_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226335r794676_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226335r877380_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226336r794681_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226337r794682_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226338r794673_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226338r852150_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226339r794642_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226340r794674_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226340r852151_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226341r794643_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226342r794644_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226343r794645_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226344r794675_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226344r852152_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226345r794646_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226346r794647_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226347r794648_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226348r794632_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226349r794671_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226350r794677_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226349r852153_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226350r852154_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226351r794683_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226352r794622_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226353r794633_rule" selected="false" />
@@ -2685,33 +2665,33 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226356r794635_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226357r794641_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226358r794684_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226370r794649_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226370r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226371r794624_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226373r794625_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226374r794651_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226375r794652_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226377r794654_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226378r794655_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226379r794656_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226374r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226375r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226377r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226378r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226379r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226381r794626_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226382r794627_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226383r794628_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226384r794629_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226385r794630_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226386r794658_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226387r794659_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226388r794660_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226389r794661_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226390r794662_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226391r794663_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226392r794664_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226393r794621_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226394r794665_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226395r794666_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226396r794667_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226397r794668_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226398r794669_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226399r794670_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226386r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226387r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226388r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226389r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226390r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226391r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226392r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226393r852172_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226394r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226395r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226396r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226397r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226398r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226399r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-226400r794631_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Value id="xccdf_mil.disa.stig_value_virtualize_write_failures_per_user_locations_var" type="number" operator="equals">
@@ -3557,12 +3537,12 @@ Disable-WindowsOptionalFeature -Online -FeatureName SMB1Protocol
 Alternately:
 Search for "Features".
 Select "Turn Windows features on or off".
-De-select "SMB 1.0/CIFS File Sharing Support". 
+De-select "SMB 1.0/CIFS File Sharing Support".
 
 The system must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-27739r794698_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5163" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5163" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3592,7 +3572,7 @@ The system must be restarted for the change to take effect.
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-27740r794700_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5165" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5165" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3627,7 +3607,7 @@ The system must be restarted for the changes to take effect.
 These policy settings requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-27741r794765_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5167" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5167" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3661,14 +3641,14 @@ Alternately:
 Use the "Remove Roles and Features Wizard" and deselect "Windows PowerShell 2.0 Engine" under "Windows PowerShell".</xccdf:fixtext>
           <xccdf:fix id="F-27745r794767_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5193" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5193" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226056">
         <xccdf:title>SRG-OS-000329-GPOS-00128</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226056r794778_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226056r852054_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AC-000001</xccdf:version>
           <xccdf:title>Windows 2012 account lockout duration must be configured to 15 minutes or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system. This parameter specifies the period of time that an account will remain locked after the specified number of failed logon attempts.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3688,7 +3668,7 @@ Use the "Remove Roles and Features Wizard" and deselect "Windows PowerShell 2.0 
 A value of "0" is also acceptable, requiring an administrator to unlock the account.</xccdf:fixtext>
           <xccdf:fix id="F-27746r794777_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4422" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4422" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3714,14 +3694,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-27747r475495_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_threshold_var" export-name="oval:mil.disa.fso.windows:var:442300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4423" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4423" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226058">
         <xccdf:title>SRG-OS-000021-GPOS-00005</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226058r794278_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226058r852055_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AC-000003</xccdf:version>
           <xccdf:title>The reset period for the account lockout counter must be configured to 15 minutes or greater on Windows 2012.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system.  This parameter specifies the period of time that must pass after failed logon attempts before the counter is reset to "0".  The smaller this value is, the less effective the account lockout feature will be in protecting the local system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3741,7 +3721,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-27748r475498_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_reset_counter_var" export-name="oval:mil.disa.fso.windows:var:442400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4424" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4424" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3767,7 +3747,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-27749r475501_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_enforce_history_var" export-name="oval:mil.disa.fso.windows:var:442500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4425" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4425" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3793,7 +3773,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-27750r475504_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_maximum_age_var" export-name="oval:mil.disa.fso.windows:var:442600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4426" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4426" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3819,7 +3799,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-27751r475507_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_age_var" export-name="oval:mil.disa.fso.windows:var:442700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4427" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4427" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3845,7 +3825,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-27752r475510_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_length_var" export-name="oval:mil.disa.fso.windows:var:442800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4428" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4428" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3874,14 +3854,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-27753r475513_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_complexity_var" export-name="oval:mil.disa.fso.windows:var:442900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4429" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4429" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226064">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226064r794293_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226064r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AC-000009</xccdf:version>
           <xccdf:title>Reversible password encryption must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storing passwords using reversible encryption is essentially the same as storing clear-text versions of the passwords.  For this reason, this policy must never be enabled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3900,7 +3880,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-27754r475516_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_reversible_encryption_var" export-name="oval:mil.disa.fso.windows:var:443000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4430" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4430" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3925,7 +3905,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fixtext fixref="F-27755r475519_fix">Configure the policy value in the Default Domain Policy for Computer Configuration -&gt;  Policies -&gt; Windows Settings -&gt; Security Settings -&gt; Account Policies -&gt; Kerberos Policy -&gt; "Enforce user logon restrictions" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27755r475519_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4696" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4696" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3950,7 +3930,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fixtext fixref="F-27756r794791_fix">Configure the policy value in the Default Domain Policy for Computer Configuration -&gt;  Policies -&gt; Windows Settings -&gt; Security Settings -&gt; Account Policies -&gt; Kerberos Policy -&gt; "Maximum lifetime for service ticket" to a maximum of 600 minutes, but not 0, which equates to "Ticket doesn't expire".</xccdf:fixtext>
           <xccdf:fix id="F-27756r794791_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4697" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4697" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3975,7 +3955,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fixtext fixref="F-27757r794793_fix">Configure the policy value in the Default Domain Policy for Computer Configuration -&gt;  Policies -&gt; Windows Settings -&gt; Security Settings -&gt; Account Policies -&gt; Kerberos Policy -&gt; "Maximum lifetime for user ticket" to a maximum of 10 hours, but not 0, which equates to "Ticket doesn't expire".</xccdf:fixtext>
           <xccdf:fix id="F-27757r794793_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4698" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4698" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4000,14 +3980,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fixtext fixref="F-27758r475528_fix">Configure the policy value in the Default Domain Policy for Computer Configuration -&gt;  Policies -&gt; Windows Settings -&gt; Security Settings -&gt; Account Policies -&gt; Kerberos Policy -&gt; "Maximum lifetime for user ticket renewal" to a maximum of 7 days or less.</xccdf:fixtext>
           <xccdf:fix id="F-27758r475528_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4699" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4699" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226069">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226069r794309_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226069r852056_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AC-000014-DC</xccdf:version>
           <xccdf:title>The computer clock synchronization tolerance must be limited to 5 minutes or less.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting determines the maximum time difference (in minutes) that Kerberos will tolerate between the time on a client's clock and the time on a server's clock while still considering the two clocks synchronous.  In order to prevent replay attacks, Kerberos uses timestamps as part of its protocol definition.  For timestamps to work properly, the clocks of the client and the server need to be in sync as much as possible.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4026,14 +4006,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fixtext fixref="F-27759r475531_fix">Configure the policy value in the Default Domain Policy for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Account Policies -&gt; Kerberos Policy -&gt; "Maximum tolerance for computer clock synchronization" to a maximum of 5 minutes or less.</xccdf:fixtext>
           <xccdf:fix id="F-27759r475531_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4700" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4700" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226070">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226070r794318_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226070r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AD-000001-DC</xccdf:version>
           <xccdf:title>Active Directory data files must have proper access control permissions.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Improper access permissions for directory data related files could allow unauthorized users to read, modify, or delete directory data or audit trails.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4055,7 +4035,7 @@ BUILTIN\Administrators:(I)(F)
 (F) - full access</xccdf:fixtext>
           <xccdf:fix id="F-27760r475534_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4981" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4981" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4081,7 +4061,7 @@ Credential validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-27775r475579_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Logon -&gt; "Audit Credential Validation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27775r475579_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4664" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4664" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4107,14 +4087,14 @@ Credential validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-27776r475582_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Logon -&gt; "Audit Credential Validation" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27776r475582_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4665" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4665" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226087">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226087r794341_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226087r852064_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000011-DC</xccdf:version>
           <xccdf:title>Windows Server 2012/2012 R2 domain controllers must be configured to audit Account Management - Computer Account Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4134,14 +4114,14 @@ Computer Account Management records events such as creating, changing, deleting,
           <xccdf:fixtext fixref="F-27777r475585_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit Computer Account Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27777r475585_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4666" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4666" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226088">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226088r794342_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226088r852065_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000015</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - Other Account Management Events successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4161,14 +4141,14 @@ Other Account Management Events records events such as the access of a password 
           <xccdf:fixtext fixref="F-27778r475588_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Management -&gt; "Audit Other Account Management Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27778r475588_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4668" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4668" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226089">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226089r794274_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226089r852066_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000017</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - Security Group Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4193,14 +4173,14 @@ Security Group Management records events such as creating, deleting, or changing
           <xccdf:fixtext fixref="F-27779r475591_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Management -&gt; "Audit Security Group Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27779r475591_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4670" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4670" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226090">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226090r794275_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226090r852067_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000019</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - User Account Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4225,14 +4205,14 @@ User Account Management records events such as creating, changing, deleting, ren
           <xccdf:fixtext fixref="F-27780r475594_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Management -&gt; "Audit User Account Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27780r475594_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4672" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4672" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226091">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226091r794276_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226091r852068_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000020</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - User Account Management failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4257,7 +4237,7 @@ User Account Management records events such as creating, changing, deleting, ren
           <xccdf:fixtext fixref="F-27781r475597_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Management -&gt; "Audit User Account Management" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27781r475597_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4673" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4673" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4283,34 +4263,7 @@ Process Creation records events related to the creation of a process and the sou
           <xccdf:fixtext fixref="F-27782r475600_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Detailed Tracking -&gt; "Audit Process Creation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27782r475600_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4674" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-226093">
-        <xccdf:title>SRG-OS-000474-GPOS-00219</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226093r794360_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000030</xccdf:version>
-          <xccdf:title>Windows Server 2012/2012 R2 must be configured to audit Logon/Logoff - Account Lockout successes.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
-
-Account Lockout events can be used to identify potentially malicious logon attempts.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Microsoft Windows Server 2012-2012 R2 DC</dc:subject>
-            <dc:identifier>4217</dc:identifier>
-          </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/legacy">SV-92765</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">V-78057</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-001404</xccdf:ident>
-          <xccdf:fixtext fixref="F-27783r475603_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Account Lockout" with "Success" selected.</xccdf:fixtext>
-          <xccdf:fix id="F-27783r475603_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5182" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4674" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4337,14 +4290,14 @@ Account Lockout events can be used to identify potentially malicious logon attem
           <xccdf:fixtext fixref="F-27784r475606_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Account Lockout" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27784r475606_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5183" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5183" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226095">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226095r794782_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226095r852069_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000031-DC</xccdf:version>
           <xccdf:title>The system must be configured to audit DS Access - Directory Service Access successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detecting attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4366,14 +4319,14 @@ Audit directory service access records events related to users accessing an Acti
 Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; DS Access -&gt; "Directory Service Access" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27785r794781_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4709" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4709" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226096">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226096r794784_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226096r852070_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000032-DC</xccdf:version>
           <xccdf:title>The system must be configured to audit DS Access - Directory Service Access failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detecting attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4395,14 +4348,14 @@ Audit directory service access records events related to users accessing an Acti
 Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; DS Access -&gt; "Directory Service Access" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27786r794783_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4710" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4710" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226097">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226097r794786_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226097r852071_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000035-DC</xccdf:version>
           <xccdf:title>The system must be configured to audit DS Access - Directory Service Changes successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detecting attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4424,36 +4377,7 @@ Audit directory service changes records events related to changes made to object
 Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; DS Access -&gt; "Directory Service Changes" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27787r794785_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4711" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-226098">
-        <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226098r794788_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000036-DC</xccdf:version>
-          <xccdf:title>The system must be configured to audit DS Access - Directory Service Changes failures.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detecting attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
-
-Audit directory service changes records events related to changes made to objects in Active Directory Domain Services.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Microsoft Windows Server 2012-2012 R2 DC</dc:subject>
-            <dc:identifier>4217</dc:identifier>
-          </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/legacy">SV-51155</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">V-33666</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002234</xccdf:ident>
-          <xccdf:fixtext fixref="F-27788r794787_fix">Detailed auditing subcategories are configured in Security Settings -&gt; Advanced Audit Policy Configuration. The summary level settings under Security Settings -&gt; Local Policies -&gt; Audit Policy will not be enforced (see V-14230).
-
-Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; DS Access -&gt; "Directory Service Changes" with "Failure" selected.</xccdf:fixtext>
-          <xccdf:fix id="F-27788r794787_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4712" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4711" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4480,7 +4404,7 @@ Logoff records user logoffs.  If this is an interactive logoff, it is recorded o
           <xccdf:fixtext fixref="F-27789r475621_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Logon/Logoff -&gt; "Audit Logoff" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27789r475621_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4675" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4675" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4507,7 +4431,7 @@ Logon records user logons.  If this is an interactive logon, it is recorded on t
           <xccdf:fixtext fixref="F-27790r475624_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Logon/Logoff -&gt; "Audit Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27790r475624_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4676" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4676" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4534,7 +4458,7 @@ Logon records user logons.  If this is an interactive logon, it is recorded on t
           <xccdf:fixtext fixref="F-27791r475627_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Logon/Logoff -&gt; "Audit Logon" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27791r475627_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4677" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4677" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4560,7 +4484,7 @@ Special Logon records special logons which have administrative privileges and ca
           <xccdf:fixtext fixref="F-27792r475630_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Logon/Logoff -&gt; "Audit Special Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27792r475630_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4678" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4678" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4586,14 +4510,14 @@ Audit Policy Change records events related to changes in audit policy.&lt;/VulnD
           <xccdf:fixtext fixref="F-27797r475645_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Policy Change -&gt; "Audit Audit Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27797r475645_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4681" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4681" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226108">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226108r794352_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226108r852073_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000086</xccdf:version>
           <xccdf:title>The system must be configured to audit Policy Change - Audit Policy Change failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4613,14 +4537,14 @@ Audit Policy Change records events related to changes in audit policy.&lt;/VulnD
           <xccdf:fixtext fixref="F-27798r475648_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Policy Change -&gt; "Audit Audit Policy Change" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27798r475648_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4682" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4682" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226109">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226109r794353_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226109r852074_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000087</xccdf:version>
           <xccdf:title>The system must be configured to audit Policy Change - Authentication Policy Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4640,7 +4564,7 @@ Authentication Policy Change records events related to changes in authentication
           <xccdf:fixtext fixref="F-27799r475651_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Policy Change -&gt; "Audit Authentication Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27799r475651_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4683" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4683" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4666,14 +4590,14 @@ Authorization Policy Change records events related to changes in user rights, su
           <xccdf:fixtext fixref="F-27800r475654_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Policy Change -&gt; "Audit Authorization Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27800r475654_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4975" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4975" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226111">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226111r794354_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226111r852075_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000101</xccdf:version>
           <xccdf:title>The system must be configured to audit Privilege Use - Sensitive Privilege Use successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4693,14 +4617,14 @@ Sensitive Privilege Use records events related to use of sensitive privileges, s
           <xccdf:fixtext fixref="F-27801r475657_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Privilege Use -&gt; "Audit Sensitive Privilege Use" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27801r475657_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4684" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4684" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226112">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226112r794355_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226112r852076_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000102</xccdf:version>
           <xccdf:title>The system must be configured to audit Privilege Use - Sensitive Privilege Use failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4720,7 +4644,7 @@ Sensitive Privilege Use records events related to use of sensitive privileges, s
           <xccdf:fixtext fixref="F-27802r475660_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Privilege Use -&gt; "Audit Sensitive Privilege Use" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27802r475660_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4685" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4685" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4746,7 +4670,7 @@ IPsec Driver records events related to the IPSec Driver such as dropped packets.
           <xccdf:fixtext fixref="F-27803r475663_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit IPsec Driver" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27803r475663_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4686" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4686" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4772,14 +4696,14 @@ IPsec Driver records events related to the IPsec Driver such as dropped packets.
           <xccdf:fixtext fixref="F-27804r475666_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit IPsec Driver" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27804r475666_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4687" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4687" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226115">
         <xccdf:title>SRG-OS-000064-GPOS-00033</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226115r794290_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226115r852077_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000105</xccdf:version>
           <xccdf:title>Windows Server 2012/2012 R2 must be configured to audit System - Other System Events successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4802,14 +4726,14 @@ Satisfies: SRG-OS-000458-GPOS-00203&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:fixtext fixref="F-27805r475669_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27805r475669_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5190" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5190" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226116">
         <xccdf:title>SRG-OS-000064-GPOS-00033</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226116r794291_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226116r852078_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000106</xccdf:version>
           <xccdf:title>Windows Server 2012/2012 R2 must be configured to audit System - Other System Events failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4832,14 +4756,14 @@ Satisfies: SRG-OS-000458-GPOS-00203&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:fixtext fixref="F-27806r475672_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27806r475672_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5191" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5191" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226117">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226117r794356_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226117r852079_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000107</xccdf:version>
           <xccdf:title>The system must be configured to audit System - Security State Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4859,14 +4783,14 @@ Security State Change records events related to changes in the security state, s
           <xccdf:fixtext fixref="F-27807r475675_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit Security State Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27807r475675_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4688" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4688" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226118">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226118r794357_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226118r852080_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000109</xccdf:version>
           <xccdf:title>The system must be configured to audit System - Security System Extension successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4886,14 +4810,14 @@ Security System Extension records events related to extension code being loaded 
           <xccdf:fixtext fixref="F-27808r475678_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit Security System Extension" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27808r475678_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4690" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4690" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226119">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226119r794358_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226119r852081_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000111</xccdf:version>
           <xccdf:title>The system must be configured to audit System - System Integrity successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4913,14 +4837,14 @@ System Integrity records events related to violations of integrity to the securi
           <xccdf:fixtext fixref="F-27809r475681_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit System Integrity" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27809r475681_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4692" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4692" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226120">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226120r794359_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226120r852082_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000112</xccdf:version>
           <xccdf:title>The system must be configured to audit System - System Integrity failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4940,7 +4864,7 @@ System Integrity records events related to violations of integrity to the securi
           <xccdf:fixtext fixref="F-27810r475684_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit System Integrity" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27810r475684_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4693" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4693" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4971,7 +4895,7 @@ TrustedInstaller - Full Control
 Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xccdf:fixtext>
           <xccdf:fix id="F-27824r475726_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4984" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4984" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4996,7 +4920,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fixtext fixref="F-27825r475729_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Network -&gt; Link-Layer Topology Discovery -&gt; "Turn on Mapper I/O (LLTDIO) driver" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27825r475729_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4431" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4431" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5021,7 +4945,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fixtext fixref="F-27826r475732_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Network -&gt; Link-Layer Topology Discovery -&gt; "Turn on Responder (RSPNDR) driver" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27826r475732_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4432" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4432" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5047,7 +4971,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27827r475735_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_microsoft_peer_to_peer_networking_services_var" export-name="oval:mil.disa.fso.windows:var:443300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4433" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4433" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5073,7 +4997,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27828r475738_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prohibit_installation_network_bridge_var" export-name="oval:mil.disa.fso.windows:var:443400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4434" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4434" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5099,7 +5023,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27829r475741_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_domain_users_to_elevate_when_setting_a_networks_location_var" export-name="oval:mil.disa.fso.windows:var:443500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4435" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4435" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5125,7 +5049,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27830r475744_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_route_all_traffic_through_the_internal_network_var" export-name="oval:mil.disa.fso.windows:var:443600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4436" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4436" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5150,7 +5074,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fixtext fixref="F-27835r475759_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Network -&gt; TCPIP Settings -&gt; Parameters -&gt; "Set IP Stateless Autoconfiguration Limits State" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27835r475759_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4727" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4727" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5175,7 +5099,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fixtext fixref="F-27836r475762_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Network -&gt; Windows Connect Now -&gt; "Configuration of wireless settings using Windows Connect Now" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27836r475762_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4441" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4441" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5201,17 +5125,17 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27837r475765_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prohibit_access_of_the_windows_connect_now_wizards_var" export-name="oval:mil.disa.fso.windows:var:444200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4442" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4442" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226148">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226148r794467_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226148r852091_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000016</xccdf:version>
           <xccdf:title>Windows Update must be prevented from searching for point and print drivers.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent Windows from searching Windows Update for point and print drivers.  Only the local driver store and server driver cache will be searched.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5228,14 +5152,14 @@ This setting will prevent Windows from searching Windows Update for point and pr
           <xccdf:fix id="F-27838r475768_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_extend_point_and_print_connection_to_search_windows_update_and_use_alternate_connection_if_needed_var" export-name="oval:mil.disa.fso.windows:var:444300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4443" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4443" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226149">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226149r794468_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226149r852092_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000018</xccdf:version>
           <xccdf:title>Optional component installation and component repair must be prevented from using Windows Update.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Uncontrolled system updates can introduce issues to a system.  Obtaining update components from an outside source may also potentially provide sensitive information outside of the enterprise.  Optional component installation or repair must be obtained from an internal source.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5253,7 +5177,7 @@ This setting will prevent Windows from searching Windows Update for point and pr
           <xccdf:fixtext fixref="F-27839r475771_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; "Specify settings for optional component installation and component repair" to "Enabled" and with "Never attempt to download payload from Windows Update" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27839r475771_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4444" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4444" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5279,7 +5203,7 @@ This setting will prevent Windows from searching Windows Update for point and pr
           <xccdf:fix id="F-27840r475774_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_remote_access_to_the_pnp_interface_var" export-name="oval:mil.disa.fso.windows:var:444500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4445" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4445" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5289,7 +5213,7 @@ This setting will prevent Windows from searching Windows Update for point and pr
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226151r794420_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000020</xccdf:version>
           <xccdf:title>An Error Report must not be sent when a generic device driver is installed.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents an error report from being sent when a generic device driver is installed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5306,7 +5230,7 @@ This setting prevents an error report from being sent when a generic device driv
           <xccdf:fix id="F-27841r475777_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_send_windows_error_report_when_generic_driver_is_installed_on_device_var" export-name="oval:mil.disa.fso.windows:var:444600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4446" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4446" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5332,7 +5256,7 @@ This setting prevents an error report from being sent when a generic device driv
           <xccdf:fix id="F-27842r475780_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_create_system_restore_point_when_new_device_driver_installed_var" export-name="oval:mil.disa.fso.windows:var:444700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4447" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4447" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5342,7 +5266,7 @@ This setting prevents an error report from being sent when a generic device driv
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226153r794421_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000022</xccdf:version>
           <xccdf:title>Device metadata retrieval from the Internet must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent Windows from retrieving device metadata from the Internet.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5359,7 +5283,7 @@ This setting will prevent Windows from retrieving device metadata from the Inter
           <xccdf:fix id="F-27843r475783_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prevent_device_metadata_retrieval_from_the_internet_var" export-name="oval:mil.disa.fso.windows:var:444800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4448" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4448" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5369,7 +5293,7 @@ This setting will prevent Windows from retrieving device metadata from the Inter
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226154r794422_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000023</xccdf:version>
           <xccdf:title>Windows must be prevented from sending an error report when a device driver requests additional software during installation.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent Windows from sending an error report to Microsoft when a device driver requests additional software during installation.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5385,17 +5309,17 @@ This setting will prevent Windows from sending an error report to Microsoft when
           <xccdf:fixtext fixref="F-27844r475786_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Device Installation -&gt; "Prevent Windows from sending an error report when a device driver requests additional software during installation" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27844r475786_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4449" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4449" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226155">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226155r794469_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226155r852093_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000024</xccdf:version>
           <xccdf:title>Device driver searches using Windows Update must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent the system from searching Windows Update for device drivers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5412,14 +5336,14 @@ This setting will prevent the system from searching Windows Update for device dr
           <xccdf:fix id="F-27845r475789_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_specify_search_order_for_device_driver_source_locations_var" export-name="oval:mil.disa.fso.windows:var:445000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4450" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4450" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226156">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226156r794470_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226156r852094_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000025</xccdf:version>
           <xccdf:title>Device driver updates must only search managed servers, not Windows Update.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Uncontrolled system updates can introduce issues to a system.  Obtaining update components from an outside source may also potentially provide sensitive information outside of the enterprise.  Device driver updates must be obtained from an internal source.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5437,17 +5361,17 @@ This setting will prevent the system from searching Windows Update for device dr
           <xccdf:fixtext fixref="F-27846r475792_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Device Installation -&gt; "Specify the search server for device driver updates" to "Enabled" with "Search Managed Server" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27846r475792_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4451" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4451" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226157">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226157r794471_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226157r852095_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000026</xccdf:version>
           <xccdf:title>Users must not be prompted to search Windows Update for device drivers.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents users from being prompted to search Windows Update for device drivers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5464,7 +5388,7 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:fix id="F-27847r475795_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_windows_update_device_driver_search_prompt_var" export-name="oval:mil.disa.fso.windows:var:445200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4452" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4452" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5489,7 +5413,7 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:fixtext fixref="F-27848r475798_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Early Launch Antimalware -&gt; "Boot-Start Driver Initialization Policy" to "Enabled" with "Good and Unknown" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27848r475798_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4453" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4453" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5515,7 +5439,7 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:fix id="F-27849r475801_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_registry_policy_processing_var" export-name="oval:mil.disa.fso.windows:var:445400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4454" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4454" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5540,7 +5464,7 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:fixtext fixref="F-27850r475804_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Group Policy -&gt; "Turn off background refresh of Group Policy" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27850r475804_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4989" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4989" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5562,12 +5486,12 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:ident system="http://cyber.mil/legacy">SV-51609</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-36680</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-27851r475807_fix">If the \Windows\WinStore directory exists, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Internet Communication Management &gt;&gt; Internet Communication settings &gt;&gt; "Turn off access to the Store" to "Enabled".   
+          <xccdf:fixtext fixref="F-27851r475807_fix">If the \Windows\WinStore directory exists, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Internet Communication Management &gt;&gt; Internet Communication settings &gt;&gt; "Turn off access to the Store" to "Enabled".
 
 Alternately, uninstall the "Desktop Experience" feature from Windows 2012.  This is located under "User Interfaces and Infrastructure" in the "Add Roles and Features Wizard".  The \Windows\WinStore directory may need to be manually deleted after this.</xccdf:fixtext>
           <xccdf:fix id="F-27851r475807_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4455" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4455" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5577,7 +5501,7 @@ Alternately, uninstall the "Desktop Experience" feature from Windows 2012.  This
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226162r794424_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000032</xccdf:version>
           <xccdf:title>Downloading print driver packages over HTTP must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents the computer from downloading print driver packages over HTTP.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5594,7 +5518,7 @@ This setting prevents the computer from downloading print driver packages over H
           <xccdf:fix id="F-27852r475810_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_downloading_of_print_drivers_over_http_var" export-name="oval:mil.disa.fso.windows:var:445700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4457" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4457" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5619,7 +5543,7 @@ This setting prevents the computer from downloading print driver packages over H
           <xccdf:fixtext fixref="F-27853r475813_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Internet Communication Management -&gt; Internet Communication settings -&gt; "Turn off Event Viewer "Events.asp" links" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27853r475813_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4623" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4623" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5629,7 +5553,7 @@ This setting prevents the computer from downloading print driver packages over H
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226164r794426_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000035</xccdf:version>
           <xccdf:title>Errors in handwriting recognition on tablet PCs must not be reported to Microsoft.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents errors in handwriting recognition on tablet PCs from being reported to Microsoft.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5646,7 +5570,7 @@ This setting prevents errors in handwriting recognition on tablet PCs from being
           <xccdf:fix id="F-27854r475816_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_handwriting_recognition_error_reporting_var" export-name="oval:mil.disa.fso.windows:var:445800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4458" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4458" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5656,7 +5580,7 @@ This setting prevents errors in handwriting recognition on tablet PCs from being
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226165r794427_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000038</xccdf:version>
           <xccdf:title>The Internet File Association service must be turned off.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents unhandled file associations from using the Microsoft Web service to find an application.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5673,7 +5597,7 @@ This setting prevents unhandled file associations from using the Microsoft Web s
           <xccdf:fix id="F-27855r475819_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_internet_file_association_service_var" export-name="oval:mil.disa.fso.windows:var:446100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4461" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4461" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5683,7 +5607,7 @@ This setting prevents unhandled file associations from using the Microsoft Web s
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226166r794428_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000039</xccdf:version>
           <xccdf:title>Printing over HTTP must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents the client computer from printing over HTTP, which allows the computer to print to printers on the intranet as well as the Internet.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5700,7 +5624,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
           <xccdf:fix id="F-27856r475822_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_printing_over_http_var" export-name="oval:mil.disa.fso.windows:var:446200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4462" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4462" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5710,7 +5634,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226167r794429_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000045</xccdf:version>
           <xccdf:title>The Windows Customer Experience Improvement Program must be disabled.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting ensures the Windows Customer Experience Improvement Program is disabled so information is not passed to the vendor.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5727,17 +5651,17 @@ This setting ensures the Windows Customer Experience Improvement Program is disa
           <xccdf:fix id="F-27857r475825_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_disable_the_windows_messenger_customer_experience_improvement_program_var" export-name="oval:mil.disa.fso.windows:var:446800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4468" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4468" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226168">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226168r794472_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226168r852096_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000047</xccdf:version>
           <xccdf:title>Windows must be prevented from using Windows Update to search for drivers.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents Windows from searching Windows Update for device drivers when no local drivers for a device are present.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -5754,7 +5678,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27858r475828_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_windows_update_device_driver_searching_var" export-name="oval:mil.disa.fso.windows:var:447000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4470" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4470" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5779,7 +5703,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fixtext fixref="F-27859r475831_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Locale Services -&gt; "Disallow copying of user input methods to the system account for sign-in" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27859r475831_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4471" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4471" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5804,7 +5728,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fixtext fixref="F-27860r475834_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Logon -&gt; "Enumerate local users on domain-joined computers" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27860r475834_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4473" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4473" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5829,14 +5753,14 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fixtext fixref="F-27861r475837_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Logon -&gt; "Turn off app notifications on the lock screen" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27861r475837_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4474" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4474" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226172">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226172r794480_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226172r852097_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000054</xccdf:version>
           <xccdf:title>Users must be prompted to authenticate on resume from sleep (on battery).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Authentication must always be required when accessing a system.  This setting ensures the user is prompted for a password on resume from sleep (on battery).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5855,14 +5779,14 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27862r475840_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_on_battery_var" export-name="oval:mil.disa.fso.windows:var:447500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4475" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4475" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226173">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226173r794481_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226173r852098_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000055</xccdf:version>
           <xccdf:title>The user must be prompted to authenticate on resume from sleep (plugged in).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Authentication must always be required when accessing a system.  This setting ensures the user is prompted for a password on resume from sleep (plugged in).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5881,7 +5805,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27863r475843_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_plugged_var" export-name="oval:mil.disa.fso.windows:var:447600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4476" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4476" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5907,7 +5831,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27864r475846_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_offer_remote_assistance_var" export-name="oval:mil.disa.fso.windows:var:447900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4479" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4479" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5933,7 +5857,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27865r475849_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_solicited_remote_assistance_var" export-name="oval:mil.disa.fso.windows:var:448000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4480" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4480" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5959,7 +5883,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27866r475852_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_on_session_logging_var" export-name="oval:mil.disa.fso.windows:var:448100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4481" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4481" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5984,7 +5908,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fixtext fixref="F-27867r475855_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Troubleshooting and Diagnostics -&gt; Application Compatibility Diagnostics -&gt; "Detect compatibility issues for applications and drivers" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27867r475855_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4484" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4484" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5994,7 +5918,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226178r794434_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000066</xccdf:version>
           <xccdf:title>Microsoft Support Diagnostic Tool (MSDT) interactive communication with Microsoft must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents the MSDT from communicating with and sending collected data to Microsoft, the default support provider.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -6011,7 +5935,7 @@ This setting prevents the MSDT from communicating with and sending collected dat
           <xccdf:fix id="F-27868r475858_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_microsoft_support_diagnostic_tool_turn_on_msdt_interactive_communication_with_support_provider_var" export-name="oval:mil.disa.fso.windows:var:448500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4485" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4485" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6021,7 +5945,7 @@ This setting prevents the MSDT from communicating with and sending collected dat
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226179r794435_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000067</xccdf:version>
           <xccdf:title>Access to Windows Online Troubleshooting Service (WOTS) must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents users from searching troubleshooting content on Microsoft servers.  Only local content will be available.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -6038,7 +5962,7 @@ This setting prevents users from searching troubleshooting content on Microsoft 
           <xccdf:fix id="F-27869r475861_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_troubleshooting_allow_user_to_access_online_troubleshooting_content_on_microsoft_servers_from_the_troubleshooting_control_panel_var" export-name="oval:mil.disa.fso.windows:var:448600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4486" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4486" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6048,7 +5972,7 @@ This setting prevents users from searching troubleshooting content on Microsoft 
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226180r794436_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000068</xccdf:version>
           <xccdf:title>Responsiveness events must be prevented from being aggregated and sent to Microsoft.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents responsiveness events from being aggregated and sent to Microsoft.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -6065,7 +5989,7 @@ This setting prevents responsiveness events from being aggregated and sent to Mi
           <xccdf:fix id="F-27870r475864_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_enable_disable_perftrack_var" export-name="oval:mil.disa.fso.windows:var:448700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4487" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4487" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6090,7 +6014,7 @@ This setting prevents responsiveness events from being aggregated and sent to Mi
           <xccdf:fixtext fixref="F-27872r475870_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; App Package Deployment  -&gt; "Allow all trusted apps to install" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27872r475870_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4488" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4488" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6100,7 +6024,7 @@ This setting prevents responsiveness events from being aggregated and sent to Mi
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226183r794438_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000071</xccdf:version>
           <xccdf:title>The Application Compatibility Program Inventory must be prevented from collecting data and sending the information to Microsoft.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent the Program Inventory from collecting data about a system and sending the information to Microsoft.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -6117,14 +6041,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27873r475873_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_program_inventory_var" export-name="oval:mil.disa.fso.windows:var:448900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4489" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4489" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226184">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226184r794477_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226184r852100_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000072</xccdf:version>
           <xccdf:title>Autoplay must be turned off for non-volume devices.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing Autoplay to execute may introduce malicious code to a system.  Autoplay begins reading from a drive as soon as media is inserted into the drive.  As a result, the setup file of programs or music on audio media may start.  This setting will disable Autoplay for non-volume devices (such as Media Transfer Protocol (MTP) devices).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6143,14 +6067,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27874r475876_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_autoplay_for_non_volume_devices_var" export-name="oval:mil.disa.fso.windows:var:449000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4490" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4490" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226185">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226185r794478_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226185r852101_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000073</xccdf:version>
           <xccdf:title>The default Autorun behavior must be configured to prevent Autorun commands.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing Autorun commands to execute may introduce malicious code to a system.  Configuring this setting prevents Autorun commands from executing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6169,14 +6093,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27875r475879_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_default_behavior_for_autorun_var" export-name="oval:mil.disa.fso.windows:var:449100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4491" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4491" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226186">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226186r794479_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226186r852102_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000074</xccdf:version>
           <xccdf:title>Autoplay must be disabled for all drives.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing Autoplay to execute may introduce malicious code to a system.  Autoplay begins reading from a drive as soon media is inserted into the drive.  As a result, the setup file of programs or music on audio media may start.  By default, Autoplay is disabled on removable drives, such as the floppy disk drive (but not the CD-ROM drive) and on network drives.  Enabling this policy disables Autoplay on all drives.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6194,7 +6118,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fixtext fixref="F-27876r475882_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; AutoPlay Policies -&gt; "Turn off AutoPlay" to "Enabled:All Drives".</xccdf:fixtext>
           <xccdf:fix id="F-27876r475882_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4492" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4492" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6219,7 +6143,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fixtext fixref="F-27877r475885_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Biometrics -&gt; "Allow the use of biometrics" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27877r475885_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4493" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4493" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6244,7 +6168,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fixtext fixref="F-27878r475888_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Credential User Interface -&gt; "Do not display the password reveal button" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27878r475888_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4494" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4494" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6270,14 +6194,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27879r475891_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_enumerate_administrator_accounts_on_elevation_var" export-name="oval:mil.disa.fso.windows:var:449500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4495" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4495" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226190">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226190r794463_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226190r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000084</xccdf:version>
           <xccdf:title>The Application event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6296,14 +6220,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27880r475894_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_application_log_size_var" export-name="oval:mil.disa.fso.windows:var:450200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4502" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4502" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226191">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226191r794464_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226191r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000085</xccdf:version>
           <xccdf:title>The Security event log size must be configured to 196608 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6322,14 +6246,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27881r475897_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_security_log_size_var" export-name="oval:mil.disa.fso.windows:var:450300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4503" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4503" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226192">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226192r794465_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226192r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000086</xccdf:version>
           <xccdf:title>The Setup event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6348,14 +6272,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27882r475900_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_setup_log_size_var" export-name="oval:mil.disa.fso.windows:var:450400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4504" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4504" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226193">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226193r794466_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226193r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000087</xccdf:version>
           <xccdf:title>The System event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6374,7 +6298,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27883r475903_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_system_log_size_var" export-name="oval:mil.disa.fso.windows:var:450500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4505" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4505" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6396,7 +6320,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:ident system="http://cyber.mil/legacy">SV-51747</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-36707</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000381</xccdf:ident>
-          <xccdf:fixtext fixref="F-27884r475906_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; File Explorer &gt;&gt; "Configure Windows SmartScreen" to "Enabled" with either "Give user a warning before running downloaded unknown software" or "Require approval from an administrator before running downloaded unknown software" selected.   
+          <xccdf:fixtext fixref="F-27884r475906_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; File Explorer &gt;&gt; "Configure Windows SmartScreen" to "Enabled" with either "Give user a warning before running downloaded unknown software" or "Require approval from an administrator before running downloaded unknown software" selected.
 
 Microsoft has changed this setting several times in the Windows 10 administrative templates, which will affect group policies in a domain if later templates are used.
 
@@ -6405,14 +6329,14 @@ v1607 of Windows 10 and Windows Server 2016 changed the setting to only Enabled 
 v1703 of Windows 10 or later administrative templates changed the policy name to "Configure Windows Defender SmartScreen", and the selectable options are "Warn" and "Warn and prevent bypass". When either of these are applied to a Windows 2012/2012 R2 system, it will configure the registry equivalent of "Give user a warning…").</xccdf:fixtext>
           <xccdf:fix id="F-27884r475906_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4506" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4506" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226195">
         <xccdf:title>SRG-OS-000433-GPOS-00192</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226195r794488_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226195r852107_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000089</xccdf:version>
           <xccdf:title>Explorer Data Execution Prevention must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Data Execution Prevention (DEP) provides additional protection by performing  checks on memory to help prevent malicious code from running.  This setting will prevent Data Execution Prevention from being turned off for File Explorer.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6431,14 +6355,14 @@ v1703 of Windows 10 or later administrative templates changed the policy name to
           <xccdf:fix id="F-27885r475909_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_data_execution_prevention_for_explorer_var" export-name="oval:mil.disa.fso.windows:var:450700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4507" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4507" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226196">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226196r794487_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226196r852108_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000090</xccdf:version>
           <xccdf:title>Turning off File Explorer heap termination on corruption must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Legacy plug-in applications may continue to function when a File Explorer session has become corrupt.  Disabling this feature will prevent this.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6457,7 +6381,7 @@ v1703 of Windows 10 or later administrative templates changed the policy name to
           <xccdf:fix id="F-27886r475912_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_heap_termination_corruption_var" export-name="oval:mil.disa.fso.windows:var:450800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4508" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4508" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6483,7 +6407,7 @@ v1703 of Windows 10 or later administrative templates changed the policy name to
           <xccdf:fix id="F-27887r475915_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_shell_protocol_protected_mode_var" export-name="oval:mil.disa.fso.windows:var:450900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4509" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4509" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6510,14 +6434,14 @@ v1703 of Windows 10 or later administrative templates changed the policy name to
 If location services are approved by the organization for a device, this must be documented.</xccdf:fixtext>
           <xccdf:fix id="F-27888r475918_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4510" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4510" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226199">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226199r794482_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226199r852109_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000096</xccdf:version>
           <xccdf:title>Passwords must not be saved in the Remote Desktop Client.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Saving passwords in the Remote Desktop Client could allow an unauthorized user to establish a remote desktop session to another system.  The system must be configured to prevent users from saving passwords in the Remote Desktop Client.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6536,7 +6460,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27889r475921_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_passwords_to_be_saved_var" export-name="oval:mil.disa.fso.windows:var:451100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4511" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4511" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6562,14 +6486,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27890r475924_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_drive_redirection_var" export-name="oval:mil.disa.fso.windows:var:451200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4512" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4512" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226201">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226201r794483_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226201r852110_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000099</xccdf:version>
           <xccdf:title>Remote Desktop Services must always prompt a client for passwords upon connection.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting controls the ability of users to supply passwords automatically as part of their remote desktop connection.  Disabling this setting would allow anyone to use the stored credentials in a connection item to connect to the terminal server.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6588,14 +6512,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27891r475927_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_always_prompt_for_password_upon_connection_var" export-name="oval:mil.disa.fso.windows:var:451300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4513" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4513" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226202">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226202r794408_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226202r877398_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000100</xccdf:version>
           <xccdf:title>Remote Desktop Services must be configured with the client connection encryption set to the required level.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Remote connections must be encrypted to prevent interception of data or sensitive information. Selecting "High Level" will ensure encryption of Remote Desktop Services sessions in both directions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6615,7 +6539,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27892r475930_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_set_client_connection_encryption_level_var" export-name="oval:mil.disa.fso.windows:var:451400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4514" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4514" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6641,7 +6565,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27893r475933_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_delete_temp_folder_upon_exit_var" export-name="oval:mil.disa.fso.windows:var:451700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4517" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4517" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6667,7 +6591,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27894r475936_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_use_temporary_folders_per_session_var" export-name="oval:mil.disa.fso.windows:var:451800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4518" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4518" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6692,7 +6616,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27895r475939_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; RSS Feeds -&gt; "Prevent downloading of enclosures" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27895r475939_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4519" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4519" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6717,14 +6641,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27896r475942_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; RSS Feeds -&gt; "Turn on Basic feed authentication over HTTP" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27896r475942_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4728" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4728" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226209">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226209r794473_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226209r852112_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000115</xccdf:version>
           <xccdf:title>Users must be prevented from changing installation options.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Installation options for applications are typically controlled by administrators.  This setting prevents users from changing installation options that may bypass security features.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6742,14 +6666,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27899r475951_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Installer -&gt; "Allow user control over installs" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27899r475951_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4525" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4525" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226210">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226210r794474_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226210r852113_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000116</xccdf:version>
           <xccdf:title>The Windows Installer Always install with elevated privileges option must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Standard user accounts must not be granted elevated privileges.  Enabling Windows Installer to elevate privileges when installing applications can allow malicious persons and applications to gain full control of a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6767,7 +6691,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27900r475954_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Installer -&gt; "Always install with elevated privileges" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27900r475954_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4526" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4526" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6792,14 +6716,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27901r475957_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Installer -&gt; "Prevent Internet Explorer security prompt for Windows Installer scripts" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27901r475957_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4527" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4527" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226212">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226212r794475_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226212r852114_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000118</xccdf:version>
           <xccdf:title>Nonadministrators must be prevented from applying vendor-signed updates.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Uncontrolled system updates can introduce issues to a system.  This setting will prevent users from applying vendor-signed updates (though they may be from a trusted source).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6818,7 +6742,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27902r475960_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prohibit_non_administrators_install_signed_updates_var" export-name="oval:mil.disa.fso.windows:var:452800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4528" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4528" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6828,7 +6752,7 @@ If location services are approved by the organization for a device, this must be
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226213r794445_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000120</xccdf:version>
           <xccdf:title>Windows Media Digital Rights Management (DRM) must be prevented from accessing the Internet.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This check verifies that Windows Media DRM will be prevented from accessing the Internet.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -6844,7 +6768,7 @@ This check verifies that Windows Media DRM will be prevented from accessing the 
           <xccdf:fixtext fixref="F-27903r475963_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Media Digital Rights Management -&gt; "Prevent Windows Media DRM Internet Access" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27903r475963_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4625" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4625" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6854,7 +6778,7 @@ This check verifies that Windows Media DRM will be prevented from accessing the 
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226214r794506_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000121</xccdf:version>
           <xccdf:title>Users must not be presented with Privacy and Installation options on first use of Windows Media Player.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents users from being presented with Privacy and Installation options on first use of Windows Media Player, which could enable some communication with the vendor.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -6870,14 +6794,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27904r475966_fix">If Windows Media Player is installed, configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Media Player -&gt; "Do Not Show First Use Dialog Boxes" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27904r475966_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4624" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4624" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226215">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226215r794476_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226215r852115_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000122</xccdf:version>
           <xccdf:title>Windows Media Player must be configured to prevent automatic checking for updates.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Uncontrolled system updates can introduce issues to a system.  The automatic check for updates performed by Windows Media Player must be disabled to ensure a constant platform and to prevent the introduction of unknown\untested software on the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6896,14 +6820,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fix id="F-27905r475969_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prevent_automatic_updates_var" export-name="oval:mil.disa.fso.windows:var:453000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4530" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4530" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226216">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226216r794449_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226216r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000123</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain text passwords that could be used to compromise a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6921,14 +6845,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27906r475972_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Client -&gt; "Allow Basic authentication" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27906r475972_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4531" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4531" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226217">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226217r794485_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226217r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000124</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised.  Windows remote management connections must be encrypted to prevent this.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6947,14 +6871,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27907r475975_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Client -&gt; "Allow unencrypted traffic" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27907r475975_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4532" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4532" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226218">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226218r794450_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226218r877395_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000125</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not use Digest authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Digest authentication is not as strong as other options and may be subject to man-in-the-middle attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6972,14 +6896,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27908r475978_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Client -&gt; "Disallow Digest authentication" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27908r475978_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4533" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4533" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226219">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226219r794451_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226219r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000126</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain text passwords that could be used to compromise a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6997,14 +6921,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27909r475981_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Service -&gt; "Allow Basic authentication" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27909r475981_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4534" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4534" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226220">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226220r794486_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226220r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000127</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised.  Windows remote management connections must be encrypted to prevent this.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7023,14 +6947,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27910r475984_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Service -&gt; "Allow unencrypted traffic" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27910r475984_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4535" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4535" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226221">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226221r794484_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226221r852118_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000128</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not store RunAs credentials.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storage of administrative credentials could allow unauthorized access.  Disallowing the storage of RunAs credentials for Windows Remote Management will prevent them from being used with plug-ins.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7048,14 +6972,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27911r475987_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Service -&gt; "Disallow WinRM from storing RunAs credentials" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27911r475987_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4536" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4536" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226222">
         <xccdf:title>SRG-OS-000250-GPOS-00093</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226222r794457_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226222r877394_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000130</xccdf:version>
           <xccdf:title>The Remote Desktop Session Host must require secure RPC communications.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing unsecure RPC communication exposes the system to man-in-the-middle attacks and data disclosure attacks.  A man-in-the-middle attack occurs when an intruder captures packets between a client and server and modifies them before allowing the packets to be exchanged.  Usually the attacker will modify the information in the packets in an attempt to cause either the client or server to reveal sensitive information.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7073,14 +6997,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27912r475990_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Security -&gt; "Require secure RPC communication" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27912r475990_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4537" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4537" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226224">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226224r794459_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226224r852119_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000132</xccdf:version>
           <xccdf:title>Users must be prevented from mapping local COM ports and redirecting data from the Remote Desktop Session Host to local COM ports.  (Remote Desktop Services Role).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Preventing the redirection of Remote Desktop session data to a client computer's COM ports helps reduce possible exposure of sensitive data.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7098,14 +7022,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27914r475996_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Device and Resource Redirection -&gt; "Do not allow COM port redirection" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27914r475996_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4628" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4628" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226225">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226225r794460_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226225r852120_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000133</xccdf:version>
           <xccdf:title>Users must be prevented from mapping local LPT ports and redirecting data from the Remote Desktop Session Host to local LPT ports.  (Remote Desktop Services Role).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Preventing the redirection of Remote Desktop session data to a client computer's LPT ports helps reduce possible exposure of sensitive data.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7123,14 +7047,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27915r475999_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Device and Resource Redirection -&gt; "Do not allow LPT port redirection" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27915r475999_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4629" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4629" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226226">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226226r794461_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226226r852121_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000134</xccdf:version>
           <xccdf:title>The system must be configured to ensure smart card devices can be redirected to the Remote Desktop session.  (Remote Desktop Services Role).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Enabling the redirection of smart card devices allows their use within Remote Desktop sessions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7148,14 +7072,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27916r476002_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Device and Resource Redirection -&gt; "Do not allow smart card device redirection" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27916r476002_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4631" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4631" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226227">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226227r794462_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226227r852122_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000135</xccdf:version>
           <xccdf:title>Users must be prevented from redirecting Plug and Play devices to the Remote Desktop Session Host.  (Remote Desktop Services Role).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Preventing the redirection of Plug and Play devices in Remote Desktop sessions helps reduce possible exposure of sensitive data.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7173,7 +7097,7 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27917r476005_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Device and Resource Redirection -&gt; "Do not allow supported Plug and Play device redirection" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27917r476005_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4630" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4630" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7202,7 +7126,7 @@ Satisfies: SRG-OS-000042-GPOS-00021&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:fixtext fixref="F-27920r476535_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Audit Process Creation &gt;&gt; "Include command line in process creation events" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27920r476535_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5178" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5178" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7226,14 +7150,14 @@ Satisfies: SRG-OS-000042-GPOS-00021&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:fixtext fixref="F-27927r476556_fix">Update the system to a supported release or service pack level.</xccdf:fixtext>
           <xccdf:fix id="F-27927r476556_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4538" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4538" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226261">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226261r819682_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226261r890480_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-PK-000001</xccdf:version>
           <xccdf:title>The DoD Root CA certificates must be installed in the Trusted Root Store.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7247,23 +7171,23 @@ Satisfies: SRG-OS-000042-GPOS-00021&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:ident system="http://cyber.mil/legacy">SV-52961</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-32272</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-27951r819681_fix">Install the DoD Root CA certificates:
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
+          <xccdf:fixtext fixref="F-27951r890479_fix">Install the DoD Root CA certificates:
 DoD Root CA 3
 DoD Root CA 4
 DoD Root CA 5
 
-The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-27951r819681_fix" />
+The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-27951r890479_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4837" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4837" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226262">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226262r819685_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226262r890483_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-PK-000003</xccdf:version>
           <xccdf:title>The DoD Interoperability Root CA cross-certificates must be installed into the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7277,24 +7201,23 @@ The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke
           <xccdf:ident system="http://cyber.mil/legacy">V-32274</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-52957</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-27952r819684_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
+          <xccdf:fixtext fixref="F-27952r890482_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
 
 Issued To - Issued By - Thumbprint
 DoD Root CA 3 - DoD Interoperability Root CA 2 - 49CBE933151872E17C8EAE7F0ABA97FB610F6477
-DoD Root CA 3 - DoD Interoperability Root CA 2 - AC06108CA348CC03B53795C64BF84403C1DBD341
 
-The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-27952r819684_fix" />
+The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-27952r890482_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4838" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4838" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226263">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226263r794522_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226263r894351_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-PK-000004</xccdf:version>
           <xccdf:title>The US DoD CCEB Interoperability Root CA cross-certificates must be installed into the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7309,22 +7232,22 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:ident system="http://cyber.mil/legacy">SV-52196</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
-          <xccdf:fixtext fixref="F-27953r794521_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
+          <xccdf:fixtext fixref="F-27953r894347_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
 
 Issued To - Issued By - Thumbprint
-DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2 - AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9
+DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2 - 9B74964506C7ED9138070D08D5F8B969866560C8
 
-The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-27953r794521_fix" />
+The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-27953r894347_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4839" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4839" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226268">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226268r794557_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226268r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-RG-000001</xccdf:version>
           <xccdf:title>Standard user accounts must only have Read permissions to the Winlogon registry key.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Permissions on the Winlogon registry key must only allow privileged accounts to change registry values.  If standard users have these permissions, there is a potential for programs to run with elevated privileges when a privileged user logs on to the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7355,14 +7278,14 @@ Users - Read
 ALL APPLICATION PACKAGES - Read</xccdf:fixtext>
           <xccdf:fix id="F-27958r476649_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5176" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5176" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226269">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226269r794558_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226269r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-RG-000002</xccdf:version>
           <xccdf:title>Standard user accounts must only have Read permissions to the Active Setup\Installed Components registry key.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Permissions on the Active Setup\Installed Components registry key must only allow privileged accounts to add or change registry values.  If standard user accounts have these permissions, there is a potential for programs to run with elevated privileges when a privileged user logs on to the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7379,7 +7302,7 @@ ALL APPLICATION PACKAGES - Read</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27959r476652_fix">Maintain the default permissions of the following registry keys:
 HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Active Setup\Installed Components\
 HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Active Setup\Installed Components\ (64-bit systems only)
- 
+
 Users - Read
 Administrators - Full Control
 SYSTEM - Full Control
@@ -7387,14 +7310,14 @@ CREATOR OWNER - Full Control (Subkeys only)
 ALL APPLICATION PACKAGES - Read</xccdf:fixtext>
           <xccdf:fix id="F-27959r476652_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5175" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5175" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226270">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226270r794559_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226270r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-RG-000004</xccdf:version>
           <xccdf:title>Anonymous access to the registry must be restricted.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The registry is integral to the function, security, and stability of the Windows system.  Some processes may require anonymous access to the registry.  This must be limited to properly protect the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7422,7 +7345,7 @@ Backup Operators - Read - This key only
 LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fix id="F-27960r476655_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5196" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5196" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7448,7 +7371,7 @@ LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fix id="F-27961r476658_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_guest_account_status_var" export-name="oval:mil.disa.fso.windows:var:453901" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4539" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4539" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7474,7 +7397,7 @@ LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fix id="F-27962r476661_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_limit_blank_password_use_var" export-name="oval:mil.disa.fso.windows:var:454000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4540" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4540" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7499,7 +7422,7 @@ LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27963r476664_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Accounts: Rename administrator account" to a name other than "Administrator".</xccdf:fixtext>
           <xccdf:fix id="F-27963r476664_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4541" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4541" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7524,7 +7447,7 @@ LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27964r476667_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Accounts: Rename guest account" to a name other than "Guest".</xccdf:fixtext>
           <xccdf:fix id="F-27964r476667_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4542" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4542" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7551,7 +7474,7 @@ This setting prevents the system from setting up a default system access control
           <xccdf:fix id="F-27965r476670_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_audit_access_global_system_objects_var" export-name="oval:mil.disa.fso.windows:var:454300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4543" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4543" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7561,7 +7484,7 @@ This setting prevents the system from setting up a default system access control
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226276r794552_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000008</xccdf:version>
           <xccdf:title>Auditing of Backup and Restore Privileges must be turned off.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
 This setting prevents the system from generating audit events for every file backed up or restored, which could fill the security log in Windows, making it difficult to identify actual issues.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -7578,7 +7501,7 @@ This setting prevents the system from generating audit events for every file bac
           <xccdf:fix id="F-27966r476673_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_audit_use_backup_restore_privilege_var" export-name="oval:mil.disa.fso.windows:var:454400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4544" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4544" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7588,7 +7511,7 @@ This setting prevents the system from generating audit events for every file bac
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226277r794513_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000009</xccdf:version>
           <xccdf:title>Audit policy using subcategories must be enabled.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
 This setting allows administrators to enable more precise auditing capabilities.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 DC</dc:title>
@@ -7605,7 +7528,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27967r476676_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_override_audit_policy_settings_var" export-name="oval:mil.disa.fso.windows:var:454500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4545" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4545" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7631,14 +7554,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27968r476679_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_format_eject_removable_media_var" export-name="oval:mil.disa.fso.windows:var:454600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4546" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4546" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226279">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226279r794566_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226279r852134_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000012</xccdf:version>
           <xccdf:title>Outgoing secure channel traffic must be encrypted or signed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted.  If this policy is enabled, outgoing secure channel traffic will be encrypted and signed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7658,14 +7581,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27969r476682_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_encrypt_or_sign_secure_channel_data_always_var" export-name="oval:mil.disa.fso.windows:var:454700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4547" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4547" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226280">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226280r794567_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226280r852135_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000013</xccdf:version>
           <xccdf:title>Outgoing secure channel traffic must be encrypted when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted.  If this policy is enabled, outgoing secure channel traffic will be encrypted.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7685,14 +7608,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27970r476685_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_encrypt_secure_channel_data_when_possible_var" export-name="oval:mil.disa.fso.windows:var:454800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4548" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4548" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226281">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226281r794568_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226281r852136_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000014</xccdf:version>
           <xccdf:title>Outgoing secure channel traffic must be signed when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but the channel is not integrity checked.  If this policy is enabled, outgoing secure channel traffic will be signed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7712,7 +7635,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27971r476688_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_secure_channel_data_when_possible_var" export-name="oval:mil.disa.fso.windows:var:454900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4549" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4549" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7738,7 +7661,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27972r476691_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_disable_machine_account_password_changes_var" export-name="oval:mil.disa.fso.windows:var:455000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4550" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4550" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7764,14 +7687,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27973r476694_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_machine_account_password_age_var" export-name="oval:mil.disa.fso.windows:var:455100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4551" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4551" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226284">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226284r794569_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226284r852137_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000017</xccdf:version>
           <xccdf:title>The system must be configured to require a strong session key.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A computer connecting to a domain controller will establish a secure channel.  Requiring strong session keys enforces 128-bit encryption between systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7791,7 +7714,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27974r476697_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_strong_session_key_var" export-name="oval:mil.disa.fso.windows:var:455200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4552" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4552" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7817,7 +7740,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27975r476700_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_display_last_user_name_var" export-name="oval:mil.disa.fso.windows:var:455300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4553" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4553" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7843,7 +7766,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27976r476703_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_require_ctrlaltdel_var" export-name="oval:mil.disa.fso.windows:var:455400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4554" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4554" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7868,7 +7791,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fixtext fixref="F-27977r476706_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Interactive logon: Machine inactivity limit" to "900" seconds" or less, excluding "0" which is effectively disabled.</xccdf:fixtext>
           <xccdf:fix id="F-27977r476706_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4988" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4988" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7895,7 +7818,7 @@ This setting allows administrators to enable more precise auditing capabilities.
 Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive Logon: Number of previous logons to cache (in case Domain Controller is not available)" to "4" logons or less.</xccdf:fixtext>
           <xccdf:fix id="F-27980r476715_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4616" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4616" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7921,7 +7844,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27981r476718_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prompt_user_to_change_password_before_expiration_var" export-name="oval:mil.disa.fso.windows:var:455500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4555" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4555" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7946,14 +7869,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-27982r476721_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Interactive logon: Smart card removal behavior" to  "Lock Workstation" or "Force Logoff".</xccdf:fixtext>
           <xccdf:fix id="F-27982r476721_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4556" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4556" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226293">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226293r794570_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226293r852138_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000028</xccdf:version>
           <xccdf:title>The Windows SMB client must be configured to always perform SMB packet signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.  Digitally signed SMB packets aid in preventing man-in-the-middle attacks.  If this policy is enabled, the SMB client will only communicate with an SMB server that performs SMB packet signing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7973,14 +7896,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27983r476724_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_client_always_var" export-name="oval:mil.disa.fso.windows:var:455700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4557" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4557" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226294">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226294r794571_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226294r852139_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000029</xccdf:version>
           <xccdf:title>The Windows SMB client must be enabled to perform SMB packet signing when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.   If this policy is enabled, the SMB client will request packet signing when communicating with an SMB server that is enabled or required to perform SMB packet signing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8000,14 +7923,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27984r476727_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_client_server_agrees_var" export-name="oval:mil.disa.fso.windows:var:455800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4558" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4558" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226295">
         <xccdf:title>SRG-OS-000074-GPOS-00042</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226295r794528_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226295r877396_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000030</xccdf:version>
           <xccdf:title>Unencrypted passwords must not be sent to third-party SMB Servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Some non-Microsoft SMB servers only support unencrypted (plain text) password authentication.  Sending plain text passwords across the network, when authenticating to an SMB server, reduces the overall security of the environment.  Check with the vendor of the SMB server to see if there is a way to support encrypted password authentication.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8026,14 +7949,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27985r476730_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_send_unencrypted_password_to_third_party_smb_servers_var" export-name="oval:mil.disa.fso.windows:var:455900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4559" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4559" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226296">
         <xccdf:title>SRG-OS-000163-GPOS-00072</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226296r794608_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226296r852140_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000031</xccdf:version>
           <xccdf:title>The amount of idle time required before suspending a session must be properly set.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Open sessions can increase the avenues of attack on a system.  This setting is used to control when a computer disconnects an inactive SMB session.  If client activity resumes, the session is automatically reestablished.  This protects critical and sensitive network data from exposure to unauthorized personnel with physical access to the computer.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8053,14 +7976,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27986r476733_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_amount_of_idle_time_required_before_suspending_session_var" export-name="oval:mil.disa.fso.windows:var:456000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4560" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4560" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226297">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226297r794572_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226297r852141_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000032</xccdf:version>
           <xccdf:title>The Windows SMB server must be configured to always perform SMB packet signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.  Digitally signed SMB packets aid in preventing man-in-the-middle attacks.  If this policy is enabled, the SMB server will only communicate with an SMB client that performs SMB packet signing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8080,14 +8003,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27987r476736_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_server_always_var" export-name="oval:mil.disa.fso.windows:var:456100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4561" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4561" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226298">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226298r794573_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226298r852142_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000033</xccdf:version>
           <xccdf:title>The Windows SMB server must perform SMB packet signing when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.   Digitally signed SMB packets aid in preventing man-in-the-middle attacks.  If this policy is enabled, the SMB server will negotiate SMB packet signing as requested by the client.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8107,7 +8030,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27988r476739_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_server_client_agrees_var" export-name="oval:mil.disa.fso.windows:var:456200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4562" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4562" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8133,7 +8056,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27989r476742_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_disconnect_client_when_logon_hours_expire_var" export-name="oval:mil.disa.fso.windows:var:456300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4563" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4563" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8159,7 +8082,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27990r476745_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_microsoft_network_server_server_spn_target_name_validation_level_var" export-name="oval:mil.disa.fso.windows:var:456400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4564" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4564" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8195,7 +8118,7 @@ Value Name: DefaultPassword
 Severity Override Guidance: If the DefaultName or DefaultDomainName in the same registry path contain an administrator account name and the DefaultPassword contains a value, this is a CAT I finding.</xccdf:fixtext>
           <xccdf:fix id="F-27991r794592_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4565" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4565" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8223,7 +8146,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27992r476751_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_MSS_IPv6_source_routing_protection_level_var" export-name="oval:mil.disa.fso.windows:var:456600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4566" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4566" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8251,7 +8174,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27993r476754_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ip_source_routing_protection_level_var" export-name="oval:mil.disa.fso.windows:var:456700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4567" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4567" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8279,14 +8202,14 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27994r476757_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_icmp_redirects_var" export-name="oval:mil.disa.fso.windows:var:456800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4568" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4568" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226305">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226305r794561_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226305r852143_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000041</xccdf:version>
           <xccdf:title>The system must be configured to limit how often keep-alive packets are sent.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting controls how often TCP sends a keep-alive packet in attempting to verify that an idle connection is still intact.  A higher value could allow an attacker to cause a denial of service with numerous connections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8307,7 +8230,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27995r476760_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_keep_alive_time_var" export-name="oval:mil.disa.fso.windows:var:456900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4569" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4569" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8335,14 +8258,14 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27996r476763_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_no_default_exempt_var" export-name="oval:mil.disa.fso.windows:var:457000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4570" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4570" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226307">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226307r794562_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226307r852144_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000043</xccdf:version>
           <xccdf:title>The system must be configured to ignore NetBIOS name release requests except from WINS servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring the system to ignore name release requests, except from WINS servers, prevents a denial of service (DoS) attack.  The DoS consists of sending a NetBIOS name release request to the server for each entry in the server's cache, causing a response delay in the normal operation of the servers WINS resolution capability.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8357,20 +8280,20 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:ident system="http://cyber.mil/legacy">SV-52928</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-4116</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002385</xccdf:ident>
-          <xccdf:fixtext fixref="F-27997r476766_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers" to "Enabled".   
+          <xccdf:fixtext fixref="F-27997r476766_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers" to "Enabled".
 
 (See "Updating the Windows Security Options File" in the STIG Overview document if MSS settings are not visible in the system's policy tools.)</xccdf:fixtext>
           <xccdf:fix id="F-27997r476766_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_no_name_release_on_demand_var" export-name="oval:mil.disa.fso.windows:var:457100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4571" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4571" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226308">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226308r794563_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226308r852145_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000044</xccdf:version>
           <xccdf:title>The system must be configured to disable the Internet Router Discovery Protocol (IRDP).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The Internet Router Discovery Protocol (IRDP) is used to detect and configure default gateway addresses on the computer.  If a router is impersonated on a network, traffic could be routed through the compromised system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8391,7 +8314,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27998r476769_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_router_discovery_var" export-name="oval:mil.disa.fso.windows:var:457200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4572" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4572" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8419,7 +8342,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27999r476772_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_safe_dll_search_mode_var" export-name="oval:mil.disa.fso.windows:var:457300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4573" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4573" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8447,14 +8370,14 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-28000r476775_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_screen_saver_grace_period_var" export-name="oval:mil.disa.fso.windows:var:457400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4574" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4574" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226311">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226311r794564_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226311r852146_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000047</xccdf:version>
           <xccdf:title>IPv6 TCP data retransmissions must be configured to prevent resources from becoming exhausted.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring Windows to limit the number of times that IPv6 TCP retransmits unacknowledged data segments before aborting the attempt helps prevent resources from becoming exhausted.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8475,14 +8398,14 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-28001r476778_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_MSS_tcp_max_data_retransmissions_ipv6_var" export-name="oval:mil.disa.fso.windows:var:457500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4575" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4575" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226312">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226312r794565_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226312r852147_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000048</xccdf:version>
           <xccdf:title>The system must limit how many times unacknowledged TCP data is retransmitted.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;In a SYN flood attack, the attacker sends a continuous stream of SYN packets to a server, and the server leaves the half-open connections open until it is overwhelmed and is no longer able to respond to legitimate requests.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8497,20 +8420,20 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:ident system="http://cyber.mil/legacy">SV-52929</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-4438</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002385</xccdf:ident>
-          <xccdf:fixtext fixref="F-28002r476781_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "MSS: (TcpMaxDataRetransmissions) How many times unacknowledged data is retransmitted (3 recommended, 5 is default)" to "3" or less.   
+          <xccdf:fixtext fixref="F-28002r476781_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "MSS: (TcpMaxDataRetransmissions) How many times unacknowledged data is retransmitted (3 recommended, 5 is default)" to "3" or less.
 
 (See "Updating the Windows Security Options File" in the STIG Overview document if MSS settings are not visible in the system's policy tools.)</xccdf:fixtext>
           <xccdf:fix id="F-28002r476781_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_tcp_max_data_retransmissions_var" export-name="oval:mil.disa.fso.windows:var:457600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4576" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4576" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226313">
         <xccdf:title>SRG-OS-000046-GPOS-00022</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226313r794512_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226313r852148_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000049</xccdf:version>
           <xccdf:title>The system must generate an audit event when the audit log reaches a percentage of full threshold.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;When the audit log reaches a given percent full, an audit event is written to the security log.  It is recorded as a successful audit event under the category of System.  This option may be especially useful if the audit logs are set to be cleared manually.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8533,7 +8456,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-28003r476784_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_event_log_threshold_warning_var" export-name="oval:mil.disa.fso.windows:var:457700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4577" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4577" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8559,7 +8482,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-28005r476790_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_anonymous_enumeration_sam_var" export-name="oval:mil.disa.fso.windows:var:457800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4578" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4578" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8585,7 +8508,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-28006r476793_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_anonymous_enumeration_sam_accounts_shares_var" export-name="oval:mil.disa.fso.windows:var:457900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4579" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4579" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8611,7 +8534,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-28007r476796_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_let_everyone_permissions_apply_to_anonymous_users_var" export-name="oval:mil.disa.fso.windows:var:458100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4581" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4581" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8635,7 +8558,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fixtext fixref="F-28008r476799_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network access: Named pipes that can be accessed anonymously" to only include "netlogon, samr, lsarpc".</xccdf:fixtext>
           <xccdf:fix id="F-28008r476799_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4701" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4701" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8659,12 +8582,12 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:ident system="http://cyber.mil/cci">CCI-001090</xccdf:ident>
           <xccdf:fixtext fixref="F-28009r476802_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network access: Remotely accessible registry paths" with the following entries:
 
-System\CurrentControlSet\Control\ProductOptions 
-System\CurrentControlSet\Control\Server Applications 
+System\CurrentControlSet\Control\ProductOptions
+System\CurrentControlSet\Control\Server Applications
 Software\Microsoft\Windows NT\CurrentVersion</xccdf:fixtext>
           <xccdf:fix id="F-28009r476802_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4582" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4582" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8701,7 +8624,7 @@ System\CurrentControlSet\Services\Eventlog
 System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-28010r476805_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4583" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4583" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8727,7 +8650,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-28011r476808_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_restrict_anonymous_access_to_named_pipes_and_shares_var" export-name="oval:mil.disa.fso.windows:var:458400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4584" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4584" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8752,7 +8675,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fixtext fixref="F-28012r476811_fix">Ensure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network access: Shares that can be accessed anonymously" contains no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-28012r476811_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4585" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4585" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8778,7 +8701,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-28013r476814_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_sharing_and_security_model_for_local_accounts_var" export-name="oval:mil.disa.fso.windows:var:458600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4586" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4586" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8804,7 +8727,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-28014r476817_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_Network_security_Allow_Local_System_to_use_computer_identity_for_NTLM_var" export-name="oval:mil.disa.fso.windows:var:458700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4587" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4587" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8830,7 +8753,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-28015r476820_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_Network_security_Allow_LocalSystem_NULL_session_fallback_var" export-name="oval:mil.disa.fso.windows:var:458800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4588" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4588" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8856,7 +8779,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-28016r476823_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_Network_Security_Allow_PKU2U_authentication_requests_to_this_computer_to_use_online_identities_var" export-name="oval:mil.disa.fso.windows:var:458900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4589" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4589" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8889,14 +8812,14 @@ Future encryption types
 Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have operational impacts and must be thoroughly tested for the environment before changing. This includes but is not limited to parent\child trusts where RC4 is still enabled; selecting "The other domain supports Kerberos AES Encryption" may be required on the domain trusts to allow client communication across the trust relationship.</xccdf:fixtext>
           <xccdf:fix id="F-28017r476826_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4590" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4590" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226328">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226328r794527_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226328r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000065</xccdf:version>
           <xccdf:title>The system must be configured to prevent the storage of the LAN Manager hash of passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The LAN Manager hash uses a weak encryption algorithm and there are several tools available that use this hash to retrieve account passwords.  This setting controls whether or not a LAN Manager hash of the password is stored in the SAM the next time the password is changed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8915,7 +8838,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-28018r476829_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_store_lan_manager_hash_value_on_next_password_change_var" export-name="oval:mil.disa.fso.windows:var:459100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4591" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4591" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8941,7 +8864,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-28019r476832_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_force_logoff_when_logon_hours_expire_var" export-name="oval:mil.disa.fso.windows:var:459200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4592" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4592" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8967,7 +8890,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-28020r476835_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_lan_manager_authentication_level_var" export-name="oval:mil.disa.fso.windows:var:459300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4593" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4593" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8993,7 +8916,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-28021r476838_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ldap_client_signing_requirements_var" export-name="oval:mil.disa.fso.windows:var:459400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4594" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4594" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9018,7 +8941,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fixtext fixref="F-28022r476841_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) clients" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-28022r476841_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4595" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4595" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9043,7 +8966,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fixtext fixref="F-28023r476844_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) servers" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-28023r476844_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4596" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4596" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9069,14 +8992,14 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-28024r476847_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_shutdown_allow_system_shutdown_without_having_logon_var" export-name="oval:mil.disa.fso.windows:var:459900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4599" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4599" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226335">
         <xccdf:title>SRG-OS-000396-GPOS-00176</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226335r794676_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226335r877380_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000074</xccdf:version>
           <xccdf:title>The system must be configured to use FIPS-compliant algorithms for encryption, hashing, and signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting ensures that the system uses algorithms that are FIPS-compliant for encryption, hashing, and signing.  FIPS-compliant algorithms meet specific standards established by the U.S. Government and must be the algorithms used for all OS encryption functions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -9095,7 +9018,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-28025r476850_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_system_cryptography_use_fips_compliant_alorithm_var" export-name="oval:mil.disa.fso.windows:var:460000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4600" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4600" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9121,7 +9044,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-28026r476853_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_system_objects_require_case_insensitivity_var" export-name="oval:mil.disa.fso.windows:var:460100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4601" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4601" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9147,14 +9070,14 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-28027r476856_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_system_objects_strengthen_default_permissions_internal_system_objects_var" export-name="oval:mil.disa.fso.windows:var:460200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4602" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4602" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226338">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226338r794673_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226338r852150_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000077</xccdf:version>
           <xccdf:title>User Account Control approval mode for the built-in Administrator must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized.  This setting configures the built-in Administrator account so that it runs in Admin Approval Mode.
@@ -9177,7 +9100,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-28028r476859_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_admin_approval_mode_var" export-name="oval:mil.disa.fso.windows:var:460300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4603" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4603" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9206,14 +9129,14 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
 More secure options for this setting would also be acceptable (e.g., Prompt for credentials, Prompt for consent (or credentials) on the secure desktop).</xccdf:fixtext>
           <xccdf:fix id="F-28029r476862_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4604" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4604" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226340">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226340r794674_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226340r852151_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000079</xccdf:version>
           <xccdf:title>User Account Control must automatically deny standard user requests for elevation.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized.  This setting controls the behavior of elevation when requested by a standard user account.
@@ -9236,7 +9159,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-28030r476865_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_behavior_elevation_prompt_standard_users_var" export-name="oval:mil.disa.fso.windows:var:460500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4605" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4605" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9264,7 +9187,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-28031r476868_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_detect_application_installations_prompt_elevation_var" export-name="oval:mil.disa.fso.windows:var:460600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4606" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4606" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9292,7 +9215,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-28032r476871_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_only_elevate_executables_signed_validated_var" export-name="oval:mil.disa.fso.windows:var:460700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4607" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4607" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9320,14 +9243,14 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-28033r476874_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_only_elevate_uiaccess_applications_var" export-name="oval:mil.disa.fso.windows:var:460800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4608" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4608" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226344">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226344r794675_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226344r852152_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000083</xccdf:version>
           <xccdf:title>User Account Control must run all administrators in Admin Approval Mode, enabling UAC.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized.  This setting enables UAC.
@@ -9350,7 +9273,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-28034r476877_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_run_administrators_admin_approval_mode_var" export-name="oval:mil.disa.fso.windows:var:460900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4609" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4609" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9378,7 +9301,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-28035r476880_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_switch_secure_desktop_prompting_elevation_var" export-name="oval:mil.disa.fso.windows:var:461000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4610" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4610" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9406,7 +9329,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-28036r476883_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_virtualize_write_failures_per_user_locations_var" export-name="oval:mil.disa.fso.windows:var:461100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4611" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4611" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9433,7 +9356,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
 Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "User Account Control: Allow UIAccess applications to prompt for elevation without using the secure desktop" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-28037r476886_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4627" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4627" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9458,14 +9381,14 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fixtext fixref="F-28038r476889_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "System settings: Optional subsystems" to "Blank" (Configured with no entries).</xccdf:fixtext>
           <xccdf:fix id="F-28038r476889_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4621" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4621" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226349">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226349r794671_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226349r852153_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000089</xccdf:version>
           <xccdf:title>The print driver installation privilege must be restricted to administrators.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing users to install drivers can introduce malware or cause the instability of a system.  Print driver installation should be restricted to administrators.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -9483,14 +9406,14 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fixtext fixref="F-28039r476892_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Devices: Prevent users from installing printer drivers" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-28039r476892_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4618" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4618" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226350">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226350r794677_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226350r852154_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000090-DC</xccdf:version>
           <xccdf:title>Domain controllers must require LDAP access signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unsigned network traffic is susceptible to man in the middle attacks where an intruder captures packets between the server and the client and modifies them before forwarding them to the client.  In the case of an LDAP server, this means that an attacker could cause a client to make decisions based on false records from the LDAP directory.  You can lower the risk of an attacker pulling this off in a corporate network by implementing strong physical security measures to protect the network infrastructure.  Furthermore, implementing Internet Protocol security (IPSec) authentication header mode (AH), which performs mutual authentication and packet integrity for Internet Protocol (IP) traffic, can make all types of man in the middle attacks extremely difficult.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -9509,7 +9432,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fixtext fixref="F-28040r476895_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Domain controller: LDAP server signing requirements" to "Require signing".</xccdf:fixtext>
           <xccdf:fix id="F-28040r476895_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4702" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4702" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9534,7 +9457,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fixtext fixref="F-28041r476898_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Domain controller: Refuse machine account password changes" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-28041r476898_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4703" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4703" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9564,7 +9487,7 @@ Both the holders of a digital certificate and the issuing authority must protect
           <xccdf:fixtext fixref="F-28042r476901_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "System cryptography: Force strong key protection for user keys stored on the computer" to "User must enter a password each time they use a key".</xccdf:fixtext>
           <xccdf:fix id="F-28042r476901_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4973" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4973" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9589,7 +9512,7 @@ Both the holders of a digital certificate and the issuing authority must protect
           <xccdf:fixtext fixref="F-28043r476904_fix">Remove or disable the Fax (fax) service.</xccdf:fixtext>
           <xccdf:fix id="F-28043r476904_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4731" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4731" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9611,7 +9534,7 @@ Both the holders of a digital certificate and the issuing authority must protect
           <xccdf:ident system="http://cyber.mil/legacy">SV-52237</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-26602</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000382</xccdf:ident>
-          <xccdf:fixtext fixref="F-28044r476907_fix">Remove or disable the "Microsoft FTP Service" (Service name: FTPSVC).   
+          <xccdf:fixtext fixref="F-28044r476907_fix">Remove or disable the "Microsoft FTP Service" (Service name: FTPSVC).
 
 To remove the "FTP Server" role from a system:
 Start "Server Manager"
@@ -9623,7 +9546,7 @@ De-select "FTP Server" under "Web Server (IIS).
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-28044r476907_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4732" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4732" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9648,7 +9571,7 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-28045r476910_fix">Remove or disable the Peer Networking Identity Manager (p2pimsvc) service.</xccdf:fixtext>
           <xccdf:fix id="F-28045r476910_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4733" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4733" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9673,7 +9596,7 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-28046r476913_fix">Remove or disable the Simple TCP/IP Services (simptcp) service.</xccdf:fixtext>
           <xccdf:fix id="F-28046r476913_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4734" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4734" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9698,7 +9621,7 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-28047r476916_fix">Remove or disable the Telnet (tlntsvr) service.</xccdf:fixtext>
           <xccdf:fix id="F-28047r476916_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4735" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4735" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9723,14 +9646,14 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-28048r476919_fix">Configure the Startup Type for the Smart Card Removal Policy service to "Automatic".</xccdf:fixtext>
           <xccdf:fix id="F-28048r476919_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4736" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4736" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226370">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226370r794649_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226370r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000001</xccdf:version>
           <xccdf:title>The Access Credential Manager as a trusted caller user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9750,7 +9673,7 @@ Accounts with the "Access Credential Manager as a trusted caller" user right may
           <xccdf:fixtext fixref="F-28060r476955_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Access Credential Manager as a trusted caller" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-28060r476955_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4987" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4987" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9785,14 +9708,14 @@ Severity Override Guidance: If an application requires this user right, this can
 - The application account must meet requirements for application account passwords, such as length (V-36661) and required changes frequency (V-36662).</xccdf:fixtext>
           <xccdf:fix id="F-28061r794623_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4704" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4704" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226372">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226372r794650_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226372r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000003</xccdf:version>
           <xccdf:title>The Act as part of the operating system user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9812,7 +9735,7 @@ Accounts with the "Act as part of the operating system" user right can assume th
           <xccdf:fixtext fixref="F-28062r476961_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Act as part of the operating system" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-28062r476961_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4617" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4617" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9841,14 +9764,14 @@ Accounts with the "Allow log on locally" user right can log on interactively to 
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28063r476964_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4636" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4636" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226374">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226374r794651_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226374r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000007</xccdf:version>
           <xccdf:title>The Back up files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9870,14 +9793,14 @@ Accounts with the "Back up files and directories" user right can circumvent file
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28065r476969_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4638" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4638" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226375">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226375r794652_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226375r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000011</xccdf:version>
           <xccdf:title>The Create a pagefile user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9899,14 +9822,14 @@ Accounts with the "Create a pagefile" user right can change the size of a pagefi
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28066r476972_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4642" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4642" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226376">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226376r794653_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226376r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000012</xccdf:version>
           <xccdf:title>The Create a token object user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9926,14 +9849,14 @@ The "Create a token object" user right allows a process to create an access toke
           <xccdf:fixtext fixref="F-28067r476975_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create a token object" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-28067r476975_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4643" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4643" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226377">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226377r794654_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226377r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000013</xccdf:version>
           <xccdf:title>The Create global objects user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9958,14 +9881,14 @@ Local Service
 Network Service</xccdf:fixtext>
           <xccdf:fix id="F-28068r476978_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4644" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4644" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226378">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226378r794655_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226378r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000014</xccdf:version>
           <xccdf:title>The Create permanent shared objects user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9985,14 +9908,14 @@ Accounts with the "Create permanent shared objects" user right could expose sens
           <xccdf:fixtext fixref="F-28069r476981_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create permanent shared objects" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-28069r476981_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4645" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4645" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226379">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226379r794656_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226379r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000015</xccdf:version>
           <xccdf:title>The Create symbolic links user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10016,14 +9939,14 @@ Administrators
 Systems that have the Hyper-V role will also have "Virtual Machines" given this user right.  If this needs to be added manually, enter it as "NT Virtual Machine\Virtual Machines".</xccdf:fixtext>
           <xccdf:fix id="F-28070r476984_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4646" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4646" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226380">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226380r794657_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226380r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000016</xccdf:version>
           <xccdf:title>The Debug programs user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10045,7 +9968,7 @@ Accounts with the "Debug programs" user right can attach a debugger to any proce
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28071r476987_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4633" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4633" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -10057,7 +9980,7 @@ Administrators</xccdf:fixtext>
           <xccdf:title>The Deny access to this computer from the network user right on domain controllers must be configured to prevent unauthenticated access.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
-The "Deny access to this computer from the network" user right defines the accounts that are prevented from logging on from the network.  
+The "Deny access to this computer from the network" user right defines the accounts that are prevented from logging on from the network.
 
 The Guests group must be assigned this right to prevent unauthenticated access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -10076,7 +9999,7 @@ The Guests group must be assigned this right to prevent unauthenticated access.&
 Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-28072r476990_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4695" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4695" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -10088,7 +10011,7 @@ Guests Group</xccdf:fixtext>
           <xccdf:title>The Deny log on as a batch job user right on domain controllers must be configured to prevent unauthenticated access.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
-The "Deny log on as a batch job" user right defines accounts that are prevented from logging on to the system as a batch job, such as Task Scheduler.  
+The "Deny log on as a batch job" user right defines accounts that are prevented from logging on to the system as a batch job, such as Task Scheduler.
 
 The Guests group must be assigned to prevent unauthenticated access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -10106,7 +10029,7 @@ The Guests group must be assigned to prevent unauthenticated access.&lt;/VulnDis
 Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-28073r476993_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4713" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4713" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -10118,7 +10041,7 @@ Guests Group</xccdf:fixtext>
           <xccdf:title>The Deny log on as a service user right must be configured to include no accounts or groups (blank) on domain controllers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
-The "Deny log on as a service" user right defines accounts that are denied log on as a service.  
+The "Deny log on as a service" user right defines accounts that are denied log on as a service.
 
 Incorrect configurations could prevent services from starting and result in a DoS.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -10134,7 +10057,7 @@ Incorrect configurations could prevent services from starting and result in a Do
           <xccdf:fixtext fixref="F-28074r476996_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; User Rights Assignment -&gt; "Deny log on as a service" to include no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-28074r476996_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4705" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4705" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -10146,7 +10069,7 @@ Incorrect configurations could prevent services from starting and result in a Do
           <xccdf:title>The Deny log on locally user right on domain controllers must be configured to prevent unauthenticated access.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
-The "Deny log on locally" user right defines accounts that are prevented from logging on interactively.  
+The "Deny log on locally" user right defines accounts that are prevented from logging on interactively.
 
 The Guests group must be assigned this right to prevent unauthenticated access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -10164,7 +10087,7 @@ The Guests group must be assigned this right to prevent unauthenticated access.&
 Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-28075r476999_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4706" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4706" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -10195,14 +10118,14 @@ The Guests group must be assigned this right to prevent unauthenticated access.&
 Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-28076r477002_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4714" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4714" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226386">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226386r794658_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226386r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000022-DC</xccdf:version>
           <xccdf:title>Unauthorized accounts must not have the Enable computer and user accounts to be trusted for delegation user right on domain controllers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10224,14 +10147,14 @@ The "Enable computer and user accounts to be trusted for delegation" user right 
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28077r477005_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4707" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4707" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226387">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226387r794659_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226387r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000023</xccdf:version>
           <xccdf:title>The Force shutdown from a remote system user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10253,14 +10176,14 @@ Accounts with the "Force shutdown from a remote system" user right can remotely 
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28078r477008_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4647" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4647" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226388">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226388r794660_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226388r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000024</xccdf:version>
           <xccdf:title>The Generate security audits user right must only be assigned to Local Service and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10283,14 +10206,14 @@ Local Service
 Network Service</xccdf:fixtext>
           <xccdf:fix id="F-28079r477011_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4648" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4648" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226389">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226389r794661_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226389r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000025</xccdf:version>
           <xccdf:title>The Impersonate a client after authentication user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10315,14 +10238,14 @@ Local Service
 Network Service</xccdf:fixtext>
           <xccdf:fix id="F-28080r477014_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4649" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4649" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226390">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226390r794662_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226390r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000027</xccdf:version>
           <xccdf:title>The Increase scheduling priority user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10344,14 +10267,14 @@ Accounts with the "Increase scheduling priority" user right can change a schedul
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28081r477017_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4651" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4651" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226391">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226391r794663_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226391r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000028</xccdf:version>
           <xccdf:title>The Load and unload device drivers user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10373,14 +10296,14 @@ The "Load and unload device drivers" user right allows device drivers to dynamic
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28082r477020_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4652" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4652" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226392">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226392r794664_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226392r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000029</xccdf:version>
           <xccdf:title>The Lock pages in memory user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10400,14 +10323,14 @@ The "Lock pages in memory" user right allows physical memory to be assigned to p
           <xccdf:fixtext fixref="F-28083r477023_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Lock pages in memory" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-28083r477023_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4653" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4653" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226393">
         <xccdf:title>SRG-OS-000057-GPOS-00027</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226393r794621_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226393r852172_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000032</xccdf:version>
           <xccdf:title>The Manage auditing and security log user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10433,14 +10356,14 @@ Accounts with the "Manage auditing and security log" user right can manage the s
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28084r477026_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4990" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4990" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226394">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226394r794665_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226394r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000034</xccdf:version>
           <xccdf:title>The Modify firmware environment values user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10462,14 +10385,14 @@ Accounts with the "Modify firmware environment values" user right can change har
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28085r477029_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4656" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4656" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226395">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226395r794666_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226395r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000035</xccdf:version>
           <xccdf:title>The Perform volume maintenance tasks user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10491,14 +10414,14 @@ Accounts with the "Perform volume maintenance tasks" user right can manage volum
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28086r477032_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4657" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4657" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226396">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226396r794667_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226396r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000036</xccdf:version>
           <xccdf:title>The Profile single process user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10520,14 +10443,14 @@ Accounts with the "Profile single process" user right can monitor nonsystem proc
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28087r477035_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4658" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4658" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226397">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226397r794668_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226397r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000040</xccdf:version>
           <xccdf:title>The Restore files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10549,14 +10472,14 @@ Accounts with the "Restore files and directories" user right can circumvent file
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28088r477038_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4661" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4661" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226398">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226398r794669_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226398r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000042</xccdf:version>
           <xccdf:title>The Take ownership of files or other objects user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10578,14 +10501,14 @@ Accounts with the "Take ownership of files or other objects" user right can take
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28089r477041_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4663" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4663" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-226399">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226399r794670_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-226399r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000044-DC</xccdf:version>
           <xccdf:title>Unauthorized accounts must not have the Add workstations to domain user right.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10607,7 +10530,7 @@ Accounts with the "Add workstations to domain" right may add computers to a doma
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28090r477044_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4708" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4708" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -10636,18 +10559,18 @@ Accounts with the "Allow log on through Remote Desktop Services" user right can 
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-28092r477050_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4637" href="U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4637" href="U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
     </xccdf:Benchmark>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2022-05-01T21:44:56">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2023-03-28T17:41:17">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-05-01T21:44:55</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:16</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.windows:def:4422" version="3" class="compliance">
@@ -13885,20 +13808,6 @@ Administrators</xccdf:fixtext>
             <criterion test_ref="oval:mil.disa.fso.windows:tst:471101" comment="Audit - Directory Service Changes - Success and Failure" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4712" version="1" class="compliance">
-          <metadata>
-            <title>Audit - Directory Service Changes - Failure</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-            </affected>
-            <reference source="DISA" ref_id="33666" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <description>The system must be configured to audit DS Access - Directory Service Changes failures.</description>
-          </metadata>
-          <criteria operator="OR" comment="Audit - Directory Service Changes - Failure">
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:471200" comment="Audit - Directory Service Changes - Failure only" />
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:471101" comment="Audit - Directory Service Changes - Success and Failure" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.fso.windows:def:4713" version="1" class="compliance">
           <!--This check for the Deny log on as a batch will return an Unknown with Policy Auditor 5.3 due a case sensitivity issue with user right name as defined in the schema - sedenyremoteInteractivelogonright.-->
           <metadata>
@@ -14075,7 +13984,7 @@ Administrators</xccdf:fixtext>
             <criterion test_ref="oval:mil.disa.fso.windows:tst:474000" comment="Access Credential Manager as a trusted caller - None" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4837" version="5" class="compliance">
+        <definition id="oval:mil.disa.fso.windows:def:4837" version="6" class="compliance">
           <metadata>
             <title>WN12-PK-000001 - The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
             <affected family="windows">
@@ -14084,11 +13993,11 @@ Administrators</xccdf:fixtext>
             <reference source="DISA" ref_id="32272" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
             <description>To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.</description>
           </metadata>
-          <criteria operator="AND">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:4200" comment="Verifies the DoD Root CA certificates are installed in the Trusted Root Store." />
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253427" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4838" version="5" class="compliance">
+        <definition id="oval:mil.disa.fso.windows:def:4838" version="6" class="compliance">
           <metadata>
             <title>WN12-PK-000003 - The DoD Interoperability Root CA cross-certificates must be installed into the Untrusted Certificates Store on unclassified systems</title>
             <affected family="windows">
@@ -14097,12 +14006,11 @@ Administrators</xccdf:fixtext>
             <reference source="DISA" ref_id="32274" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
             <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
           </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:483800" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:483801" comment="DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" />
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253429" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4839" version="5" class="compliance">
+        <definition id="oval:mil.disa.fso.windows:def:4839" version="6" class="compliance">
           <metadata>
             <title>WN12-PK-000004 - The US DoD CCEB Interoperability Root CA cross-certificates must be installed into the Untrusted Certificates Store on unclassified systems</title>
             <affected family="windows">
@@ -14112,7 +14020,7 @@ Administrators</xccdf:fixtext>
             <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
           </metadata>
           <criteria>
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:483900" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" />
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253430" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.fso.windows:def:4973" version="1" class="compliance">
@@ -14457,18 +14365,6 @@ Administrators</xccdf:fixtext>
             <criterion test_ref="oval:mil.disa.fso.windows:tst:518100" comment="Verifies 'Include command line in process creation events' is set to 'Enabled'" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:5182" version="1" class="compliance">
-          <metadata>
-            <title>WN12-AU-000030</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-            </affected>
-            <description>Windows Server 2012/2012 R2 must be configured to audit Logon/Logoff - Account Lockout successes.</description>
-          </metadata>
-          <criteria operator="OR" comment="Audit - Account Lockout - Success">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:119" comment="Is Audit - Logon/Logoff - Account Lockout set to audit successes" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.fso.windows:def:5183" version="1" class="compliance">
           <metadata>
             <title>WN12-AU-000031</title>
@@ -14569,18 +14465,33 @@ Administrators</xccdf:fixtext>
             </criteria>
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:119" version="1" class="compliance">
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253427" version="1">
           <metadata>
-            <title>WN10-AU-000055</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The system must be configured to audit Logon/Logoff - Account Lockout successes.</description>
+            <title>The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
+            <description />
           </metadata>
-          <criteria operator="OR" comment="Audit - Special Logon - Success">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:11900" comment="Audit - Account Lockout - Success only" />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:11901" comment="Audit - Account Lockout - Success and Failure" />
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342700" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342701" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342702" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253429" version="3">
+          <metadata>
+            <title>The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342900" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253430" version="2">
+          <metadata>
+            <title>The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25343000" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:147" version="1" class="compliance">
@@ -14595,22 +14506,6 @@ Administrators</xccdf:fixtext>
           <criteria operator="OR" comment="Audit - Special Logon - Success">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:14700" comment="Audit - Account Lockout - Failure only" />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:11901" comment="Audit - Account Lockout - Success and Failure" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:4200" version="2" class="compliance">
-          <metadata>
-            <title>DoD Root CA Certificates</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The DoD Root CA certificates must be installed in the Trusted Root Store.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420001" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420002" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420003" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:4202" version="1" class="compliance">
@@ -15754,10 +15649,6 @@ Administrators</xccdf:fixtext>
           <object object_ref="oval:mil.disa.fso.windows:obj:466400" />
           <state state_ref="oval:mil.disa.fso.windows:ste:471101" />
         </auditeventpolicysubcategories_test>
-        <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:471200" version="1" comment="Audit - Directory Service Changes - Failure only" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:466400" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:471200" />
-        </auditeventpolicysubcategories_test>
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:471300" version="1" check="all" comment="Deny log on as a batch job - Guests">
           <object object_ref="oval:mil.disa.fso.windows:obj:469500" />
           <state state_ref="oval:mil.disa.fso.windows:ste:471300" />
@@ -15821,15 +15712,6 @@ Administrators</xccdf:fixtext>
           <object object_ref="oval:mil.disa.fso.windows:obj:461700" />
           <state state_ref="oval:mil.disa.fso.windows:ste:474000" />
         </accesstoken_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:483800" version="4" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.fso.windows:obj:483800" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:483801" version="3" comment="DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.fso.windows:obj:483805" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:483900" version="2" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.fso.windows:obj:483900" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:497300" version="1" comment="HKEY_LOCAL_MACHINE\System\Policies\Microsoft\Cryptography\ForceKeyProtection exists and equals 2" check_existence="all_exist" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:497300" />
           <state state_ref="oval:mil.disa.fso.windows:ste:497300" />
@@ -16028,10 +15910,21 @@ Administrators</xccdf:fixtext>
         <regkeyeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:519604" version="1" check="all" check_existence="none_exist" comment="Winreg key has no non-admin rights to check">
           <object object_ref="oval:mil.disa.fso.windows:obj:519603" />
         </regkeyeffectiverights53_test>
-        <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11900" version="1" comment="'Audit Account Lockout' is set to 'Success'" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:11900" />
-        </auditeventpolicysubcategories_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342700" version="2" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342700" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342701" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342705" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342702" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342710" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342900" version="2" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342900" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25343000" version="2" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25343000" />
+        </registry_test>
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11901" version="1" comment="'Audit Account Lockout' is set to 'Success' and 'Failure'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
           <state state_ref="oval:mil.disa.stig.windows:ste:11901" />
@@ -16040,15 +15933,6 @@ Administrators</xccdf:fixtext>
           <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
           <state state_ref="oval:mil.disa.stig.windows:ste:14700" />
         </auditeventpolicysubcategories_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420001" version="1" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420005" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420002" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420010" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420003" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420015" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420200" version="1" comment="'Interactive logon: Machine inactivity limit' is set to '900' seconds or less" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:420200" />
           <state state_ref="oval:mil.disa.stig.windows:ste:420200" />
@@ -17035,87 +16919,6 @@ Administrators</xccdf:fixtext>
           <namespace datatype="string">root\cimv2</namespace>
           <wql datatype="string">SELECT startmode FROM Win32_Service WHERE name='SCPolicySvc'</wql>
         </wmi_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483800" version="3">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483801</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483804</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483801" version="3">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483802</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483803</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483802" version="4">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483803" version="4">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483804" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483805" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483806</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483809</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483806" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483807</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483808</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483807" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483808" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483809" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483900" version="2">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483901</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483904</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483901" version="2">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483902</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483903</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483902" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483903" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483904" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:497300" version="1" comment="HKEY_LOCAL_MACHINE\System\Policies\Microsoft\Cryptography\ForceKeyProtection">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">SOFTWARE\Policies\Microsoft\Cryptography</key>
@@ -17407,85 +17210,139 @@ Administrators</xccdf:fixtext>
             <filter>oval:mil.disa.fso.windows:ste:519602</filter>
           </set>
         </regkeyeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420005" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342700" version="2">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420006</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420009</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342701</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342702</object_reference>
           </set>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420006" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342701" version="1">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420007</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420008</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342703</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342704</object_reference>
           </set>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420007" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420008" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420009" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342702" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420010" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420011</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420014</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420011" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420012</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420013</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420012" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342703" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420013" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342704" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420014" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342705" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342706</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342707</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342706" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342708</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342709</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342707" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420015" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342708" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342709" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342710" version="1">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420016</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420019</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342711</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342712</object_reference>
           </set>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420016" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342711" version="1">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420017</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420018</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342713</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342714</object_reference>
           </set>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420017" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342712" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342713" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420018" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342714" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420019" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342900" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342901</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342904</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342901" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342902</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342903</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342902" version="3">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342903" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342904" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343000" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343001</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343004</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343001" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343002</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343003</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343002" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343003" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343004" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420200" version="1">
@@ -18332,9 +18189,6 @@ Administrators</xccdf:fixtext>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:471101" version="1" comment="Audit - Directory Service Changes - Success and Failure">
           <directory_service_changes datatype="string" operation="equals">AUDIT_SUCCESS_FAILURE</directory_service_changes>
         </auditeventpolicysubcategories_state>
-        <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:471200" version="1" comment="Audit - Directory Service Changes - Failure only">
-          <directory_service_changes datatype="string" operation="equals">AUDIT_FAILURE</directory_service_changes>
-        </auditeventpolicysubcategories_state>
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:471300" version="1" comment="Deny log on as a batch job">
           <sedenybatchLogonright datatype="boolean" operation="equals">1</sedenybatchLogonright>
         </accesstoken_state>
@@ -18607,9 +18461,6 @@ Administrators</xccdf:fixtext>
           <key_wow64_32key datatype="boolean" operation="equals">0</key_wow64_32key>
           <key_wow64_res datatype="boolean" operation="equals">0</key_wow64_res>
         </regkeyeffectiverights53_state>
-        <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11900" version="1" comment="'Account Lockout' is set to 'Success'">
-          <account_lockout datatype="string">AUDIT_SUCCESS</account_lockout>
-        </auditeventpolicysubcategories_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11901" version="1" comment="'Account Lockout' is set to 'Success' and 'Failure'">
           <account_lockout datatype="string">AUDIT_SUCCESS_FAILURE</account_lockout>
         </auditeventpolicysubcategories_state>
@@ -19130,12 +18981,12 @@ Administrators</xccdf:fixtext>
       </variables>
     </oval_definitions>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2022-05-01T21:44:56">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2023-03-28T17:41:17">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-05-01T21:44:55</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:16</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.windows:def:4398" version="2" class="inventory">

--- a/scap/content/guides/disa/stig-ws2012-ms.xml
+++ b/scap/content/guides/disa/stig-ws2012-ms.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
-  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2022-05-01T21:45:45">
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
+  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2023-03-28T17:41:20">
     <dictionaries>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+          <cat:uri name="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
         </cat:catalog>
       </component-ref>
     </dictionaries>
     <checklists>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-xccdf.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-xccdf.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          <cat:uri name="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
         </cat:catalog>
       </component-ref>
     </checklists>
     <checks>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
     </checks>
   </data-stream>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2022-05-01T21:45:45">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2023-03-28T17:41:20">
     <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0">
       <cpe-item name="cpe:/o:microsoft:windows_server_2012:-">
         <title>Microsoft Windows Server 2012</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.windows:def:4398</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.windows:def:4398</check>
       </cpe-item>
       <cpe-item name="cpe:/o:microsoft:windows_server_2012:r2">
         <title>Microsoft Windows Server 2012</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.windows:def:4968</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.fso.windows:def:4968</check>
       </cpe-item>
     </cpe-list>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2022-05-01T21:45:45">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2023-03-28T17:41:20">
     <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_Windows_2012_MS_STIG" xml:lang="en" style="SCAP_1.2">
-      <xccdf:status date="2022-03-01">accepted</xccdf:status>
-      <xccdf:title>Microsoft Windows Server 2012/2012 R2 Member Server Security Technical Implementation Guide</xccdf:title>
-      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
+      <xccdf:status date="2023-02-27">accepted</xccdf:status>
+      <xccdf:title>Microsoft Windows Server 2012/2012 R2 Member Server STIG SCAP Benchmark</xccdf:title>
+      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
       <xccdf:notice id="terms-of-use" xml:lang="en" />
       <xccdf:front-matter xml:lang="en" />
       <xccdf:rear-matter xml:lang="en" />
@@ -44,12 +44,12 @@
         <dc:publisher>DISA</dc:publisher>
         <dc:source>STIG.DOD.MIL</dc:source>
       </xccdf:reference>
-      <xccdf:plain-text id="release-info">Release: 3.3 Benchmark Date: 31 May 2022</xccdf:plain-text>
-      <xccdf:plain-text id="generator">3.3.0.27375</xccdf:plain-text>
+      <xccdf:plain-text id="release-info">Release: 3.5 Benchmark Date: 11 May 2023</xccdf:plain-text>
+      <xccdf:plain-text id="generator">3.4.0.34222</xccdf:plain-text>
       <xccdf:plain-text id="conventionsVersion">1.10.0</xccdf:plain-text>
       <xccdf:platform idref="cpe:/o:microsoft:windows_server_2012:-" />
       <xccdf:platform idref="cpe:/o:microsoft:windows_server_2012:r2" />
-      <xccdf:version update="http://iase.disa.mil/stigs">003.003</xccdf:version>
+      <xccdf:version update="http://iase.disa.mil/stigs">003.005</xccdf:version>
       <xccdf:metadata>
         <dc:creator>DISA</dc:creator>
         <dc:publisher>DISA</dc:publisher>
@@ -79,7 +79,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225279" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225280" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225281" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225282" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225283" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225284" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225285" selected="true" />
@@ -332,7 +331,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225279" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225280" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225281" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225282" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225283" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225284" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225285" selected="true" />
@@ -585,7 +583,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225279" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225280" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225281" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225282" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225283" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225284" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225285" selected="true" />
@@ -838,7 +835,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225279" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225280" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225281" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225282" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225283" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225284" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225285" selected="true" />
@@ -1091,7 +1087,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225279" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225280" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225281" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225282" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225283" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225284" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225285" selected="true" />
@@ -1344,7 +1339,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225279" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225280" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225281" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225282" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225283" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225284" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225285" selected="true" />
@@ -1597,7 +1591,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225279" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225280" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225281" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225282" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225283" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225284" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225285" selected="true" />
@@ -1850,7 +1843,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225279" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225280" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225281" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225282" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225283" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225284" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225285" selected="true" />
@@ -2103,7 +2095,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225279" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225280" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225281" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-225282" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225283" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225284" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-225285" selected="true" />
@@ -2339,32 +2330,32 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225448r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225450r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225451r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225545r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225545r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225546r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225547r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225547r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225548r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225549r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225550r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225551r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225552r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225553r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225554r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225555r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225556r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225550r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225551r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225552r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225553r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225554r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225555r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225556r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225559r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225562r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225563r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225564r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225565r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225566r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225567r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225568r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225569r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225570r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225571r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225572r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225573r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225574r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225562r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225563r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225564r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225565r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225566r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225567r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225568r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225569r852282_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225570r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225571r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225572r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225573r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225574r877392_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_CAT_I_Only">
         <xccdf:title>CAT I Only</xccdf:title>
@@ -2373,9 +2364,9 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225260r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225261r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225265r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225266r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225266r852182_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225267r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225268r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225268r852183_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225269r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225270r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225271r569185_rule" selected="false" />
@@ -2383,31 +2374,30 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225273r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225275r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225276r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225277r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225278r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225279r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225280r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225277r852184_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225278r852185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225279r852186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225280r852187_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225281r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225282r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225283r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225284r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225285r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225286r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225287r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225292r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225293r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225294r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225293r852188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225294r852189_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225295r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225296r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225297r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225296r852190_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225297r852191_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225298r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225299r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225300r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225301r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225302r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225303r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225304r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225305r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225300r852192_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225301r852193_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225302r852194_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225303r852195_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225304r852196_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225305r852197_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225313r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225314r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225315r569185_rule" selected="false" />
@@ -2418,16 +2408,16 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225324r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225325r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225326r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225327r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225328r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225327r852200_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225328r852201_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225329r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225330r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225331r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225332r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225333r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225334r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225335r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225336r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225334r852202_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225335r852203_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225336r852204_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225337r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225338r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225339r569185_rule" selected="false" />
@@ -2438,15 +2428,15 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225344r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225345r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225346r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225347r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225347r852205_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225348r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225349r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225350r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225351r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225352r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225351r852206_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225352r852207_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225353r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225355r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225356r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225356r877039_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225357r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225358r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225359r569185_rule" selected="false" />
@@ -2456,42 +2446,42 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225367r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225368r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225369r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225370r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225371r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225372r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225373r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225370r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225371r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225372r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225373r877391_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225374r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225375r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225376r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225375r852217_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225376r852218_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225377r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225378r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225379r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225379r852219_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225380r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225381r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225382r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225381r852220_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225382r877398_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225383r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225384r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225385r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225386r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225389r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225389r852222_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225391r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225392r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225392r852224_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225393r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225394r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225395r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225397r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225398r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225400r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225401r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225402r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225404r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225405r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225406r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225407r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225395r852225_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225397r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225398r877395_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225400r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225401r852228_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225402r877394_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225404r852229_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225405r852230_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225406r852231_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225407r852232_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225410r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225441r819688_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225442r819691_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225443r569252_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225441r890492_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225442r894333_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225443r894336_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225446r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225448r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225450r569185_rule" selected="false" />
@@ -2500,39 +2490,39 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225453r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225454r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225455r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225456r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225457r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225458r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225456r852245_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225457r852246_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225458r852247_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225459r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225460r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225461r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225461r852248_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225462r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225463r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225464r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225467r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225468r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225469r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225470r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225471r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225472r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225473r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225474r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225475r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225470r852249_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225471r852250_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225472r877396_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225473r852251_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225474r852252_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225475r852253_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225476r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225477r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225478r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225478r877377_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225479r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225480r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225481r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225482r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225482r852254_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225483r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225484r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225485r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225484r852255_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225485r852256_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225486r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225487r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225488r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225489r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225490r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225488r852257_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225489r852258_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225490r852259_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225494r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225500r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225501r569185_rule" selected="false" />
@@ -2544,21 +2534,21 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225509r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225510r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225511r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225512r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225512r877380_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225513r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225514r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225515r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225515r852261_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225516r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225517r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225517r852262_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225518r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225519r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225520r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225521r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225521r852263_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225522r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225523r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225524r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225525r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225526r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225526r852264_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225527r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225528r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225529r569185_rule" selected="false" />
@@ -2566,33 +2556,33 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225531r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225532r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225533r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225545r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225545r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225546r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225548r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225549r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225550r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225551r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225553r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225554r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225555r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225550r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225551r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225553r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225554r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225555r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225557r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225558r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225559r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225560r569185_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225561r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225562r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225563r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225564r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225565r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225566r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225567r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225568r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225569r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225570r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225571r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225572r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225573r569185_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225574r569185_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225562r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225563r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225564r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225565r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225566r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225567r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225568r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225569r852282_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225570r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225571r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225572r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225573r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225574r877392_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Value id="xccdf_mil.disa.stig_value_virtualize_write_failures_per_user_locations_var" type="number" operator="equals">
         <xccdf:title>Virtualize file and registry write failures to per-user locations</xccdf:title>
@@ -3445,12 +3435,12 @@ Disable-WindowsOptionalFeature -Online -FeatureName SMB1Protocol
 Alternately:
 Search for "Features".
 Select "Turn Windows features on or off".
-De-select "SMB 1.0/CIFS File Sharing Support".   
+De-select "SMB 1.0/CIFS File Sharing Support".
 
 The system must be restarted for the changes to take effect.</xccdf:fixtext>
           <xccdf:fix id="F-26946r471120_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5163" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5163" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3480,7 +3470,7 @@ The system must be restarted for the change to take effect.
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-26947r471123_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5165" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5165" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3515,7 +3505,7 @@ The system must be restarted for the changes to take effect.
 These policy settings requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-26948r471126_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5167" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5167" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3549,14 +3539,14 @@ Alternately:
 Use the "Remove Roles and Features Wizard" and deselect "Windows PowerShell 2.0 Engine" under "Windows PowerShell".</xccdf:fixtext>
           <xccdf:fix id="F-26952r471138_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5193" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5193" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225266">
         <xccdf:title>SRG-OS-000329-GPOS-00128</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225266r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225266r852182_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AC-000001</xccdf:version>
           <xccdf:title>Windows 2012 account lockout duration must be configured to 15 minutes or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system. This parameter specifies the period of time that an account will remain locked after the specified number of failed logon attempts.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3576,7 +3566,7 @@ Use the "Remove Roles and Features Wizard" and deselect "Windows PowerShell 2.0 
 A value of "0" is also acceptable, requiring an administrator to unlock the account.</xccdf:fixtext>
           <xccdf:fix id="F-26953r471141_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4422" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4422" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3602,14 +3592,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-26954r471144_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_threshold_var" export-name="oval:mil.disa.fso.windows:var:442300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4423" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4423" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225268">
         <xccdf:title>SRG-OS-000021-GPOS-00005</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225268r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225268r852183_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AC-000003</xccdf:version>
           <xccdf:title>The reset period for the account lockout counter must be configured to 15 minutes or greater on Windows 2012.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system.  This parameter specifies the period of time that must pass after failed logon attempts before the counter is reset to "0".  The smaller this value is, the less effective the account lockout feature will be in protecting the local system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3629,7 +3619,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-26955r471147_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_reset_counter_var" export-name="oval:mil.disa.fso.windows:var:442400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4424" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4424" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3655,7 +3645,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-26956r471150_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_enforce_history_var" export-name="oval:mil.disa.fso.windows:var:442500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4425" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4425" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3681,7 +3671,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-26957r471153_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_maximum_age_var" export-name="oval:mil.disa.fso.windows:var:442600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4426" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4426" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3707,7 +3697,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-26958r471156_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_age_var" export-name="oval:mil.disa.fso.windows:var:442700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4427" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4427" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3733,7 +3723,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-26959r471159_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_length_var" export-name="oval:mil.disa.fso.windows:var:442800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4428" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4428" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3762,14 +3752,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-26960r471162_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_complexity_var" export-name="oval:mil.disa.fso.windows:var:442900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4429" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4429" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225274">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225274r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225274r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AC-000009</xccdf:version>
           <xccdf:title>Reversible password encryption must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storing passwords using reversible encryption is essentially the same as storing clear-text versions of the passwords.  For this reason, this policy must never be enabled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3788,7 +3778,7 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-26961r471165_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_reversible_encryption_var" export-name="oval:mil.disa.fso.windows:var:443000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4430" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4430" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3814,7 +3804,7 @@ Credential validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-26962r471168_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Logon -&gt; "Audit Credential Validation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26962r471168_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4664" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4664" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3840,14 +3830,14 @@ Credential validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-26963r471171_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Logon -&gt; "Audit Credential Validation" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26963r471171_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4665" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4665" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225277">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225277r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225277r852184_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000015</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - Other Account Management Events successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3867,14 +3857,14 @@ Other Account Management Events records events such as the access of a password 
           <xccdf:fixtext fixref="F-26964r471174_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Management -&gt; "Audit Other Account Management Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26964r471174_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4668" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4668" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225278">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225278r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225278r852185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000017</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - Security Group Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3899,14 +3889,14 @@ Security Group Management records events such as creating, deleting, or changing
           <xccdf:fixtext fixref="F-26965r471177_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Management -&gt; "Audit Security Group Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26965r471177_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4670" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4670" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225279">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225279r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225279r852186_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000019</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - User Account Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3931,14 +3921,14 @@ User Account Management records events such as creating, changing, deleting, ren
           <xccdf:fixtext fixref="F-26966r471180_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Management -&gt; "Audit User Account Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26966r471180_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4672" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4672" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225280">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225280r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225280r852187_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000020</xccdf:version>
           <xccdf:title>The system must be configured to audit Account Management - User Account Management failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3963,7 +3953,7 @@ User Account Management records events such as creating, changing, deleting, ren
           <xccdf:fixtext fixref="F-26967r471183_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Account Management -&gt; "Audit User Account Management" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26967r471183_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4673" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4673" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3989,34 +3979,7 @@ Process Creation records events related to the creation of a process and the sou
           <xccdf:fixtext fixref="F-26968r471186_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Detailed Tracking -&gt; "Audit Process Creation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26968r471186_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4674" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-225282">
-        <xccdf:title>SRG-OS-000470-GPOS-00214</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225282r569185_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000030</xccdf:version>
-          <xccdf:title>Windows Server 2012/2012 R2 must be configured to audit Logon/Logoff - Account Lockout successes.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
-
-Account Lockout events can be used to identify potentially malicious logon attempts.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Microsoft Windows Server 2012-2012 R2 MS</dc:subject>
-            <dc:identifier>4214</dc:identifier>
-          </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/legacy">SV-92765</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">V-78057</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-001404</xccdf:ident>
-          <xccdf:fixtext fixref="F-26969r471189_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Account Lockout" with "Success" selected.</xccdf:fixtext>
-          <xccdf:fix id="F-26969r471189_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5182" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4674" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4043,7 +4006,7 @@ Account Lockout events can be used to identify potentially malicious logon attem
           <xccdf:fixtext fixref="F-26970r471192_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Account Lockout" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26970r471192_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5183" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5183" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4070,7 +4033,7 @@ Logoff records user logoffs.  If this is an interactive logoff, it is recorded o
           <xccdf:fixtext fixref="F-26971r471195_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Logon/Logoff -&gt; "Audit Logoff" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26971r471195_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4675" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4675" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4097,7 +4060,7 @@ Logon records user logons.  If this is an interactive logon, it is recorded on t
           <xccdf:fixtext fixref="F-26972r471198_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Logon/Logoff -&gt; "Audit Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26972r471198_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4676" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4676" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4124,7 +4087,7 @@ Logon records user logons.  If this is an interactive logon, it is recorded on t
           <xccdf:fixtext fixref="F-26973r471201_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Logon/Logoff -&gt; "Audit Logon" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26973r471201_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4677" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4677" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4150,7 +4113,7 @@ Special Logon records special logons which have administrative privileges and ca
           <xccdf:fixtext fixref="F-26974r471204_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Logon/Logoff -&gt; "Audit Special Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26974r471204_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4678" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4678" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4176,14 +4139,14 @@ Audit Policy Change records events related to changes in audit policy.&lt;/VulnD
           <xccdf:fixtext fixref="F-26979r471219_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Policy Change -&gt; "Audit Audit Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26979r471219_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4681" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4681" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225293">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225293r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225293r852188_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000086</xccdf:version>
           <xccdf:title>The system must be configured to audit Policy Change - Audit Policy Change failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4203,14 +4166,14 @@ Audit Policy Change records events related to changes in audit policy.&lt;/VulnD
           <xccdf:fixtext fixref="F-26980r471222_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Policy Change -&gt; "Audit Audit Policy Change" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26980r471222_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4682" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4682" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225294">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225294r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225294r852189_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000087</xccdf:version>
           <xccdf:title>The system must be configured to audit Policy Change - Authentication Policy Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4230,7 +4193,7 @@ Authentication Policy Change records events related to changes in authentication
           <xccdf:fixtext fixref="F-26981r471225_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Policy Change -&gt; "Audit Authentication Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26981r471225_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4683" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4683" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4256,14 +4219,14 @@ Authorization Policy Change records events related to changes in user rights, su
           <xccdf:fixtext fixref="F-26982r471228_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Policy Change -&gt; "Audit Authorization Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26982r471228_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4975" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4975" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225296">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225296r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225296r852190_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000101</xccdf:version>
           <xccdf:title>The system must be configured to audit Privilege Use - Sensitive Privilege Use successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4283,14 +4246,14 @@ Sensitive Privilege Use records events related to use of sensitive privileges, s
           <xccdf:fixtext fixref="F-26983r471231_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Privilege Use -&gt; "Audit Sensitive Privilege Use" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26983r471231_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4684" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4684" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225297">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225297r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225297r852191_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000102</xccdf:version>
           <xccdf:title>The system must be configured to audit Privilege Use - Sensitive Privilege Use failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4310,7 +4273,7 @@ Sensitive Privilege Use records events related to use of sensitive privileges, s
           <xccdf:fixtext fixref="F-26984r471234_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; Privilege Use -&gt; "Audit Sensitive Privilege Use" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26984r471234_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4685" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4685" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4336,7 +4299,7 @@ IPsec Driver records events related to the IPSec Driver such as dropped packets.
           <xccdf:fixtext fixref="F-26985r471237_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit IPsec Driver" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26985r471237_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4686" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4686" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4362,14 +4325,14 @@ IPsec Driver records events related to the IPsec Driver such as dropped packets.
           <xccdf:fixtext fixref="F-26986r471240_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit IPsec Driver" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26986r471240_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4687" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4687" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225300">
         <xccdf:title>SRG-OS-000064-GPOS-00033</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225300r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225300r852192_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000105</xccdf:version>
           <xccdf:title>Windows Server 2012/2012 R2 must be configured to audit System - Other System Events successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4392,14 +4355,14 @@ Satisfies: SRG-OS-000458-GPOS-00203&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:fixtext fixref="F-26987r471243_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26987r471243_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5190" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5190" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225301">
         <xccdf:title>SRG-OS-000064-GPOS-00033</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225301r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225301r852193_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000106</xccdf:version>
           <xccdf:title>Windows Server 2012/2012 R2 must be configured to audit System - Other System Events failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4422,14 +4385,14 @@ Satisfies: SRG-OS-000458-GPOS-00203&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:fixtext fixref="F-26988r471246_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26988r471246_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5191" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5191" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225302">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225302r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225302r852194_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000107</xccdf:version>
           <xccdf:title>The system must be configured to audit System - Security State Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4449,14 +4412,14 @@ Security State Change records events related to changes in the security state, s
           <xccdf:fixtext fixref="F-26989r471249_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit Security State Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26989r471249_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4688" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4688" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225303">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225303r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225303r852195_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000109</xccdf:version>
           <xccdf:title>The system must be configured to audit System - Security System Extension successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4476,14 +4439,14 @@ Security System Extension records events related to extension code being loaded 
           <xccdf:fixtext fixref="F-26990r471252_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit Security System Extension" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26990r471252_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4690" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4690" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225304">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225304r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225304r852196_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000111</xccdf:version>
           <xccdf:title>The system must be configured to audit System - System Integrity successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4503,14 +4466,14 @@ System Integrity records events related to violations of integrity to the securi
           <xccdf:fixtext fixref="F-26991r471255_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit System Integrity" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26991r471255_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4692" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4692" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225305">
         <xccdf:title>SRG-OS-000471-GPOS-00215</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225305r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225305r852197_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-AU-000112</xccdf:version>
           <xccdf:title>The system must be configured to audit System - System Integrity failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4530,7 +4493,7 @@ System Integrity records events related to violations of integrity to the securi
           <xccdf:fixtext fixref="F-26992r471258_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Advanced Audit Policy Configuration -&gt; System Audit Policies -&gt; System -&gt; "Audit System Integrity" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26992r471258_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4693" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4693" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4561,7 +4524,7 @@ TrustedInstaller - Full Control
 Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xccdf:fixtext>
           <xccdf:fix id="F-27000r471282_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4984" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4984" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4586,7 +4549,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fixtext fixref="F-27001r471285_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Network -&gt; Link-Layer Topology Discovery -&gt; "Turn on Mapper I/O (LLTDIO) driver" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27001r471285_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4431" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4431" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4611,7 +4574,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fixtext fixref="F-27002r471288_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Network -&gt; Link-Layer Topology Discovery -&gt; "Turn on Responder (RSPNDR) driver" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27002r471288_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4432" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4432" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4637,7 +4600,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27003r471291_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_microsoft_peer_to_peer_networking_services_var" export-name="oval:mil.disa.fso.windows:var:443300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4433" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4433" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4663,7 +4626,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27004r471294_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prohibit_installation_network_bridge_var" export-name="oval:mil.disa.fso.windows:var:443400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4434" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4434" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4689,7 +4652,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27005r471297_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_domain_users_to_elevate_when_setting_a_networks_location_var" export-name="oval:mil.disa.fso.windows:var:443500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4435" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4435" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4715,7 +4678,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27006r471300_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_route_all_traffic_through_the_internal_network_var" export-name="oval:mil.disa.fso.windows:var:443600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4436" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4436" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4740,7 +4703,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fixtext fixref="F-27011r471315_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Network -&gt; TCPIP Settings -&gt; Parameters -&gt; "Set IP Stateless Autoconfiguration Limits State" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27011r471315_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4727" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4727" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4765,7 +4728,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fixtext fixref="F-27012r471318_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Network -&gt; Windows Connect Now -&gt; "Configuration of wireless settings using Windows Connect Now" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27012r471318_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4441" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4441" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4791,17 +4754,17 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES - Read &amp; Execute</xc
           <xccdf:fix id="F-27013r471321_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prohibit_access_of_the_windows_connect_now_wizards_var" export-name="oval:mil.disa.fso.windows:var:444200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4442" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4442" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225327">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225327r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225327r852200_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000016</xccdf:version>
           <xccdf:title>Windows Update must be prevented from searching for point and print drivers.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent Windows from searching Windows Update for point and print drivers.  Only the local driver store and server driver cache will be searched.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -4818,14 +4781,14 @@ This setting will prevent Windows from searching Windows Update for point and pr
           <xccdf:fix id="F-27014r471324_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_extend_point_and_print_connection_to_search_windows_update_and_use_alternate_connection_if_needed_var" export-name="oval:mil.disa.fso.windows:var:444300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4443" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4443" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225328">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225328r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225328r852201_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000018</xccdf:version>
           <xccdf:title>Optional component installation and component repair must be prevented from using Windows Update.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Uncontrolled system updates can introduce issues to a system.  Obtaining update components from an outside source may also potentially provide sensitive information outside of the enterprise.  Optional component installation or repair must be obtained from an internal source.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4843,7 +4806,7 @@ This setting will prevent Windows from searching Windows Update for point and pr
           <xccdf:fixtext fixref="F-27015r471327_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; "Specify settings for optional component installation and component repair" to "Enabled" and with "Never attempt to download payload from Windows Update" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27015r471327_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4444" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4444" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4869,7 +4832,7 @@ This setting will prevent Windows from searching Windows Update for point and pr
           <xccdf:fix id="F-27016r471330_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_remote_access_to_the_pnp_interface_var" export-name="oval:mil.disa.fso.windows:var:444500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4445" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4445" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4879,7 +4842,7 @@ This setting will prevent Windows from searching Windows Update for point and pr
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225330r569185_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000020</xccdf:version>
           <xccdf:title>An Error Report must not be sent when a generic device driver is installed.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents an error report from being sent when a generic device driver is installed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -4896,7 +4859,7 @@ This setting prevents an error report from being sent when a generic device driv
           <xccdf:fix id="F-27017r471333_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_send_windows_error_report_when_generic_driver_is_installed_on_device_var" export-name="oval:mil.disa.fso.windows:var:444600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4446" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4446" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4922,7 +4885,7 @@ This setting prevents an error report from being sent when a generic device driv
           <xccdf:fix id="F-27018r471336_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_create_system_restore_point_when_new_device_driver_installed_var" export-name="oval:mil.disa.fso.windows:var:444700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4447" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4447" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4932,7 +4895,7 @@ This setting prevents an error report from being sent when a generic device driv
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225332r569185_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000022</xccdf:version>
           <xccdf:title>Device metadata retrieval from the Internet must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent Windows from retrieving device metadata from the Internet.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -4949,7 +4912,7 @@ This setting will prevent Windows from retrieving device metadata from the Inter
           <xccdf:fix id="F-27019r471339_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prevent_device_metadata_retrieval_from_the_internet_var" export-name="oval:mil.disa.fso.windows:var:444800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4448" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4448" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4959,7 +4922,7 @@ This setting will prevent Windows from retrieving device metadata from the Inter
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225333r569185_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000023</xccdf:version>
           <xccdf:title>Windows must be prevented from sending an error report when a device driver requests additional software during installation.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent Windows from sending an error report to Microsoft when a device driver requests additional software during installation.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -4975,17 +4938,17 @@ This setting will prevent Windows from sending an error report to Microsoft when
           <xccdf:fixtext fixref="F-27020r471342_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Device Installation -&gt; "Prevent Windows from sending an error report when a device driver requests additional software during installation" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27020r471342_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4449" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4449" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225334">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225334r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225334r852202_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000024</xccdf:version>
           <xccdf:title>Device driver searches using Windows Update must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent the system from searching Windows Update for device drivers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5002,14 +4965,14 @@ This setting will prevent the system from searching Windows Update for device dr
           <xccdf:fix id="F-27021r471345_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_specify_search_order_for_device_driver_source_locations_var" export-name="oval:mil.disa.fso.windows:var:445000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4450" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4450" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225335">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225335r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225335r852203_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000025</xccdf:version>
           <xccdf:title>Device driver updates must only search managed servers, not Windows Update.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Uncontrolled system updates can introduce issues to a system.  Obtaining update components from an outside source may also potentially provide sensitive information outside of the enterprise.  Device driver updates must be obtained from an internal source.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5027,17 +4990,17 @@ This setting will prevent the system from searching Windows Update for device dr
           <xccdf:fixtext fixref="F-27022r471348_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Device Installation -&gt; "Specify the search server for device driver updates" to "Enabled" with "Search Managed Server" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27022r471348_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4451" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4451" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225336">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225336r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225336r852204_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000026</xccdf:version>
           <xccdf:title>Users must not be prompted to search Windows Update for device drivers.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents users from being prompted to search Windows Update for device drivers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5054,7 +5017,7 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:fix id="F-27023r471351_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_windows_update_device_driver_search_prompt_var" export-name="oval:mil.disa.fso.windows:var:445200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4452" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4452" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5079,7 +5042,7 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:fixtext fixref="F-27024r471354_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Early Launch Antimalware -&gt; "Boot-Start Driver Initialization Policy" to "Enabled" with "Good and Unknown" selected.</xccdf:fixtext>
           <xccdf:fix id="F-27024r471354_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4453" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4453" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5105,7 +5068,7 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:fix id="F-27025r471357_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_registry_policy_processing_var" export-name="oval:mil.disa.fso.windows:var:445400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4454" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4454" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5130,7 +5093,7 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:fixtext fixref="F-27026r471360_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Group Policy -&gt; "Turn off background refresh of Group Policy" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27026r471360_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4989" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4989" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5152,12 +5115,12 @@ This setting prevents users from being prompted to search Windows Update for dev
           <xccdf:ident system="http://cyber.mil/legacy">SV-51609</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-36680</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000366</xccdf:ident>
-          <xccdf:fixtext fixref="F-27027r471363_fix">If the \Windows\WinStore directory exists, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Internet Communication Management &gt;&gt; Internet Communication settings &gt;&gt; "Turn off access to the Store" to "Enabled".   
+          <xccdf:fixtext fixref="F-27027r471363_fix">If the \Windows\WinStore directory exists, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Internet Communication Management &gt;&gt; Internet Communication settings &gt;&gt; "Turn off access to the Store" to "Enabled".
 
 Alternately, uninstall the "Desktop Experience" feature from Windows 2012.  This is located under "User Interfaces and Infrastructure" in the "Add Roles and Features Wizard".  The \Windows\WinStore directory may need to be manually deleted after this.</xccdf:fixtext>
           <xccdf:fix id="F-27027r471363_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4455" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4455" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5167,7 +5130,7 @@ Alternately, uninstall the "Desktop Experience" feature from Windows 2012.  This
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225341r569185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000032</xccdf:version>
           <xccdf:title>Downloading print driver packages over HTTP must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents the computer from downloading print driver packages over HTTP.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5184,7 +5147,7 @@ This setting prevents the computer from downloading print driver packages over H
           <xccdf:fix id="F-27028r471366_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_downloading_of_print_drivers_over_http_var" export-name="oval:mil.disa.fso.windows:var:445700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4457" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4457" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5209,7 +5172,7 @@ This setting prevents the computer from downloading print driver packages over H
           <xccdf:fixtext fixref="F-27029r471369_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Internet Communication Management -&gt; Internet Communication settings -&gt; "Turn off Event Viewer "Events.asp" links" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27029r471369_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4623" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4623" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5219,7 +5182,7 @@ This setting prevents the computer from downloading print driver packages over H
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225343r569185_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000035</xccdf:version>
           <xccdf:title>Errors in handwriting recognition on tablet PCs must not be reported to Microsoft.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents errors in handwriting recognition on tablet PCs from being reported to Microsoft.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5236,7 +5199,7 @@ This setting prevents errors in handwriting recognition on tablet PCs from being
           <xccdf:fix id="F-27030r471372_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_handwriting_recognition_error_reporting_var" export-name="oval:mil.disa.fso.windows:var:445800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4458" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4458" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5246,7 +5209,7 @@ This setting prevents errors in handwriting recognition on tablet PCs from being
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225344r569185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000038</xccdf:version>
           <xccdf:title>The Internet File Association service must be turned off.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents unhandled file associations from using the Microsoft Web service to find an application.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5263,7 +5226,7 @@ This setting prevents unhandled file associations from using the Microsoft Web s
           <xccdf:fix id="F-27031r471375_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_internet_file_association_service_var" export-name="oval:mil.disa.fso.windows:var:446100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4461" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4461" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5273,7 +5236,7 @@ This setting prevents unhandled file associations from using the Microsoft Web s
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225345r569185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000039</xccdf:version>
           <xccdf:title>Printing over HTTP must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents the client computer from printing over HTTP, which allows the computer to print to printers on the intranet as well as the Internet.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5290,7 +5253,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
           <xccdf:fix id="F-27032r471378_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_printing_over_http_var" export-name="oval:mil.disa.fso.windows:var:446200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4462" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4462" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5300,7 +5263,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225346r569185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000045</xccdf:version>
           <xccdf:title>The Windows Customer Experience Improvement Program must be disabled.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting ensures the Windows Customer Experience Improvement Program is disabled so information is not passed to the vendor.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5317,17 +5280,17 @@ This setting ensures the Windows Customer Experience Improvement Program is disa
           <xccdf:fix id="F-27033r471381_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_disable_the_windows_messenger_customer_experience_improvement_program_var" export-name="oval:mil.disa.fso.windows:var:446800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4468" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4468" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225347">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225347r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225347r852205_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000047</xccdf:version>
           <xccdf:title>Windows must be prevented from using Windows Update to search for drivers.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents Windows from searching Windows Update for device drivers when no local drivers for a device are present.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5344,7 +5307,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27034r471384_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_windows_update_device_driver_searching_var" export-name="oval:mil.disa.fso.windows:var:447000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4470" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4470" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5369,7 +5332,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fixtext fixref="F-27035r471387_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Locale Services -&gt; "Disallow copying of user input methods to the system account for sign-in" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27035r471387_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4471" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4471" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5394,7 +5357,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fixtext fixref="F-27036r471390_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Logon -&gt; "Enumerate local users on domain-joined computers" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27036r471390_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4473" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4473" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5419,14 +5382,14 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fixtext fixref="F-27037r471393_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Logon -&gt; "Turn off app notifications on the lock screen" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27037r471393_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4474" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4474" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225351">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225351r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225351r852206_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000054</xccdf:version>
           <xccdf:title>Users must be prompted to authenticate on resume from sleep (on battery).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Authentication must always be required when accessing a system.  This setting ensures the user is prompted for a password on resume from sleep (on battery).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5445,14 +5408,14 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27038r471396_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_on_battery_var" export-name="oval:mil.disa.fso.windows:var:447500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4475" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4475" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225352">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225352r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225352r852207_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000055</xccdf:version>
           <xccdf:title>The user must be prompted to authenticate on resume from sleep (plugged in).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Authentication must always be required when accessing a system.  This setting ensures the user is prompted for a password on resume from sleep (plugged in).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5471,7 +5434,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27039r471399_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_plugged_var" export-name="oval:mil.disa.fso.windows:var:447600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4476" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4476" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5497,7 +5460,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27040r471402_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_offer_remote_assistance_var" export-name="oval:mil.disa.fso.windows:var:447900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4479" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4479" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5523,7 +5486,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27041r471405_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_solicited_remote_assistance_var" export-name="oval:mil.disa.fso.windows:var:448000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4480" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4480" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5549,14 +5512,14 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27042r471408_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_on_session_logging_var" export-name="oval:mil.disa.fso.windows:var:448100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4481" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4481" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225356">
         <xccdf:title>SRG-OS-000379-GPOS-00164</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225356r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225356r877039_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000064-MS</xccdf:version>
           <xccdf:title>Unauthenticated RPC clients must be restricted from connecting to the RPC server.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring RPC to restrict unauthenticated RPC clients from connecting to the RPC server will prevent anonymous connections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5575,7 +5538,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fix id="F-27043r471411_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_restrictions_for_unauthenticated_rpc_clients_var" export-name="oval:mil.disa.fso.windows:var:448300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4483" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4483" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5600,7 +5563,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
           <xccdf:fixtext fixref="F-27044r471414_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; System -&gt; Troubleshooting and Diagnostics -&gt; Application Compatibility Diagnostics -&gt; "Detect compatibility issues for applications and drivers" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27044r471414_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4484" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4484" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5610,7 +5573,7 @@ This setting prevents Windows from searching Windows Update for device drivers w
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225358r569185_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000066</xccdf:version>
           <xccdf:title>Microsoft Support Diagnostic Tool (MSDT) interactive communication with Microsoft must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents the MSDT from communicating with and sending collected data to Microsoft, the default support provider.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5627,7 +5590,7 @@ This setting prevents the MSDT from communicating with and sending collected dat
           <xccdf:fix id="F-27045r471417_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_microsoft_support_diagnostic_tool_turn_on_msdt_interactive_communication_with_support_provider_var" export-name="oval:mil.disa.fso.windows:var:448500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4485" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4485" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5637,7 +5600,7 @@ This setting prevents the MSDT from communicating with and sending collected dat
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225359r569185_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000067</xccdf:version>
           <xccdf:title>Access to Windows Online Troubleshooting Service (WOTS) must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents users from searching troubleshooting content on Microsoft servers.  Only local content will be available.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5654,7 +5617,7 @@ This setting prevents users from searching troubleshooting content on Microsoft 
           <xccdf:fix id="F-27046r471420_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_troubleshooting_allow_user_to_access_online_troubleshooting_content_on_microsoft_servers_from_the_troubleshooting_control_panel_var" export-name="oval:mil.disa.fso.windows:var:448600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4486" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4486" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5664,7 +5627,7 @@ This setting prevents users from searching troubleshooting content on Microsoft 
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225360r569185_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000068</xccdf:version>
           <xccdf:title>Responsiveness events must be prevented from being aggregated and sent to Microsoft.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents responsiveness events from being aggregated and sent to Microsoft.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5681,7 +5644,7 @@ This setting prevents responsiveness events from being aggregated and sent to Mi
           <xccdf:fix id="F-27047r471423_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_enable_disable_perftrack_var" export-name="oval:mil.disa.fso.windows:var:448700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4487" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4487" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5706,7 +5669,7 @@ This setting prevents responsiveness events from being aggregated and sent to Mi
           <xccdf:fixtext fixref="F-27049r471429_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; App Package Deployment  -&gt; "Allow all trusted apps to install" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27049r471429_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4488" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4488" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5716,7 +5679,7 @@ This setting prevents responsiveness events from being aggregated and sent to Mi
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225363r569185_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000071</xccdf:version>
           <xccdf:title>The Application Compatibility Program Inventory must be prevented from collecting data and sending the information to Microsoft.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting will prevent the Program Inventory from collecting data about a system and sending the information to Microsoft.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -5733,14 +5696,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27050r471432_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_program_inventory_var" export-name="oval:mil.disa.fso.windows:var:448900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4489" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4489" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225364">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225364r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225364r852210_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000072</xccdf:version>
           <xccdf:title>Autoplay must be turned off for non-volume devices.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing Autoplay to execute may introduce malicious code to a system.  Autoplay begins reading from a drive as soon as media is inserted into the drive.  As a result, the setup file of programs or music on audio media may start.  This setting will disable Autoplay for non-volume devices (such as Media Transfer Protocol (MTP) devices).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5759,14 +5722,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27051r471435_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_autoplay_for_non_volume_devices_var" export-name="oval:mil.disa.fso.windows:var:449000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4490" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4490" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225365">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225365r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225365r852211_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000073</xccdf:version>
           <xccdf:title>The default Autorun behavior must be configured to prevent Autorun commands.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing Autorun commands to execute may introduce malicious code to a system.  Configuring this setting prevents Autorun commands from executing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5785,14 +5748,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27052r471438_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_default_behavior_for_autorun_var" export-name="oval:mil.disa.fso.windows:var:449100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4491" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4491" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225366">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225366r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225366r852212_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000074</xccdf:version>
           <xccdf:title>Autoplay must be disabled for all drives.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing Autoplay to execute may introduce malicious code to a system.  Autoplay begins reading from a drive as soon media is inserted into the drive.  As a result, the setup file of programs or music on audio media may start.  By default, Autoplay is disabled on removable drives, such as the floppy disk drive (but not the CD-ROM drive) and on network drives.  Enabling this policy disables Autoplay on all drives.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5810,7 +5773,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fixtext fixref="F-27053r471441_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; AutoPlay Policies -&gt; "Turn off AutoPlay" to "Enabled:All Drives".</xccdf:fixtext>
           <xccdf:fix id="F-27053r471441_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4492" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4492" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5835,7 +5798,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fixtext fixref="F-27054r471444_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Biometrics -&gt; "Allow the use of biometrics" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27054r471444_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4493" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4493" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5860,7 +5823,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fixtext fixref="F-27055r471447_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Credential User Interface -&gt; "Do not display the password reveal button" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27055r471447_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4494" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4494" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5886,14 +5849,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27056r471450_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_enumerate_administrator_accounts_on_elevation_var" export-name="oval:mil.disa.fso.windows:var:449500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4495" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4495" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225370">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225370r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225370r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000084</xccdf:version>
           <xccdf:title>The Application event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5912,14 +5875,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27057r471453_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_application_log_size_var" export-name="oval:mil.disa.fso.windows:var:450200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4502" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4502" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225371">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225371r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225371r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000085</xccdf:version>
           <xccdf:title>The Security event log size must be configured to 196608 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5938,14 +5901,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27058r471456_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_security_log_size_var" export-name="oval:mil.disa.fso.windows:var:450300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4503" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4503" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225372">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225372r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225372r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000086</xccdf:version>
           <xccdf:title>The Setup event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5964,14 +5927,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27059r471459_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_setup_log_size_var" export-name="oval:mil.disa.fso.windows:var:450400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4504" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4504" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225373">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225373r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225373r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000087</xccdf:version>
           <xccdf:title>The System event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5990,7 +5953,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-27060r471462_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_system_log_size_var" export-name="oval:mil.disa.fso.windows:var:450500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4505" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4505" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6012,7 +5975,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:ident system="http://cyber.mil/legacy">V-36707</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-51747</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000381</xccdf:ident>
-          <xccdf:fixtext fixref="F-27061r471465_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; File Explorer &gt;&gt; "Configure Windows SmartScreen" to "Enabled" with either "Give user a warning before running downloaded unknown software" or "Require approval from an administrator before running downloaded unknown software" selected.   
+          <xccdf:fixtext fixref="F-27061r471465_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; File Explorer &gt;&gt; "Configure Windows SmartScreen" to "Enabled" with either "Give user a warning before running downloaded unknown software" or "Require approval from an administrator before running downloaded unknown software" selected.
 
 Microsoft has changed this setting several times in the Windows 10 administrative templates, which will affect group policies in a domain if later templates are used.
 
@@ -6021,14 +5984,14 @@ v1607 of Windows 10 and Windows Server 2016 changed the setting to only Enabled 
 v1703 of Windows 10 or later administrative templates changed the policy name to "Configure Windows Defender SmartScreen", and the selectable options are "Warn" and "Warn and prevent bypass". When either of these are applied to a Windows 2012/2012 R2 system, it will configure the registry equivalent of "Give user a warning…").</xccdf:fixtext>
           <xccdf:fix id="F-27061r471465_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4506" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4506" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225375">
         <xccdf:title>SRG-OS-000433-GPOS-00192</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225375r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225375r852217_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000089</xccdf:version>
           <xccdf:title>Explorer Data Execution Prevention must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Data Execution Prevention (DEP) provides additional protection by performing  checks on memory to help prevent malicious code from running.  This setting will prevent Data Execution Prevention from being turned off for File Explorer.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6047,14 +6010,14 @@ v1703 of Windows 10 or later administrative templates changed the policy name to
           <xccdf:fix id="F-27062r471468_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_data_execution_prevention_for_explorer_var" export-name="oval:mil.disa.fso.windows:var:450700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4507" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4507" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225376">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225376r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225376r852218_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000090</xccdf:version>
           <xccdf:title>Turning off File Explorer heap termination on corruption must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Legacy plug-in applications may continue to function when a File Explorer session has become corrupt.  Disabling this feature will prevent this.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6073,7 +6036,7 @@ v1703 of Windows 10 or later administrative templates changed the policy name to
           <xccdf:fix id="F-27063r471471_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_heap_termination_corruption_var" export-name="oval:mil.disa.fso.windows:var:450800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4508" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4508" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6099,7 +6062,7 @@ v1703 of Windows 10 or later administrative templates changed the policy name to
           <xccdf:fix id="F-27064r471474_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_shell_protocol_protected_mode_var" export-name="oval:mil.disa.fso.windows:var:450900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4509" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4509" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6126,14 +6089,14 @@ v1703 of Windows 10 or later administrative templates changed the policy name to
 If location services are approved by the organization for a device, this must be documented.</xccdf:fixtext>
           <xccdf:fix id="F-27065r471477_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4510" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4510" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225379">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225379r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225379r852219_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000096</xccdf:version>
           <xccdf:title>Passwords must not be saved in the Remote Desktop Client.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Saving passwords in the Remote Desktop Client could allow an unauthorized user to establish a remote desktop session to another system.  The system must be configured to prevent users from saving passwords in the Remote Desktop Client.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6152,7 +6115,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27066r471480_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_passwords_to_be_saved_var" export-name="oval:mil.disa.fso.windows:var:451100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4511" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4511" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6178,14 +6141,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27067r471483_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_drive_redirection_var" export-name="oval:mil.disa.fso.windows:var:451200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4512" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4512" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225381">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225381r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225381r852220_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000099</xccdf:version>
           <xccdf:title>Remote Desktop Services must always prompt a client for passwords upon connection.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting controls the ability of users to supply passwords automatically as part of their remote desktop connection.  Disabling this setting would allow anyone to use the stored credentials in a connection item to connect to the terminal server.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6204,14 +6167,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27068r471486_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_always_prompt_for_password_upon_connection_var" export-name="oval:mil.disa.fso.windows:var:451300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4513" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4513" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225382">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225382r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225382r877398_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000100</xccdf:version>
           <xccdf:title>Remote Desktop Services must be configured with the client connection encryption set to the required level.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Remote connections must be encrypted to prevent interception of data or sensitive information. Selecting "High Level" will ensure encryption of Remote Desktop Services sessions in both directions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6231,7 +6194,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27069r471489_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_set_client_connection_encryption_level_var" export-name="oval:mil.disa.fso.windows:var:451400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4514" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4514" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6257,7 +6220,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27070r471492_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_delete_temp_folder_upon_exit_var" export-name="oval:mil.disa.fso.windows:var:451700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4517" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4517" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6283,7 +6246,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27071r471495_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_use_temporary_folders_per_session_var" export-name="oval:mil.disa.fso.windows:var:451800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4518" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4518" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6308,7 +6271,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27072r471498_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; RSS Feeds -&gt; "Prevent downloading of enclosures" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27072r471498_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4519" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4519" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6333,14 +6296,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27073r471501_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; RSS Feeds -&gt; "Turn on Basic feed authentication over HTTP" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27073r471501_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4728" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4728" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225389">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225389r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225389r852222_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000115</xccdf:version>
           <xccdf:title>Users must be prevented from changing installation options.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Installation options for applications are typically controlled by administrators.  This setting prevents users from changing installation options that may bypass security features.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6358,14 +6321,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27076r471510_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Installer -&gt; "Allow user control over installs" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27076r471510_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4525" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4525" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225390">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225390r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225390r852223_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000116</xccdf:version>
           <xccdf:title>The Windows Installer Always install with elevated privileges option must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Standard user accounts must not be granted elevated privileges.  Enabling Windows Installer to elevate privileges when installing applications can allow malicious persons and applications to gain full control of a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6383,7 +6346,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27077r471513_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Installer -&gt; "Always install with elevated privileges" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27077r471513_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4526" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4526" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6408,14 +6371,14 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fixtext fixref="F-27078r471516_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Installer -&gt; "Prevent Internet Explorer security prompt for Windows Installer scripts" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27078r471516_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4527" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4527" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225392">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225392r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225392r852224_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000118</xccdf:version>
           <xccdf:title>Nonadministrators must be prevented from applying vendor-signed updates.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Uncontrolled system updates can introduce issues to a system.  This setting will prevent users from applying vendor-signed updates (though they may be from a trusted source).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6434,7 +6397,7 @@ If location services are approved by the organization for a device, this must be
           <xccdf:fix id="F-27079r471519_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prohibit_non_administrators_install_signed_updates_var" export-name="oval:mil.disa.fso.windows:var:452800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4528" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4528" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6444,7 +6407,7 @@ If location services are approved by the organization for a device, this must be
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225393r569185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000120</xccdf:version>
           <xccdf:title>Windows Media Digital Rights Management (DRM) must be prevented from accessing the Internet.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This check verifies that Windows Media DRM will be prevented from accessing the Internet.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -6460,7 +6423,7 @@ This check verifies that Windows Media DRM will be prevented from accessing the 
           <xccdf:fixtext fixref="F-27080r471522_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Media Digital Rights Management -&gt; "Prevent Windows Media DRM Internet Access" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27080r471522_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4625" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4625" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6470,7 +6433,7 @@ This check verifies that Windows Media DRM will be prevented from accessing the 
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225394r569185_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000121</xccdf:version>
           <xccdf:title>Users must not be presented with Privacy and Installation options on first use of Windows Media Player.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature.  Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and uncontrolled updates to the system.
 This setting prevents users from being presented with Privacy and Installation options on first use of Windows Media Player, which could enable some communication with the vendor.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -6486,14 +6449,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27081r471525_fix">If Windows Media Player is installed, configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Media Player -&gt; "Do Not Show First Use Dialog Boxes" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27081r471525_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4624" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4624" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225395">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225395r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225395r852225_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000122</xccdf:version>
           <xccdf:title>Windows Media Player must be configured to prevent automatic checking for updates.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Uncontrolled system updates can introduce issues to a system.  The automatic check for updates performed by Windows Media Player must be disabled to ensure a constant platform and to prevent the introduction of unknown\untested software on the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6512,14 +6475,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fix id="F-27082r471528_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prevent_automatic_updates_var" export-name="oval:mil.disa.fso.windows:var:453000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4530" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4530" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225396">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225396r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225396r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000123</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain text passwords that could be used to compromise a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6537,14 +6500,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27083r471531_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Client -&gt; "Allow Basic authentication" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27083r471531_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4531" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4531" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225397">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225397r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225397r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000124</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised.  Windows remote management connections must be encrypted to prevent this.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6563,14 +6526,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27084r471534_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Client -&gt; "Allow unencrypted traffic" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27084r471534_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4532" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4532" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225398">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225398r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225398r877395_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000125</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not use Digest authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Digest authentication is not as strong as other options and may be subject to man-in-the-middle attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6588,14 +6551,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27085r471537_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Client -&gt; "Disallow Digest authentication" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27085r471537_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4533" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4533" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225399">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225399r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225399r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000126</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain text passwords that could be used to compromise a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6613,14 +6576,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27086r471540_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Service -&gt; "Allow Basic authentication" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27086r471540_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4534" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4534" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225400">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225400r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225400r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000127</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised.  Windows remote management connections must be encrypted to prevent this.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6639,14 +6602,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27087r471543_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Service -&gt; "Allow unencrypted traffic" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27087r471543_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4535" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4535" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225401">
         <xccdf:title>SRG-OS-000373-GPOS-00156</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225401r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225401r852228_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000128</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not store RunAs credentials.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storage of administrative credentials could allow unauthorized access.  Disallowing the storage of RunAs credentials for Windows Remote Management will prevent them from being used with plug-ins.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6664,14 +6627,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27088r471546_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Windows Remote Management (WinRM) -&gt; WinRM Service -&gt; "Disallow WinRM from storing RunAs credentials" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27088r471546_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4536" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4536" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225402">
         <xccdf:title>SRG-OS-000250-GPOS-00093</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225402r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225402r877394_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000130</xccdf:version>
           <xccdf:title>The Remote Desktop Session Host must require secure RPC communications.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing unsecure RPC communication exposes the system to man-in-the-middle attacks and data disclosure attacks.  A man-in-the-middle attack occurs when an intruder captures packets between a client and server and modifies them before allowing the packets to be exchanged.  Usually the attacker will modify the information in the packets in an attempt to cause either the client or server to reveal sensitive information.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6689,14 +6652,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27089r471549_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Security -&gt; "Require secure RPC communication" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27089r471549_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4537" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4537" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225404">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225404r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225404r852229_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000132</xccdf:version>
           <xccdf:title>Users must be prevented from mapping local COM ports and redirecting data from the Remote Desktop Session Host to local COM ports.  (Remote Desktop Services Role).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Preventing the redirection of Remote Desktop session data to a client computer's COM ports helps reduce possible exposure of sensitive data.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6714,14 +6677,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27091r471555_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Device and Resource Redirection -&gt; "Do not allow COM port redirection" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27091r471555_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4628" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4628" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225405">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225405r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225405r852230_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000133</xccdf:version>
           <xccdf:title>Users must be prevented from mapping local LPT ports and redirecting data from the Remote Desktop Session Host to local LPT ports.  (Remote Desktop Services Role).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Preventing the redirection of Remote Desktop session data to a client computer's LPT ports helps reduce possible exposure of sensitive data.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6739,14 +6702,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27092r471558_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Device and Resource Redirection -&gt; "Do not allow LPT port redirection" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27092r471558_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4629" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4629" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225406">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225406r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225406r852231_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000134</xccdf:version>
           <xccdf:title>The system must be configured to ensure smart card devices can be redirected to the Remote Desktop session.  (Remote Desktop Services Role).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Enabling the redirection of smart card devices allows their use within Remote Desktop sessions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6764,14 +6727,14 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27093r471561_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Device and Resource Redirection -&gt; "Do not allow smart card device redirection" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27093r471561_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4631" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4631" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225407">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225407r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225407r852232_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-CC-000135</xccdf:version>
           <xccdf:title>Users must be prevented from redirecting Plug and Play devices to the Remote Desktop Session Host.  (Remote Desktop Services Role).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Preventing the redirection of Plug and Play devices in Remote Desktop sessions helps reduce possible exposure of sensitive data.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6789,7 +6752,7 @@ This setting prevents users from being presented with Privacy and Installation o
           <xccdf:fixtext fixref="F-27094r471564_fix">Configure the policy value for Computer Configuration -&gt; Administrative Templates -&gt; Windows Components -&gt; Remote Desktop Services -&gt; Remote Desktop Session Host -&gt; Device and Resource Redirection -&gt; "Do not allow supported Plug and Play device redirection" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27094r471564_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4630" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4630" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6818,7 +6781,7 @@ Satisfies: SRG-OS-000042-GPOS-00021&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:fixtext fixref="F-27097r471573_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Audit Process Creation &gt;&gt; "Include command line in process creation events" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27097r471573_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5178" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5178" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6842,14 +6805,14 @@ Satisfies: SRG-OS-000042-GPOS-00021&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:fixtext fixref="F-27104r471594_fix">Update the system to a supported release or service pack level.</xccdf:fixtext>
           <xccdf:fix id="F-27104r471594_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4538" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4538" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225441">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225441r819688_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225441r890492_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-PK-000001</xccdf:version>
           <xccdf:title>The DoD Root CA certificates must be installed in the Trusted Root Store.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6863,23 +6826,23 @@ Satisfies: SRG-OS-000042-GPOS-00021&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;
           <xccdf:ident system="http://cyber.mil/legacy">SV-52961</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-32272</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-27128r819687_fix">Install the DoD Root CA certificates:
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
+          <xccdf:fixtext fixref="F-27128r890491_fix">Install the DoD Root CA certificates:
 DoD Root CA 3
 DoD Root CA 4
 DoD Root CA 5
 
-The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-27128r819687_fix" />
+The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-27128r890491_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4837" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4837" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225442">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225442r819691_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225442r894333_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-PK-000003</xccdf:version>
           <xccdf:title>The DoD Interoperability Root CA cross-certificates must be installed into the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6893,24 +6856,23 @@ The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke
           <xccdf:ident system="http://cyber.mil/legacy">V-32274</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-52957</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-27129r819690_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
+          <xccdf:fixtext fixref="F-27129r890494_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
 
 Issued To - Issued By - Thumbprint
 DoD Root CA 3 - DoD Interoperability Root CA 2 - 49CBE933151872E17C8EAE7F0ABA97FB610F6477
-DoD Root CA 3 - DoD Interoperability Root CA 2 - AC06108CA348CC03B53795C64BF84403C1DBD341
 
-The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-27129r819690_fix" />
+The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-27129r890494_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4838" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4838" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225443">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225443r569252_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225443r894336_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-PK-000004</xccdf:version>
           <xccdf:title>The US DoD CCEB Interoperability Root CA cross-certificates must be installed into the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6925,22 +6887,22 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:ident system="http://cyber.mil/legacy">V-40237</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
-          <xccdf:fixtext fixref="F-27130r603175_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
+          <xccdf:fixtext fixref="F-27130r894335_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
 
 Issued To - Issued By - Thumbprint
-DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2 - AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9
+DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2 - 9B74964506C7ED9138070D08D5F8B969866560C8
 
-The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-27130r603175_fix" />
+The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-27130r894335_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4839" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4839" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225444">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225444r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225444r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-RG-000001</xccdf:version>
           <xccdf:title>Standard user accounts must only have Read permissions to the Winlogon registry key.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Permissions on the Winlogon registry key must only allow privileged accounts to change registry values.  If standard users have these permissions, there is a potential for programs to run with elevated privileges when a privileged user logs on to the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6971,14 +6933,14 @@ Users - Read
 ALL APPLICATION PACKAGES - Read</xccdf:fixtext>
           <xccdf:fix id="F-27131r471675_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5176" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5176" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225445">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225445r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225445r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-RG-000002</xccdf:version>
           <xccdf:title>Standard user accounts must only have Read permissions to the Active Setup\Installed Components registry key.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Permissions on the Active Setup\Installed Components registry key must only allow privileged accounts to add or change registry values.  If standard user accounts have these permissions, there is a potential for programs to run with elevated privileges when a privileged user logs on to the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6995,7 +6957,7 @@ ALL APPLICATION PACKAGES - Read</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27132r471678_fix">Maintain the default permissions of the following registry keys:
 HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Active Setup\Installed Components\
 HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Active Setup\Installed Components\ (64-bit systems only)
- 
+
 Users - Read
 Administrators - Full Control
 SYSTEM - Full Control
@@ -7003,7 +6965,7 @@ CREATOR OWNER - Full Control (Subkeys only)
 ALL APPLICATION PACKAGES - Read</xccdf:fixtext>
           <xccdf:fix id="F-27132r471678_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5175" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5175" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7013,7 +6975,7 @@ ALL APPLICATION PACKAGES - Read</xccdf:fixtext>
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225446r569185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-RG-000003-MS</xccdf:version>
           <xccdf:title>Local administrator accounts must have their privileged token filtered to prevent elevated privileges from being used over the network on domain systems.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;A compromised local administrator account can provide means for an attacker to move laterally between domain systems.  
+          <xccdf:description>&lt;VulnDiscussion&gt;A compromised local administrator account can provide means for an attacker to move laterally between domain systems.
 
 With User Account Control enabled, filtering the privileged token for local administrator accounts will prevent the elevated privileges of these accounts from being used over the network.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -7031,14 +6993,14 @@ With User Account Control enabled, filtering the privileged token for local admi
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-27133r471681_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4694" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4694" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225447">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225447r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225447r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-RG-000004</xccdf:version>
           <xccdf:title>Anonymous access to the registry must be restricted.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The registry is integral to the function, security, and stability of the Windows system.  Some processes may require anonymous access to the registry.  This must be limited to properly protect the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7066,7 +7028,7 @@ Backup Operators - Read - This key only
 LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fix id="F-27134r471684_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5196" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5196" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7092,7 +7054,7 @@ LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fix id="F-27135r471687_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_guest_account_status_var" export-name="oval:mil.disa.fso.windows:var:453901" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4539" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4539" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7118,7 +7080,7 @@ LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fix id="F-27136r471690_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_limit_blank_password_use_var" export-name="oval:mil.disa.fso.windows:var:454000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4540" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4540" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7143,7 +7105,7 @@ LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27137r471693_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Accounts: Rename administrator account" to a name other than "Administrator".</xccdf:fixtext>
           <xccdf:fix id="F-27137r471693_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4541" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4541" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7168,7 +7130,7 @@ LOCAL SERVICE - Read - This key and subkeys</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27138r471696_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Accounts: Rename guest account" to a name other than "Guest".</xccdf:fixtext>
           <xccdf:fix id="F-27138r471696_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4542" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4542" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7195,7 +7157,7 @@ This setting prevents the system from setting up a default system access control
           <xccdf:fix id="F-27139r471699_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_audit_access_global_system_objects_var" export-name="oval:mil.disa.fso.windows:var:454300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4543" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4543" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7205,7 +7167,7 @@ This setting prevents the system from setting up a default system access control
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225453r569185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000008</xccdf:version>
           <xccdf:title>Auditing of Backup and Restore Privileges must be turned off.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
 This setting prevents the system from generating audit events for every file backed up or restored, which could fill the security log in Windows, making it difficult to identify actual issues.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -7222,7 +7184,7 @@ This setting prevents the system from generating audit events for every file bac
           <xccdf:fix id="F-27140r471702_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_audit_use_backup_restore_privilege_var" export-name="oval:mil.disa.fso.windows:var:454400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4544" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4544" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7232,7 +7194,7 @@ This setting prevents the system from generating audit events for every file bac
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225454r569185_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000009</xccdf:version>
           <xccdf:title>Audit policy using subcategories must be enabled.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.  
+          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks.  Audit logs are necessary to provide a trail of evidence in case the system or network is compromised.  Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
 This setting allows administrators to enable more precise auditing capabilities.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2012-2012 R2 MS</dc:title>
@@ -7249,7 +7211,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27141r471705_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_override_audit_policy_settings_var" export-name="oval:mil.disa.fso.windows:var:454500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4545" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4545" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7275,14 +7237,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27142r471708_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_format_eject_removable_media_var" export-name="oval:mil.disa.fso.windows:var:454600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4546" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4546" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225456">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225456r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225456r852245_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000012</xccdf:version>
           <xccdf:title>Outgoing secure channel traffic must be encrypted or signed.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted.  If this policy is enabled, outgoing secure channel traffic will be encrypted and signed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7302,14 +7264,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27143r471711_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_encrypt_or_sign_secure_channel_data_always_var" export-name="oval:mil.disa.fso.windows:var:454700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4547" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4547" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225457">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225457r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225457r852246_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000013</xccdf:version>
           <xccdf:title>Outgoing secure channel traffic must be encrypted when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted.  If this policy is enabled, outgoing secure channel traffic will be encrypted.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7329,14 +7291,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27144r471714_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_encrypt_secure_channel_data_when_possible_var" export-name="oval:mil.disa.fso.windows:var:454800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4548" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4548" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225458">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225458r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225458r852247_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000014</xccdf:version>
           <xccdf:title>Outgoing secure channel traffic must be signed when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but the channel is not integrity checked.  If this policy is enabled, outgoing secure channel traffic will be signed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7356,7 +7318,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27145r471717_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_secure_channel_data_when_possible_var" export-name="oval:mil.disa.fso.windows:var:454900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4549" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4549" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7382,7 +7344,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27146r471720_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_disable_machine_account_password_changes_var" export-name="oval:mil.disa.fso.windows:var:455000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4550" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4550" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7408,14 +7370,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27147r471723_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_machine_account_password_age_var" export-name="oval:mil.disa.fso.windows:var:455100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4551" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4551" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225461">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225461r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225461r852248_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000017</xccdf:version>
           <xccdf:title>The system must be configured to require a strong session key.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A computer connecting to a domain controller will establish a secure channel.  Requiring strong session keys enforces 128-bit encryption between systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7435,7 +7397,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27148r471726_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_strong_session_key_var" export-name="oval:mil.disa.fso.windows:var:455200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4552" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4552" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7461,7 +7423,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27149r471729_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_display_last_user_name_var" export-name="oval:mil.disa.fso.windows:var:455300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4553" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4553" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7487,7 +7449,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fix id="F-27150r471732_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_require_ctrlaltdel_var" export-name="oval:mil.disa.fso.windows:var:455400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4554" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4554" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7512,7 +7474,7 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fixtext fixref="F-27151r471735_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Interactive logon: Machine inactivity limit" to "900" seconds" or less, excluding "0" which is effectively disabled.</xccdf:fixtext>
           <xccdf:fix id="F-27151r471735_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4988" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4988" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7539,7 +7501,7 @@ This setting allows administrators to enable more precise auditing capabilities.
 Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive Logon: Number of previous logons to cache (in case Domain Controller is not available)" to "4" logons or less.</xccdf:fixtext>
           <xccdf:fix id="F-27154r471744_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4616" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4616" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7565,7 +7527,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27155r471747_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prompt_user_to_change_password_before_expiration_var" export-name="oval:mil.disa.fso.windows:var:455500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4555" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4555" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7590,14 +7552,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-27156r471750_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Interactive logon: Smart card removal behavior" to  "Lock Workstation" or "Force Logoff".</xccdf:fixtext>
           <xccdf:fix id="F-27156r471750_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4556" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4556" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225470">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225470r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225470r852249_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000028</xccdf:version>
           <xccdf:title>The Windows SMB client must be configured to always perform SMB packet signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.  Digitally signed SMB packets aid in preventing man-in-the-middle attacks.  If this policy is enabled, the SMB client will only communicate with an SMB server that performs SMB packet signing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7617,14 +7579,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27157r471753_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_client_always_var" export-name="oval:mil.disa.fso.windows:var:455700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4557" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4557" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225471">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225471r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225471r852250_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000029</xccdf:version>
           <xccdf:title>The Windows SMB client must be enabled to perform SMB packet signing when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.   If this policy is enabled, the SMB client will request packet signing when communicating with an SMB server that is enabled or required to perform SMB packet signing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7644,14 +7606,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27158r471756_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_client_server_agrees_var" export-name="oval:mil.disa.fso.windows:var:455800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4558" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4558" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225472">
         <xccdf:title>SRG-OS-000074-GPOS-00042</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225472r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225472r877396_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000030</xccdf:version>
           <xccdf:title>Unencrypted passwords must not be sent to third-party SMB Servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Some non-Microsoft SMB servers only support unencrypted (plain text) password authentication.  Sending plain text passwords across the network, when authenticating to an SMB server, reduces the overall security of the environment.  Check with the vendor of the SMB server to see if there is a way to support encrypted password authentication.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7670,14 +7632,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27159r471759_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_send_unencrypted_password_to_third_party_smb_servers_var" export-name="oval:mil.disa.fso.windows:var:455900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4559" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4559" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225473">
         <xccdf:title>SRG-OS-000163-GPOS-00072</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225473r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225473r852251_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000031</xccdf:version>
           <xccdf:title>The amount of idle time required before suspending a session must be properly set.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Open sessions can increase the avenues of attack on a system.  This setting is used to control when a computer disconnects an inactive SMB session.  If client activity resumes, the session is automatically reestablished.  This protects critical and sensitive network data from exposure to unauthorized personnel with physical access to the computer.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7697,14 +7659,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27160r471762_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_amount_of_idle_time_required_before_suspending_session_var" export-name="oval:mil.disa.fso.windows:var:456000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4560" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4560" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225474">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225474r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225474r852252_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000032</xccdf:version>
           <xccdf:title>The Windows SMB server must be configured to always perform SMB packet signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.  Digitally signed SMB packets aid in preventing man-in-the-middle attacks.  If this policy is enabled, the SMB server will only communicate with an SMB client that performs SMB packet signing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7724,14 +7686,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27161r471765_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_server_always_var" export-name="oval:mil.disa.fso.windows:var:456100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4561" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4561" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225475">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225475r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225475r852253_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000033</xccdf:version>
           <xccdf:title>The Windows SMB server must perform SMB packet signing when possible.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations.   Digitally signed SMB packets aid in preventing man-in-the-middle attacks.  If this policy is enabled, the SMB server will negotiate SMB packet signing as requested by the client.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7751,7 +7713,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27162r471768_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_digitally_sign_communications_server_client_agrees_var" export-name="oval:mil.disa.fso.windows:var:456200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4562" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4562" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7777,7 +7739,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27163r471771_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_disconnect_client_when_logon_hours_expire_var" export-name="oval:mil.disa.fso.windows:var:456300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4563" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4563" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7803,14 +7765,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fix id="F-27164r471774_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_microsoft_network_server_server_spn_target_name_validation_level_var" export-name="oval:mil.disa.fso.windows:var:456400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4564" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4564" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225478">
         <xccdf:title>SRG-OS-000480-GPOS-00229</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225478r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225478r877377_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000036</xccdf:version>
           <xccdf:title>Automatic logons must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing a system to automatically log on when the machine is booted could give access to any unauthorized individual who restarts the computer.  Automatic logon with administrator privileges would give full access to an unauthorized individual.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7839,7 +7801,7 @@ Value Name: DefaultPassword
 Severity Override Guidance: If the DefaultName or DefaultDomainName in the same registry path contain an administrator account name and the DefaultPassword contains a value, this is a CAT I finding.</xccdf:fixtext>
           <xccdf:fix id="F-27165r641828_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4565" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4565" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7867,7 +7829,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27166r471780_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_MSS_IPv6_source_routing_protection_level_var" export-name="oval:mil.disa.fso.windows:var:456600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4566" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4566" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7895,7 +7857,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27167r471783_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ip_source_routing_protection_level_var" export-name="oval:mil.disa.fso.windows:var:456700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4567" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4567" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7923,14 +7885,14 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27168r471786_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_icmp_redirects_var" export-name="oval:mil.disa.fso.windows:var:456800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4568" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4568" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225482">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225482r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225482r852254_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000041</xccdf:version>
           <xccdf:title>The system must be configured to limit how often keep-alive packets are sent.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting controls how often TCP sends a keep-alive packet in attempting to verify that an idle connection is still intact.  A higher value could allow an attacker to cause a denial of service with numerous connections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7951,7 +7913,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27169r471789_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_keep_alive_time_var" export-name="oval:mil.disa.fso.windows:var:456900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4569" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4569" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7979,14 +7941,14 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27170r471792_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_no_default_exempt_var" export-name="oval:mil.disa.fso.windows:var:457000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4570" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4570" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225484">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225484r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225484r852255_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000043</xccdf:version>
           <xccdf:title>The system must be configured to ignore NetBIOS name release requests except from WINS servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring the system to ignore name release requests, except from WINS servers, prevents a denial of service (DoS) attack.  The DoS consists of sending a NetBIOS name release request to the server for each entry in the server's cache, causing a response delay in the normal operation of the servers WINS resolution capability.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8001,20 +7963,20 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:ident system="http://cyber.mil/legacy">SV-52928</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-4116</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002385</xccdf:ident>
-          <xccdf:fixtext fixref="F-27171r471795_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers" to "Enabled".   
+          <xccdf:fixtext fixref="F-27171r471795_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers" to "Enabled".
 
 (See "Updating the Windows Security Options File" in the STIG Overview document if MSS settings are not visible in the system's policy tools.)</xccdf:fixtext>
           <xccdf:fix id="F-27171r471795_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_no_name_release_on_demand_var" export-name="oval:mil.disa.fso.windows:var:457100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4571" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4571" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225485">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225485r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225485r852256_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000044</xccdf:version>
           <xccdf:title>The system must be configured to disable the Internet Router Discovery Protocol (IRDP).</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The Internet Router Discovery Protocol (IRDP) is used to detect and configure default gateway addresses on the computer.  If a router is impersonated on a network, traffic could be routed through the compromised system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8035,7 +7997,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27172r471798_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_router_discovery_var" export-name="oval:mil.disa.fso.windows:var:457200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4572" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4572" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8063,7 +8025,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27173r471801_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_safe_dll_search_mode_var" export-name="oval:mil.disa.fso.windows:var:457300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4573" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4573" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8091,14 +8053,14 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27174r471804_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_screen_saver_grace_period_var" export-name="oval:mil.disa.fso.windows:var:457400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4574" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4574" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225488">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225488r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225488r852257_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000047</xccdf:version>
           <xccdf:title>IPv6 TCP data retransmissions must be configured to prevent resources from becoming exhausted.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring Windows to limit the number of times that IPv6 TCP retransmits unacknowledged data segments before aborting the attempt helps prevent resources from becoming exhausted.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8119,14 +8081,14 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27175r471807_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_MSS_tcp_max_data_retransmissions_ipv6_var" export-name="oval:mil.disa.fso.windows:var:457500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4575" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4575" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225489">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225489r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225489r852258_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000048</xccdf:version>
           <xccdf:title>The system must limit how many times unacknowledged TCP data is retransmitted.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;In a SYN flood attack, the attacker sends a continuous stream of SYN packets to a server, and the server leaves the half-open connections open until it is overwhelmed and is no longer able to respond to legitimate requests.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8141,20 +8103,20 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:ident system="http://cyber.mil/legacy">SV-52929</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-4438</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002385</xccdf:ident>
-          <xccdf:fixtext fixref="F-27176r471810_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "MSS: (TcpMaxDataRetransmissions) How many times unacknowledged data is retransmitted (3 recommended, 5 is default)" to "3" or less.   
+          <xccdf:fixtext fixref="F-27176r471810_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "MSS: (TcpMaxDataRetransmissions) How many times unacknowledged data is retransmitted (3 recommended, 5 is default)" to "3" or less.
 
 (See "Updating the Windows Security Options File" in the STIG Overview document if MSS settings are not visible in the system's policy tools.)</xccdf:fixtext>
           <xccdf:fix id="F-27176r471810_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_tcp_max_data_retransmissions_var" export-name="oval:mil.disa.fso.windows:var:457600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4576" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4576" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225490">
         <xccdf:title>SRG-OS-000046-GPOS-00022</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225490r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225490r852259_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000049</xccdf:version>
           <xccdf:title>The system must generate an audit event when the audit log reaches a percentage of full threshold.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;When the audit log reaches a given percent full, an audit event is written to the security log.  It is recorded as a successful audit event under the category of System.  This option may be especially useful if the audit logs are set to be cleared manually.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8177,7 +8139,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27177r471813_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_event_log_threshold_warning_var" export-name="oval:mil.disa.fso.windows:var:457700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4577" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4577" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8203,7 +8165,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27179r471819_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_anonymous_enumeration_sam_var" export-name="oval:mil.disa.fso.windows:var:457800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4578" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4578" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8229,7 +8191,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27180r471822_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_anonymous_enumeration_sam_accounts_shares_var" export-name="oval:mil.disa.fso.windows:var:457900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4579" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4579" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8255,7 +8217,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fix id="F-27181r471825_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_let_everyone_permissions_apply_to_anonymous_users_var" export-name="oval:mil.disa.fso.windows:var:458100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4581" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4581" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8280,7 +8242,7 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:fixtext fixref="F-27182r471828_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network access: Named pipes that can be accessed anonymously" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-27182r471828_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4715" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4715" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8304,12 +8266,12 @@ Severity Override Guidance: If the DefaultName or DefaultDomainName in the same 
           <xccdf:ident system="http://cyber.mil/cci">CCI-001090</xccdf:ident>
           <xccdf:fixtext fixref="F-27183r471831_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network access: Remotely accessible registry paths" with the following entries:
 
-System\CurrentControlSet\Control\ProductOptions 
-System\CurrentControlSet\Control\Server Applications 
+System\CurrentControlSet\Control\ProductOptions
+System\CurrentControlSet\Control\Server Applications
 Software\Microsoft\Windows NT\CurrentVersion</xccdf:fixtext>
           <xccdf:fix id="F-27183r471831_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4582" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4582" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8346,7 +8308,7 @@ System\CurrentControlSet\Services\Eventlog
 System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-27184r471834_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4583" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4583" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8372,7 +8334,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-27185r471837_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_restrict_anonymous_access_to_named_pipes_and_shares_var" export-name="oval:mil.disa.fso.windows:var:458400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4584" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4584" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8397,7 +8359,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27186r471840_fix">Ensure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network access: Shares that can be accessed anonymously" contains no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-27186r471840_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4585" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4585" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8423,7 +8385,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-27187r471843_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_sharing_and_security_model_for_local_accounts_var" export-name="oval:mil.disa.fso.windows:var:458600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4586" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4586" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8449,7 +8411,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-27188r471846_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_Network_security_Allow_Local_System_to_use_computer_identity_for_NTLM_var" export-name="oval:mil.disa.fso.windows:var:458700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4587" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4587" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8475,7 +8437,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-27189r471849_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_Network_security_Allow_LocalSystem_NULL_session_fallback_var" export-name="oval:mil.disa.fso.windows:var:458800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4588" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4588" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8501,7 +8463,7 @@ System\CurrentControlSet\Services\Sysmonlog</xccdf:fixtext>
           <xccdf:fix id="F-27190r471852_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_Network_Security_Allow_PKU2U_authentication_requests_to_this_computer_to_use_online_identities_var" export-name="oval:mil.disa.fso.windows:var:458900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4589" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4589" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8534,14 +8496,14 @@ Future encryption types
 Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have operational impacts and must be thoroughly tested for the environment before changing. This includes but is not limited to parent\child trusts where RC4 is still enabled; selecting "The other domain supports Kerberos AES Encryption" may be required on the domain trusts to allow client communication across the trust relationship.</xccdf:fixtext>
           <xccdf:fix id="F-27191r471855_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4590" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4590" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225505">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225505r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225505r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000065</xccdf:version>
           <xccdf:title>The system must be configured to prevent the storage of the LAN Manager hash of passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The LAN Manager hash uses a weak encryption algorithm and there are several tools available that use this hash to retrieve account passwords.  This setting controls whether or not a LAN Manager hash of the password is stored in the SAM the next time the password is changed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8560,7 +8522,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-27192r471858_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_store_lan_manager_hash_value_on_next_password_change_var" export-name="oval:mil.disa.fso.windows:var:459100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4591" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4591" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8586,7 +8548,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-27193r471861_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_force_logoff_when_logon_hours_expire_var" export-name="oval:mil.disa.fso.windows:var:459200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4592" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4592" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8612,7 +8574,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-27194r471864_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_lan_manager_authentication_level_var" export-name="oval:mil.disa.fso.windows:var:459300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4593" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4593" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8638,7 +8600,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-27195r471867_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ldap_client_signing_requirements_var" export-name="oval:mil.disa.fso.windows:var:459400" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4594" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4594" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8663,7 +8625,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fixtext fixref="F-27196r471870_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) clients" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-27196r471870_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4595" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4595" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8688,7 +8650,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fixtext fixref="F-27197r471873_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) servers" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-27197r471873_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4596" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4596" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8714,14 +8676,14 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-27198r471876_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_shutdown_allow_system_shutdown_without_having_logon_var" export-name="oval:mil.disa.fso.windows:var:459900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4599" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4599" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225512">
         <xccdf:title>SRG-OS-000396-GPOS-00176</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225512r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225512r877380_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000074</xccdf:version>
           <xccdf:title>The system must be configured to use FIPS-compliant algorithms for encryption, hashing, and signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting ensures that the system uses algorithms that are FIPS-compliant for encryption, hashing, and signing.  FIPS-compliant algorithms meet specific standards established by the U.S. Government and must be the algorithms used for all OS encryption functions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8740,7 +8702,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-27199r471879_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_system_cryptography_use_fips_compliant_alorithm_var" export-name="oval:mil.disa.fso.windows:var:460000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4600" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4600" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8766,7 +8728,7 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-27200r471882_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_system_objects_require_case_insensitivity_var" export-name="oval:mil.disa.fso.windows:var:460100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4601" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4601" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8792,14 +8754,14 @@ Note: Removing the previously allowed RC4_HMAC_MD5 encryption suite may have ope
           <xccdf:fix id="F-27201r471885_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_system_objects_strengthen_default_permissions_internal_system_objects_var" export-name="oval:mil.disa.fso.windows:var:460200" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4602" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4602" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225515">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225515r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225515r852261_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000077</xccdf:version>
           <xccdf:title>User Account Control approval mode for the built-in Administrator must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized.  This setting configures the built-in Administrator account so that it runs in Admin Approval Mode.
@@ -8822,7 +8784,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-27202r471888_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_admin_approval_mode_var" export-name="oval:mil.disa.fso.windows:var:460300" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4603" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4603" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8851,14 +8813,14 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
 More secure options for this setting would also be acceptable (e.g., Prompt for credentials, Prompt for consent (or credentials) on the secure desktop).</xccdf:fixtext>
           <xccdf:fix id="F-27203r471891_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4604" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4604" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225517">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225517r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225517r852262_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000079</xccdf:version>
           <xccdf:title>User Account Control must automatically deny standard user requests for elevation.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized.  This setting controls the behavior of elevation when requested by a standard user account.
@@ -8881,7 +8843,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-27204r471894_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_behavior_elevation_prompt_standard_users_var" export-name="oval:mil.disa.fso.windows:var:460500" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4605" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4605" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8909,7 +8871,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-27205r471897_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_detect_application_installations_prompt_elevation_var" export-name="oval:mil.disa.fso.windows:var:460600" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4606" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4606" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8937,7 +8899,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-27206r471900_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_only_elevate_executables_signed_validated_var" export-name="oval:mil.disa.fso.windows:var:460700" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4607" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4607" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8965,14 +8927,14 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-27207r471903_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_only_elevate_uiaccess_applications_var" export-name="oval:mil.disa.fso.windows:var:460800" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4608" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4608" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225521">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225521r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225521r852263_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000083</xccdf:version>
           <xccdf:title>User Account Control must run all administrators in Admin Approval Mode, enabling UAC.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized.  This setting enables UAC.
@@ -8995,7 +8957,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-27208r471906_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_run_administrators_admin_approval_mode_var" export-name="oval:mil.disa.fso.windows:var:460900" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4609" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4609" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9023,7 +8985,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-27209r471909_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_switch_secure_desktop_prompting_elevation_var" export-name="oval:mil.disa.fso.windows:var:461000" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4610" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4610" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9051,7 +9013,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fix id="F-27210r471912_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_virtualize_write_failures_per_user_locations_var" export-name="oval:mil.disa.fso.windows:var:461100" />
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4611" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4611" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9078,7 +9040,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
 Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "User Account Control: Allow UIAccess applications to prompt for elevation without using the secure desktop" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-27211r471915_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4627" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4627" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9103,14 +9065,14 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fixtext fixref="F-27212r471918_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "System settings: Optional subsystems" to "Blank" (Configured with no entries).</xccdf:fixtext>
           <xccdf:fix id="F-27212r471918_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4621" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4621" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225526">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225526r569185_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225526r852264_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-SO-000089</xccdf:version>
           <xccdf:title>The print driver installation privilege must be restricted to administrators.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing users to install drivers can introduce malware or cause the instability of a system.  Print driver installation should be restricted to administrators.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -9128,7 +9090,7 @@ Configure the policy value for Computer Configuration -&gt; Windows Settings -&g
           <xccdf:fixtext fixref="F-27213r471921_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; Security Options -&gt; "Devices: Prevent users from installing printer drivers" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-27213r471921_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4618" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4618" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9158,7 +9120,7 @@ Both the holders of a digital certificate and the issuing authority must protect
           <xccdf:fixtext fixref="F-27214r471924_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "System cryptography: Force strong key protection for user keys stored on the computer" to "User must enter a password each time they use a key".</xccdf:fixtext>
           <xccdf:fix id="F-27214r471924_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4973" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4973" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9183,7 +9145,7 @@ Both the holders of a digital certificate and the issuing authority must protect
           <xccdf:fixtext fixref="F-27215r471927_fix">Remove or disable the Fax (fax) service.</xccdf:fixtext>
           <xccdf:fix id="F-27215r471927_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4731" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4731" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9205,7 +9167,7 @@ Both the holders of a digital certificate and the issuing authority must protect
           <xccdf:ident system="http://cyber.mil/legacy">V-26602</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-52237</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000382</xccdf:ident>
-          <xccdf:fixtext fixref="F-27216r471930_fix">Remove or disable the "Microsoft FTP Service" (Service name: FTPSVC).   
+          <xccdf:fixtext fixref="F-27216r471930_fix">Remove or disable the "Microsoft FTP Service" (Service name: FTPSVC).
 
 To remove the "FTP Server" role from a system:
 Start "Server Manager"
@@ -9217,7 +9179,7 @@ De-select "FTP Server" under "Web Server (IIS).
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-27216r471930_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4732" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4732" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9242,7 +9204,7 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27217r471933_fix">Remove or disable the Peer Networking Identity Manager (p2pimsvc) service.</xccdf:fixtext>
           <xccdf:fix id="F-27217r471933_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4733" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4733" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9267,7 +9229,7 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27218r471936_fix">Remove or disable the Simple TCP/IP Services (simptcp) service.</xccdf:fixtext>
           <xccdf:fix id="F-27218r471936_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4734" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4734" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9292,7 +9254,7 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27219r471939_fix">Remove or disable the Telnet (tlntsvr) service.</xccdf:fixtext>
           <xccdf:fix id="F-27219r471939_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4735" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4735" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9317,14 +9279,14 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-27220r471942_fix">Configure the Startup Type for the Smart Card Removal Policy service to "Automatic".</xccdf:fixtext>
           <xccdf:fix id="F-27220r471942_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4736" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4736" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225545">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225545r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225545r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000001</xccdf:version>
           <xccdf:title>The Access Credential Manager as a trusted caller user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9344,7 +9306,7 @@ Accounts with the "Access Credential Manager as a trusted caller" user right may
           <xccdf:fixtext fixref="F-27232r471978_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Access Credential Manager as a trusted caller" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-27232r471978_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4987" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4987" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9374,14 +9336,14 @@ Administrators
 Authenticated Users</xccdf:fixtext>
           <xccdf:fix id="F-27233r471981_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4716" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4716" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225547">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225547r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225547r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000003</xccdf:version>
           <xccdf:title>The Act as part of the operating system user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9401,7 +9363,7 @@ Accounts with the "Act as part of the operating system" user right can assume th
           <xccdf:fixtext fixref="F-27234r471984_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Act as part of the operating system" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-27234r471984_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4617" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4617" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9430,7 +9392,7 @@ Accounts with the "Allow log on locally" user right can log on interactively to 
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27235r471987_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4636" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4636" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9456,21 +9418,21 @@ Accounts with the "Allow log on through Remote Desktop Services" user right can 
           <xccdf:ident system="http://cyber.mil/cci">CCI-000213</xccdf:ident>
           <xccdf:fixtext fixref="F-27236r471990_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Allow log on through Remote Desktop Services" to only include the following accounts or groups:
 
-Administrators   
+Administrators
 
-If the system serves the Remote Desktop Services role, the Remote Desktop Users group or another more restrictive group may be included.  
+If the system serves the Remote Desktop Services role, the Remote Desktop Users group or another more restrictive group may be included.
 
 Organizations may grant this to other groups, such as more restrictive groups with administrative or management functions, if required.  Remote Desktop Services access must be restricted to the accounts that require it.  This must be documented with the ISSO.</xccdf:fixtext>
           <xccdf:fix id="F-27236r471990_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5145" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:5145" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225550">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225550r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225550r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000007</xccdf:version>
           <xccdf:title>The Back up files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9492,14 +9454,14 @@ Accounts with the "Back up files and directories" user right can circumvent file
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27237r471993_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4638" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4638" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225551">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225551r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225551r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000011</xccdf:version>
           <xccdf:title>The Create a pagefile user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9521,14 +9483,14 @@ Accounts with the "Create a pagefile" user right can change the size of a pagefi
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27238r471996_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4642" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4642" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225552">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225552r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225552r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000012</xccdf:version>
           <xccdf:title>The Create a token object user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9548,14 +9510,14 @@ The "Create a token object" user right allows a process to create an access toke
           <xccdf:fixtext fixref="F-27239r471999_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create a token object" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-27239r471999_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4643" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4643" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225553">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225553r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225553r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000013</xccdf:version>
           <xccdf:title>The Create global objects user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9580,14 +9542,14 @@ Local Service
 Network Service</xccdf:fixtext>
           <xccdf:fix id="F-27240r472002_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4644" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4644" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225554">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225554r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225554r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000014</xccdf:version>
           <xccdf:title>The Create permanent shared objects user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9607,14 +9569,14 @@ Accounts with the "Create permanent shared objects" user right could expose sens
           <xccdf:fixtext fixref="F-27241r472005_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create permanent shared objects" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-27241r472005_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4645" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4645" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225555">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225555r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225555r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000015</xccdf:version>
           <xccdf:title>The Create symbolic links user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9638,14 +9600,14 @@ Administrators
 Systems that have the Hyper-V role will also have "Virtual Machines" given this user right.  If this needs to be added manually, enter it as "NT Virtual Machine\Virtual Machines".</xccdf:fixtext>
           <xccdf:fix id="F-27242r472008_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4646" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4646" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225556">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225556r569185_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225556r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000016</xccdf:version>
           <xccdf:title>The Debug programs user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9667,7 +9629,7 @@ Accounts with the "Debug programs" user right can attach a debugger to any proce
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27243r472011_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4633" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4633" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9711,7 +9673,7 @@ Note: Windows Server 2012 R2 added new built-in security groups, "Local account"
 Microsoft Security Advisory Patch 2871997 adds the new security groups to Windows Server 2012.</xccdf:fixtext>
           <xccdf:fix id="F-27244r472014_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4840" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4840" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9723,7 +9685,7 @@ Microsoft Security Advisory Patch 2871997 adds the new security groups to Window
           <xccdf:title>The Deny log on as a batch job user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems, and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
-The "Deny log on as a batch job" user right defines accounts that are prevented from logging on to the system as a batch job such, as Task Scheduler.  
+The "Deny log on as a batch job" user right defines accounts that are prevented from logging on to the system as a batch job such, as Task Scheduler.
 
 In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower-trust systems helps mitigate the risk of privilege escalation from credential theft attacks which could lead to the compromise of an entire domain.
 
@@ -9749,7 +9711,7 @@ All Systems:
 Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-27245r472017_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4717" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4717" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9761,7 +9723,7 @@ Guests Group</xccdf:fixtext>
           <xccdf:title>The Deny log on as a service user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems.  No other groups or accounts must be assigned this right.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
-The "Deny log on as a service" user right defines accounts that are denied log on as a service.  
+The "Deny log on as a service" user right defines accounts that are denied log on as a service.
 
 In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower-trust systems helps mitigate the risk of privilege escalation from credential theft attacks which could lead to the compromise of an entire domain.
 
@@ -9785,7 +9747,7 @@ Domain Admins Group
 Configure the "Deny log on as a service" for nondomain systems to include no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-27246r472020_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4718" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4718" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9797,7 +9759,7 @@ Configure the "Deny log on as a service" for nondomain systems to include no ent
           <xccdf:title>The Deny log on locally user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems, and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
-The "Deny log on locally" user right defines accounts that are prevented from logging on interactively.  
+The "Deny log on locally" user right defines accounts that are prevented from logging on interactively.
 
 In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower-trust systems helps mitigate the risk of privilege escalation from credential theft attacks which could lead to the compromise of an entire domain.
 
@@ -9823,7 +9785,7 @@ All Systems:
 Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-27247r472023_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4719" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4719" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -9863,18 +9825,18 @@ Local account (see Note below)
 All Systems:
 Guests group
 
-Note: Windows Server 2012 R2 added new built-in security groups, including "Local account", for assigning permissions and rights to all local accounts. 
+Note: Windows Server 2012 R2 added new built-in security groups, including "Local account", for assigning permissions and rights to all local accounts.
 Microsoft Security Advisory Patch 2871997 adds the new security groups to Windows Server 2012.</xccdf:fixtext>
           <xccdf:fix id="F-27248r472026_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4882" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4882" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225562">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225562r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225562r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000022-MS</xccdf:version>
           <xccdf:title>Unauthorized accounts must not have the Enable computer and user accounts to be trusted for delegation user right on member servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9894,14 +9856,14 @@ The "Enable computer and user accounts to be trusted for delegation" user right 
           <xccdf:fixtext fixref="F-27249r472029_fix">Configure the policy value for Computer Configuration -&gt; Windows Settings -&gt; Security Settings -&gt; Local Policies -&gt; User Rights Assignment -&gt; "Enable computer and user accounts to be trusted for delegation" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-27249r472029_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4739" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4739" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225563">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225563r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225563r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000023</xccdf:version>
           <xccdf:title>The Force shutdown from a remote system user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9923,14 +9885,14 @@ Accounts with the "Force shutdown from a remote system" user right can remotely 
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27250r472032_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4647" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4647" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225564">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225564r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225564r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000024</xccdf:version>
           <xccdf:title>The Generate security audits user right must only be assigned to Local Service and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9953,14 +9915,14 @@ Local Service
 Network Service</xccdf:fixtext>
           <xccdf:fix id="F-27251r472035_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4648" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4648" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225565">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225565r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225565r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000025</xccdf:version>
           <xccdf:title>The Impersonate a client after authentication user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -9985,14 +9947,14 @@ Local Service
 Network Service</xccdf:fixtext>
           <xccdf:fix id="F-27252r472038_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4649" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4649" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225566">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225566r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225566r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000027</xccdf:version>
           <xccdf:title>The Increase scheduling priority user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10014,14 +9976,14 @@ Accounts with the "Increase scheduling priority" user right can change a schedul
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27253r472041_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4651" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4651" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225567">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225567r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225567r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000028</xccdf:version>
           <xccdf:title>The Load and unload device drivers user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10043,14 +10005,14 @@ The "Load and unload device drivers" user right allows device drivers to dynamic
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27254r472044_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4652" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4652" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225568">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225568r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225568r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000029</xccdf:version>
           <xccdf:title>The Lock pages in memory user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10070,14 +10032,14 @@ The "Lock pages in memory" user right allows physical memory to be assigned to p
           <xccdf:fixtext fixref="F-27255r472047_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Lock pages in memory" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-27255r472047_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4653" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4653" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225569">
         <xccdf:title>SRG-OS-000057-GPOS-00027</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225569r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225569r852282_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000032</xccdf:version>
           <xccdf:title>The Manage auditing and security log user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10103,14 +10065,14 @@ Accounts with the "Manage auditing and security log" user right can manage the s
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27256r472050_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4990" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4990" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225570">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225570r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225570r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000034</xccdf:version>
           <xccdf:title>The Modify firmware environment values user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10132,14 +10094,14 @@ Accounts with the "Modify firmware environment values" user right can change har
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27257r472053_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4656" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4656" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225571">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225571r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225571r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000035</xccdf:version>
           <xccdf:title>The Perform volume maintenance tasks user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10161,14 +10123,14 @@ Accounts with the "Perform volume maintenance tasks" user right can manage volum
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27258r472056_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4657" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4657" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225572">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225572r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225572r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000036</xccdf:version>
           <xccdf:title>The Profile single process user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10190,14 +10152,14 @@ Accounts with the "Profile single process" user right can monitor nonsystem proc
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27259r472059_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4658" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4658" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225573">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225573r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225573r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000040</xccdf:version>
           <xccdf:title>The Restore files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10219,14 +10181,14 @@ Accounts with the "Restore files and directories" user right can circumvent file
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27260r472062_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4661" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4661" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225574">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225574r569185_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225574r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN12-UR-000042</xccdf:version>
           <xccdf:title>The Take ownership of files or other objects user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -10248,18 +10210,18 @@ Accounts with the "Take ownership of files or other objects" user right can take
 Administrators</xccdf:fixtext>
           <xccdf:fix id="F-27261r472065_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4663" href="U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.fso.windows:def:4663" href="U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
     </xccdf:Benchmark>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2022-05-01T21:45:45">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2023-03-28T17:41:20">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-05-01T21:45:44</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:20</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.windows:def:4422" version="3" class="compliance">
@@ -13590,7 +13552,7 @@ Administrators</xccdf:fixtext>
             <criterion test_ref="oval:mil.disa.fso.windows:tst:474000" comment="Access Credential Manager as a trusted caller - None" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4837" version="5" class="compliance">
+        <definition id="oval:mil.disa.fso.windows:def:4837" version="6" class="compliance">
           <metadata>
             <title>WN12-PK-000001 - The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
             <affected family="windows">
@@ -13599,11 +13561,11 @@ Administrators</xccdf:fixtext>
             <reference source="DISA" ref_id="32272" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
             <description>To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.</description>
           </metadata>
-          <criteria operator="AND">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:4200" comment="Verifies the DoD Root CA certificates are installed in the Trusted Root Store." />
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253427" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4838" version="5" class="compliance">
+        <definition id="oval:mil.disa.fso.windows:def:4838" version="6" class="compliance">
           <metadata>
             <title>WN12-PK-000003 - The DoD Interoperability Root CA cross-certificates must be installed into the Untrusted Certificates Store on unclassified systems</title>
             <affected family="windows">
@@ -13612,12 +13574,11 @@ Administrators</xccdf:fixtext>
             <reference source="DISA" ref_id="32274" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
             <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
           </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:483800" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:483801" comment="DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" />
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253429" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4839" version="5" class="compliance">
+        <definition id="oval:mil.disa.fso.windows:def:4839" version="6" class="compliance">
           <metadata>
             <title>WN12-PK-000004 - The US DoD CCEB Interoperability Root CA cross-certificates must be installed into the Untrusted Certificates Store on unclassified systems</title>
             <affected family="windows">
@@ -13627,7 +13588,7 @@ Administrators</xccdf:fixtext>
             <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
           </metadata>
           <criteria>
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:483900" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" />
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253430" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.fso.windows:def:4840" version="1" class="compliance">
@@ -14051,18 +14012,6 @@ Administrators</xccdf:fixtext>
             <criterion test_ref="oval:mil.disa.fso.windows:tst:518100" comment="Verifies 'Include command line in process creation events' is set to 'Enabled'" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:5182" version="1" class="compliance">
-          <metadata>
-            <title>WN12-AU-000030</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-            </affected>
-            <description>Windows Server 2012/2012 R2 must be configured to audit Logon/Logoff - Account Lockout successes.</description>
-          </metadata>
-          <criteria operator="OR" comment="Audit - Account Lockout - Success">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:119" comment="Is Audit - Logon/Logoff - Account Lockout set to audit successes" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.fso.windows:def:5183" version="1" class="compliance">
           <metadata>
             <title>WN12-AU-000031</title>
@@ -14163,18 +14112,33 @@ Administrators</xccdf:fixtext>
             </criteria>
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:119" version="1" class="compliance">
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253427" version="1">
           <metadata>
-            <title>WN10-AU-000055</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The system must be configured to audit Logon/Logoff - Account Lockout successes.</description>
+            <title>The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
+            <description />
           </metadata>
-          <criteria operator="OR" comment="Audit - Special Logon - Success">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:11900" comment="Audit - Account Lockout - Success only" />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:11901" comment="Audit - Account Lockout - Success and Failure" />
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342700" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342701" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342702" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253429" version="3">
+          <metadata>
+            <title>The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342900" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253430" version="2">
+          <metadata>
+            <title>The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25343000" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:147" version="1" class="compliance">
@@ -14189,22 +14153,6 @@ Administrators</xccdf:fixtext>
           <criteria operator="OR" comment="Audit - Special Logon - Success">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:14700" comment="Audit - Account Lockout - Failure only" />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:11901" comment="Audit - Account Lockout - Success and Failure" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:4200" version="2" class="compliance">
-          <metadata>
-            <title>DoD Root CA Certificates</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The DoD Root CA certificates must be installed in the Trusted Root Store.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420001" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420002" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420003" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:4202" version="1" class="compliance">
@@ -15364,15 +15312,6 @@ Administrators</xccdf:fixtext>
           <object object_ref="oval:mil.disa.fso.windows:obj:461700" />
           <state state_ref="oval:mil.disa.fso.windows:ste:474000" />
         </accesstoken_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:483800" version="4" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.fso.windows:obj:483800" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:483801" version="3" comment="DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.fso.windows:obj:483805" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:483900" version="2" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.fso.windows:obj:483900" />
-        </registry_test>
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:484000" version="2" comment="Deny access to this computer from the network - Domain Admins" check="at least one">
           <object object_ref="oval:mil.disa.fso.windows:obj:472100" />
           <state state_ref="oval:mil.disa.fso.windows:ste:469500" />
@@ -15554,10 +15493,21 @@ Administrators</xccdf:fixtext>
         <regkeyeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:519604" version="1" check="all" check_existence="none_exist" comment="Winreg key has no non-admin rights to check">
           <object object_ref="oval:mil.disa.fso.windows:obj:519603" />
         </regkeyeffectiverights53_test>
-        <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11900" version="1" comment="'Audit Account Lockout' is set to 'Success'" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:11900" />
-        </auditeventpolicysubcategories_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342700" version="2" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342700" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342701" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342705" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342702" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342710" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342900" version="2" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342900" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25343000" version="2" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25343000" />
+        </registry_test>
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11901" version="1" comment="'Audit Account Lockout' is set to 'Success' and 'Failure'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
           <state state_ref="oval:mil.disa.stig.windows:ste:11901" />
@@ -15566,15 +15516,6 @@ Administrators</xccdf:fixtext>
           <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
           <state state_ref="oval:mil.disa.stig.windows:ste:14700" />
         </auditeventpolicysubcategories_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420001" version="1" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420005" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420002" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420010" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420003" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420015" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420200" version="1" comment="'Interactive logon: Machine inactivity limit' is set to '900' seconds or less" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:420200" />
           <state state_ref="oval:mil.disa.stig.windows:ste:420200" />
@@ -16564,87 +16505,6 @@ Administrators</xccdf:fixtext>
           <namespace datatype="string">root\cimv2</namespace>
           <wql datatype="string">SELECT startmode FROM Win32_Service WHERE name='SCPolicySvc'</wql>
         </wmi_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483800" version="3">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483801</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483804</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483801" version="3">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483802</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483803</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483802" version="4">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483803" version="4">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483804" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483805" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483806</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483809</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483806" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483807</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483808</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483807" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483808" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483809" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483900" version="2">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483901</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483904</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483901" version="2">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:483902</object_reference>
-            <object_reference>oval:mil.disa.fso.windows:obj:483903</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483902" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483903" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:483904" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
         <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:484000" version="3" comment="Local account set union">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
             <object_reference>oval:mil.disa.fso.windows:obj:484003</object_reference>
@@ -16852,85 +16712,139 @@ Administrators</xccdf:fixtext>
             <filter>oval:mil.disa.fso.windows:ste:519602</filter>
           </set>
         </regkeyeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420005" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342700" version="2">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420006</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420009</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342701</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342702</object_reference>
           </set>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420006" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342701" version="1">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420007</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420008</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342703</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342704</object_reference>
           </set>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420007" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420008" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420009" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342702" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420010" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420011</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420014</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420011" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420012</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420013</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420012" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342703" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420013" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342704" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420014" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342705" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342706</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342707</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342706" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342708</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342709</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342707" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420015" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342708" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342709" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342710" version="1">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420016</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420019</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342711</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342712</object_reference>
           </set>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420016" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342711" version="1">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420017</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420018</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342713</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342714</object_reference>
           </set>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420017" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342712" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342713" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420018" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342714" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420019" version="1">
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342900" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342901</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342904</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342901" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342902</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342903</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342902" version="3">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342903" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342904" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343000" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343001</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343004</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343001" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343002</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343003</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343002" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343003" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343004" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
           <name datatype="string" operation="pattern match">^.+$</name>
         </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420200" version="1">
@@ -17963,9 +17877,6 @@ Administrators</xccdf:fixtext>
           <key_wow64_32key datatype="boolean" operation="equals">0</key_wow64_32key>
           <key_wow64_res datatype="boolean" operation="equals">0</key_wow64_res>
         </regkeyeffectiverights53_state>
-        <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11900" version="1" comment="'Account Lockout' is set to 'Success'">
-          <account_lockout datatype="string">AUDIT_SUCCESS</account_lockout>
-        </auditeventpolicysubcategories_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11901" version="1" comment="'Account Lockout' is set to 'Success' and 'Failure'">
           <account_lockout datatype="string">AUDIT_SUCCESS_FAILURE</account_lockout>
         </auditeventpolicysubcategories_state>
@@ -18480,12 +18391,12 @@ Administrators</xccdf:fixtext>
       </variables>
     </oval_definitions>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R3_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2022-05-01T21:45:45">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2023-03-28T17:41:20">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-05-01T21:45:44</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:20</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.windows:def:4398" version="2" class="inventory">

--- a/scap/content/guides/disa/stig-ws2016.xml
+++ b/scap/content/guides/disa/stig-ws2016.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
-  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2022-05-01T21:48:27">
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
+  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2023-03-28T17:41:26">
     <dictionaries>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+          <cat:uri name="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
         </cat:catalog>
       </component-ref>
     </dictionaries>
     <checklists>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-xccdf.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          <cat:uri name="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
         </cat:catalog>
       </component-ref>
     </checklists>
     <checks>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
     </checks>
   </data-stream>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2022-05-01T21:48:27">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2023-03-28T17:41:26">
     <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0">
       <cpe-item name="cpe:/o:microsoft:windows_server_2016:-">
         <title>Microsoft Windows Server 2016</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.windows:def:1001</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.windows:def:1001</check>
       </cpe-item>
     </cpe-list>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2022-05-01T21:48:27">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2023-03-28T17:41:26">
     <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_Windows_Server_2016_STIG" xml:lang="en" style="SCAP_1.2">
-      <xccdf:status date="2022-03-01">accepted</xccdf:status>
-      <xccdf:title>Microsoft Windows Server 2016 Security Technical Implementation Guide</xccdf:title>
-      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
+      <xccdf:status date="2023-03-02">accepted</xccdf:status>
+      <xccdf:title>Microsoft Windows Server 2016 STIG SCAP Benchmark</xccdf:title>
+      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
       <xccdf:notice id="terms-of-use" xml:lang="en" />
       <xccdf:front-matter xml:lang="en" />
       <xccdf:rear-matter xml:lang="en" />
@@ -40,31 +40,43 @@
         <dc:publisher>DISA</dc:publisher>
         <dc:source>STIG.DOD.MIL</dc:source>
       </xccdf:reference>
-      <xccdf:plain-text id="release-info">Release: 2.2 Benchmark Date: 31 May 2022</xccdf:plain-text>
-      <xccdf:plain-text id="generator">3.3.0.27375</xccdf:plain-text>
+      <xccdf:plain-text id="release-info">Release: 2.4 Benchmark Date: 11 May 2023</xccdf:plain-text>
+      <xccdf:plain-text id="generator">3.4.0.34222</xccdf:plain-text>
       <xccdf:plain-text id="conventionsVersion">1.10.0</xccdf:plain-text>
       <cpe:platform-specification>
+        <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_MemberServer">
+          <title>Windows Domain Member Server</title>
+          <logical-test negate="false" operator="AND">
+            <check-fact-ref id-ref="oval:mil.disa.stig.win:def:100004" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </logical-test>
+        </platform>
         <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_Server_2016_MS">
           <title xml:lang="en-US">Windows Server 2016 Member Server</title>
           <logical-test negate="false" operator="AND">
-            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:1008" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:1008" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </logical-test>
         </platform>
         <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_Server_2016_Standalone">
           <title xml:lang="en-US">Windows Server 2016 Standalone Server</title>
           <logical-test negate="false" operator="AND">
-            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:1009" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:1009" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </logical-test>
         </platform>
         <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_Server_2016_DC">
           <title xml:lang="en-US">Windows Server 2016 Domain Controller</title>
           <logical-test negate="false" operator="AND">
-            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:1010" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:1010" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </logical-test>
+        </platform>
+        <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_DomainController">
+          <title>Windows Domain Controller</title>
+          <logical-test negate="false" operator="AND">
+            <check-fact-ref id-ref="oval:mil.disa.stig.win:def:100005" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </logical-test>
         </platform>
       </cpe:platform-specification>
       <xccdf:platform idref="cpe:/o:microsoft:windows_server_2016:-" />
-      <xccdf:version update="http://iase.disa.mil/stigs">002.002</xccdf:version>
+      <xccdf:version update="http://iase.disa.mil/stigs">002.004</xccdf:version>
       <xccdf:metadata>
         <dc:creator>DISA</dc:creator>
         <dc:publisher>DISA</dc:publisher>
@@ -106,7 +118,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224885" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224886" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224888" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224889" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224890" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224892" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224893" selected="true" />
@@ -185,7 +196,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224987" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224988" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224989" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224990" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224995" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224996" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224997" selected="true" />
@@ -312,7 +322,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224885" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224886" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224888" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224889" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224890" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224892" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224893" selected="true" />
@@ -391,7 +400,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224987" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224988" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224989" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224990" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224995" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224996" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224997" selected="true" />
@@ -518,7 +526,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224885" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224886" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224888" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224889" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224890" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224892" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224893" selected="true" />
@@ -597,7 +604,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224987" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224988" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224989" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224990" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224995" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224996" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224997" selected="true" />
@@ -724,7 +730,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224885" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224886" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224888" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224889" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224890" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224892" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224893" selected="true" />
@@ -803,7 +808,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224987" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224988" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224989" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224990" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224995" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224996" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224997" selected="true" />
@@ -930,7 +934,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224885" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224886" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224888" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224889" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224890" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224892" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224893" selected="true" />
@@ -1009,7 +1012,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224987" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224988" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224989" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224990" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224995" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224996" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224997" selected="true" />
@@ -1136,7 +1138,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224885" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224886" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224888" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224889" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224890" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224892" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224893" selected="true" />
@@ -1215,7 +1216,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224987" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224988" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224989" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224990" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224995" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224996" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224997" selected="true" />
@@ -1342,7 +1342,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224885" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224886" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224888" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224889" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224890" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224892" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224893" selected="true" />
@@ -1421,7 +1420,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224987" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224988" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224989" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224990" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224995" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224996" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224997" selected="true" />
@@ -1548,7 +1546,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224885" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224886" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224888" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224889" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224890" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224892" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224893" selected="true" />
@@ -1627,7 +1624,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224987" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224988" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224989" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224990" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224995" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224996" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224997" selected="true" />
@@ -1754,7 +1750,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224885" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224886" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224888" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224889" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224890" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224892" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224893" selected="true" />
@@ -1833,7 +1828,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224987" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224988" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224989" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-224990" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224995" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224996" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-224997" selected="true" />
@@ -1929,38 +1923,36 @@
         <xccdf:title>Disable Slow Rules</xccdf:title>
         <xccdf:description>This profile disables rules known to have poor performance in some environments, such as systems with large numbers of user accounts.</xccdf:description>
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224997r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224998r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224998r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224999r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225002r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225005r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225014r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225017r819695_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225020r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225005r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225014r857272_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225020r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225024r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225026r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225027r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225070r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225071r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225070r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225071r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225072r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225073r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225074r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225076r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225077r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225078r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225079r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225080r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225081r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225082r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225083r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225084r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225085r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225086r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225087r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225088r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225089r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225091r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225092r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225093r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225073r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225074r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225076r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225077r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225078r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225079r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225080r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225081r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225082r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225083r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225084r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225085r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225086r852405_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225087r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225089r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225091r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225092r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225093r877392_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_CAT_I_Only">
         <xccdf:title>CAT I Only</xccdf:title>
@@ -1975,9 +1967,9 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224857r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224858r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224859r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224866r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224866r852301_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224867r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224868r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224868r852302_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224869r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224870r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224871r569186_rule" selected="false" />
@@ -1989,12 +1981,11 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224880r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224881r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224882r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224883r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224884r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224885r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224886r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224888r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224889r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224883r852305_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224884r852306_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224885r852307_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224886r852308_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224888r852309_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224890r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224892r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224893r569186_rule" selected="false" />
@@ -2002,28 +1993,28 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224895r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224896r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224897r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224900r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224901r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224902r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224903r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224904r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224905r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224906r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224907r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224908r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224909r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224910r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224911r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224912r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224913r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224900r852310_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224901r852311_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224902r852312_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224903r852313_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224904r852314_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224905r852315_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224906r852316_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224907r852317_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224908r852318_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224909r852319_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224910r852320_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224911r852321_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224912r852322_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224913r852323_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224914r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224915r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224916r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224917r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224918r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224919r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224919r852324_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224920r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224921r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224921r857251_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224922r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224924r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224925r569186_rule" selected="false" />
@@ -2035,81 +2026,80 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224931r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224935r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224936r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224937r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224938r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224939r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224937r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224938r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224939r877391_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224940r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224941r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224941r852331_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224942r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224943r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224944r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224944r852332_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224945r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224946r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224947r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224948r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224946r852333_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224947r877394_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224948r877394_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224949r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224951r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224952r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224953r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224953r852334_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224955r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224956r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224956r877377_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224957r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224959r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224960r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224962r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224963r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224965r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224966r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224967r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224968r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224969r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224987r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224988r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224989r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224990r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224995r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224959r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224960r877395_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224962r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224963r852338_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224965r852340_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224966r852341_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224967r852342_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224968r852343_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224969r852344_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224987r852359_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224988r852360_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224989r852361_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224995r852364_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224996r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224997r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224998r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224998r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-224999r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225000r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225001r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225002r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225003r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225004r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225005r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225008r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225009r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225010r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225011r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225013r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225014r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225015r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225016r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225017r819695_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225018r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225019r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225020r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225021r819698_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225022r819701_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225023r569271_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225004r852366_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225005r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225008r857258_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225009r857260_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225010r877039_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225011r857264_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225013r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225014r857272_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225015r857274_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225016r857276_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225017r890505_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225018r857278_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225019r860023_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225020r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225021r890508_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225022r894338_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225023r890514_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225024r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225026r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225027r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225028r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225029r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225030r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225031r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225032r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225029r852378_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225030r852379_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225031r852380_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225032r877039_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225033r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225034r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225034r852382_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225035r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225038r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225039r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225040r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225041r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225042r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225043r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225039r852383_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225040r852384_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225041r877396_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225042r852385_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225043r852386_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225047r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225049r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225050r569186_rule" selected="false" />
@@ -2119,35 +2109,35 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225056r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225057r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225058r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225059r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225059r877398_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225060r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225061r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225061r852388_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225062r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225063r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225064r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225064r852389_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225065r569186_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225066r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225067r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225067r852390_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225068r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225070r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225070r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225072r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225073r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225074r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225076r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225077r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225078r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225080r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225081r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225082r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225083r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225084r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225085r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225086r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225087r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225088r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225089r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225092r569186_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225093r569186_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225073r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225074r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225076r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225077r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225078r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225080r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225081r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225082r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225083r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225084r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225085r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225086r852405_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225087r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225088r891712_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225089r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225092r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-225093r877392_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Value id="xccdf_mil.disa.stig_value_winrm_client_allow_unencrypted_traffic_var" type="number" operator="equals">
         <xccdf:title>WinRM Client: Allow unencrypted traffic</xccdf:title>
@@ -2261,16 +2251,6 @@
         <xccdf:value>0</xccdf:value>
         <xccdf:value selector="disabled">0</xccdf:value>
         <xccdf:value selector="enabled">1</xccdf:value>
-      </xccdf:Value>
-      <xccdf:Value id="xccdf_mil.disa.stig_value_password_minimum_length_var" type="number" operator="greater than or equal">
-        <xccdf:title>Minimum Password Length</xccdf:title>
-        <xccdf:description>The minimum number of characters required for a password</xccdf:description>
-        <xccdf:value>14</xccdf:value>
-        <xccdf:value selector="8_characters">8</xccdf:value>
-        <xccdf:value selector="9_characters">9</xccdf:value>
-        <xccdf:value selector="12_characters">12</xccdf:value>
-        <xccdf:value selector="14_characters">14</xccdf:value>
-        <xccdf:value selector="15_characters">15</xccdf:value>
       </xccdf:Value>
       <xccdf:Value id="xccdf_mil.disa.stig_value_password_minimum_age_var" type="number" operator="greater than or equal">
         <xccdf:title>Minimum Password Age</xccdf:title>
@@ -2448,7 +2428,7 @@
           <xccdf:fixtext fixref="F-26507r465387_fix">Update the system to a Version 1607 (Build 14393.xxx) or greater.</xccdf:fixtext>
           <xccdf:fix id="F-26507r465387_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1020" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1020" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2472,7 +2452,7 @@
           <xccdf:fixtext fixref="F-26510r465396_fix">Format volumes to use NTFS or ReFS.</xccdf:fixtext>
           <xccdf:fix id="F-26510r465396_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1024" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1024" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2510,7 +2490,7 @@ Deselect "Fax Server" on the "Roles" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-26529r465453_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1041" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1041" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2548,7 +2528,7 @@ Deselect "FTP Server" under "Web Server (IIS)" on the "Roles" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-26530r465456_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1042" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1042" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2586,7 +2566,7 @@ Deselect "Peer Name Resolution Protocol" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-26531r465459_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1043" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1043" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2624,7 +2604,7 @@ Deselect "Simple TCP/IP Services" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-26532r465462_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1044" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1044" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2662,7 +2642,7 @@ Deselect "Telnet Client" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-26533r465465_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1045" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1045" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2700,7 +2680,7 @@ Deselect "TFTP Client" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-26534r465468_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1265" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1265" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2745,7 +2725,7 @@ Deselect "SMB 1.0/CIFS File Sharing Support" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-26535r465471_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1259" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1259" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2773,7 +2753,7 @@ The system must be restarted for the change to take effect.
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-26536r465474_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1260" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1260" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2801,7 +2781,7 @@ The system must be restarted for the changes to take effect.
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-26537r465477_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1261" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1261" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2839,14 +2819,14 @@ Deselect "Windows PowerShell 2.0 Engine" under "Windows PowerShell" on the "Feat
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-26538r465480_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1266" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1266" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224866">
         <xccdf:title>SRG-OS-000329-GPOS-00128</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224866r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224866r852301_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AC-000010</xccdf:version>
           <xccdf:title>Windows 2016 account lockout duration must be configured to 15 minutes or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system. This parameter specifies the period of time that an account will remain locked after the specified number of failed logon attempts.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -2866,7 +2846,7 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
 A value of "0" is also acceptable, requiring an administrator to unlock the account.</xccdf:fixtext>
           <xccdf:fix id="F-26545r465501_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1011" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1011" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2892,14 +2872,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-26546r465504_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_threshold_var" export-name="oval:mil.disa.stig.windows:var:101200" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1012" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1012" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224868">
         <xccdf:title>SRG-OS-000021-GPOS-00005</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224868r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224868r852302_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AC-000030</xccdf:version>
           <xccdf:title>Windows Server 2016 must have the period of time before the bad logon counter is reset configured to 15 minutes or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system. This parameter specifies the period of time that must pass after failed logon attempts before the counter is reset to "0". The smaller this value is, the less effective the account lockout feature will be in protecting the local system.
@@ -2921,7 +2901,7 @@ Satisfies: SRG-OS-000021-GPOS-00005, SRG-OS-000329-GPOS-00128&lt;/VulnDiscussion
           <xccdf:fix id="F-26547r465507_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_reset_counter_var" export-name="oval:mil.disa.stig.windows:var:101300" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1013" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1013" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2947,7 +2927,7 @@ Satisfies: SRG-OS-000021-GPOS-00005, SRG-OS-000329-GPOS-00128&lt;/VulnDiscussion
           <xccdf:fix id="F-26548r465510_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_enforce_history_var" export-name="oval:mil.disa.stig.windows:var:101400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1014" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1014" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2973,7 +2953,7 @@ Satisfies: SRG-OS-000021-GPOS-00005, SRG-OS-000329-GPOS-00128&lt;/VulnDiscussion
           <xccdf:fix id="F-26549r465513_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_maximum_age_var" export-name="oval:mil.disa.stig.windows:var:101500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1015" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1015" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2999,7 +2979,7 @@ Satisfies: SRG-OS-000021-GPOS-00005, SRG-OS-000329-GPOS-00128&lt;/VulnDiscussion
           <xccdf:fix id="F-26550r465516_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_age_var" export-name="oval:mil.disa.stig.windows:var:101600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1016" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1016" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3017,15 +2997,13 @@ Satisfies: SRG-OS-000021-GPOS-00005, SRG-OS-000329-GPOS-00128&lt;/VulnDiscussion
             <dc:subject>Microsoft Windows Server 2016</dc:subject>
             <dc:identifier>4205</dc:identifier>
           </xccdf:reference>
-          <xccdf:ident system="http://cce.mitre.org">CCE-46914-8</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-73321</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-87973</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000205</xccdf:ident>
           <xccdf:fixtext fixref="F-26551r465519_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Password Policy &gt;&gt; "Minimum password length" to "14" characters.</xccdf:fixtext>
           <xccdf:fix id="F-26551r465519_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_length_var" export-name="oval:mil.disa.stig.windows:var:101700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1017" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:224872" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3056,14 +3034,14 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fix id="F-26552r465522_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_complexity_var" export-name="oval:mil.disa.stig.windows:var:101800" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1018" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1018" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224874">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224874r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224874r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AC-000090</xccdf:version>
           <xccdf:title>Windows Server 2016 reversible password encryption must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storing passwords using reversible encryption is essentially the same as storing clear-text versions of the passwords, which are easily compromised. For this reason, this policy must never be enabled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3082,7 +3060,7 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fix id="F-26553r465525_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_reversible_encryption_var" export-name="oval:mil.disa.stig.windows:var:101900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1019" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1019" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3118,7 +3096,7 @@ The default location is the "%SystemRoot%\ System32\winevt\Logs" folder.
 If the location of the logs has been changed, when adding Eventlog to the permissions, it must be entered as "NT Service\Eventlog".</xccdf:fixtext>
           <xccdf:fix id="F-26556r465534_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1270" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:224877" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3154,7 +3132,7 @@ The default location is the "%SystemRoot%\ System32\winevt\Logs" folder.
 If the location of the logs has been changed, when adding Eventlog to the permissions, it must be entered as "NT Service\Eventlog".</xccdf:fixtext>
           <xccdf:fix id="F-26557r465537_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1264" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:224878" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3190,7 +3168,7 @@ The default location is the "%SystemRoot%\ System32\winevt\Logs" folder.
 If the location of the logs has been changed, when adding Eventlog to the permissions, it must be entered as "NT Service\Eventlog".</xccdf:fixtext>
           <xccdf:fix id="F-26558r465540_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1271" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:224879" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3224,7 +3202,7 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES, ALL RESTRICTED APPLICAT
 The default location is the "%SystemRoot%\ System32" folder.</xccdf:fixtext>
           <xccdf:fix id="F-26559r465543_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1054" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:224880" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3251,7 +3229,7 @@ Credential Validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-26560r465546_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Logon &gt;&gt; "Audit Credential Validation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26560r465546_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1055" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1055" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3278,14 +3256,14 @@ Credential Validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-26561r465549_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Logon &gt;&gt; "Audit Credential Validation" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26561r465549_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1056" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1056" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224883">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224883r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224883r852305_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000100</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Account Management - Other Account Management Events successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3308,14 +3286,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-26562r465552_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit Other Account Management Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26562r465552_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1057" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1057" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224884">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224884r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224884r852306_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000120</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Account Management - Security Group Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3342,14 +3320,14 @@ Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPO
           <xccdf:fixtext fixref="F-26563r465555_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit Security Group Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26563r465555_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1059" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1059" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224885">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224885r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224885r852307_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000140</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Account Management - User Account Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3376,14 +3354,14 @@ Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPO
           <xccdf:fixtext fixref="F-26564r465558_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit User Account Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26564r465558_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1061" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1061" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224886">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224886r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224886r852308_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000150</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Account Management - User Account Management failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3410,14 +3388,14 @@ Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPO
           <xccdf:fixtext fixref="F-26565r465561_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit User Account Management" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26565r465561_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1062" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1062" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224888">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224888r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224888r852309_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000170</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Detailed Tracking - Process Creation successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3440,36 +3418,7 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26567r465567_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Detailed Tracking &gt;&gt; "Audit Process Creation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26567r465567_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1063" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-224889">
-        <xccdf:title>SRG-OS-000240-GPOS-00090</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224889r569186_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000220</xccdf:version>
-          <xccdf:title>Windows Server 2016 must be configured to audit Logon/Logoff - Account Lockout successes.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
-
-Account Lockout events can be used to identify potentially malicious logon attempts.
-
-Satisfies: SRG-OS-000240-GPOS-00090, SRG-OS-000470-GPOS-00214&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Microsoft Windows Server 2016</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Microsoft Windows Server 2016</dc:subject>
-            <dc:identifier>4205</dc:identifier>
-          </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/legacy">SV-88095</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">V-73443</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-001404</xccdf:ident>
-          <xccdf:fixtext fixref="F-26568r465570_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Account Lockout" with "Success" selected.</xccdf:fixtext>
-          <xccdf:fix id="F-26568r465570_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1267" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1063" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3498,7 +3447,7 @@ Satisfies: SRG-OS-000240-GPOS-00090, SRG-OS-000470-GPOS-00214&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26569r465573_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Account Lockout" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26569r465573_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1268" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1268" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3528,7 +3477,7 @@ Satisfies: SRG-OS-000032-GPOS-00013, SRG-OS-000470-GPOS-00214, SRG-OS-000472-GPO
           <xccdf:fixtext fixref="F-26571r465579_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Logoff" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26571r465579_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1064" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1064" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3558,7 +3507,7 @@ Satisfies: SRG-OS-000032-GPOS-00013, SRG-OS-000470-GPOS-00214, SRG-OS-000472-GPO
           <xccdf:fixtext fixref="F-26572r465582_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26572r465582_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1065" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1065" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3588,7 +3537,7 @@ Satisfies: SRG-OS-000032-GPOS-00013, SRG-OS-000470-GPOS-00214, SRG-OS-000472-GPO
           <xccdf:fixtext fixref="F-26573r465585_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Logon" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26573r465585_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1066" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1066" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3617,7 +3566,7 @@ Satisfies: SRG-OS-000470-GPOS-00214, SRG-OS-000472-GPOS-00217, SRG-OS-000473-GPO
           <xccdf:fixtext fixref="F-26574r465588_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Special Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26574r465588_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1067" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1067" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3644,7 +3593,7 @@ Auditing for other object access records events related to the management of tas
           <xccdf:fixtext fixref="F-26575r465591_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Object Access &gt;&gt; "Audit Other Object Access Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26575r465591_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1274" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1274" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3671,14 +3620,14 @@ Auditing for other object access records events related to the management of tas
           <xccdf:fixtext fixref="F-26576r465594_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Object Access &gt;&gt; "Audit Other Object Access Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26576r465594_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1275" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1275" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224900">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224900r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224900r852310_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000310</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Policy Change - Audit Policy Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3701,14 +3650,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26579r465603_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Audit Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26579r465603_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1070" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1070" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224901">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224901r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224901r852311_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000320</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Policy Change - Audit Policy Change failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3731,14 +3680,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26580r465606_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Audit Policy Change" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26580r465606_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1071" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1071" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224902">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224902r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224902r852312_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000330</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Policy Change - Authentication Policy Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3761,14 +3710,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-26581r465609_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Authentication Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26581r465609_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1072" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1072" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224903">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224903r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224903r852313_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000340</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Policy Change - Authorization Policy Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3791,14 +3740,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-26582r465612_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Authorization Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26582r465612_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1073" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1073" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224904">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224904r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224904r852314_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000350</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Privilege Use - Sensitive Privilege Use successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3821,14 +3770,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-26583r465615_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Privilege Use &gt;&gt; "Audit Sensitive Privilege Use" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26583r465615_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1074" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1074" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224905">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224905r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224905r852315_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000360</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit Privilege Use - Sensitive Privilege Use failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3851,14 +3800,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-26584r465618_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Privilege Use &gt;&gt; "Audit Sensitive Privilege Use" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26584r465618_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1075" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1075" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224906">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224906r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224906r852316_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000370</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit System - IPsec Driver successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3881,14 +3830,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26585r465621_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit IPsec Driver" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26585r465621_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1076" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1076" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224907">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224907r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224907r852317_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000380</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit System - IPsec Driver failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3911,14 +3860,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26586r465624_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit IPsec Driver" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26586r465624_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1077" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1077" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224908">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224908r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224908r852318_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000390</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit System - Other System Events successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3940,14 +3889,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26587r465627_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26587r465627_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1263" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1263" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224909">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224909r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224909r852319_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000400</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit System - Other System Events failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -3970,14 +3919,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26588r465630_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26588r465630_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1269" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1269" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224910">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224910r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224910r852320_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000410</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit System - Security State Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4000,14 +3949,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26589r465633_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Security State Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26589r465633_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1078" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1078" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224911">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224911r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224911r852321_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000420</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit System - Security System Extension successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4030,14 +3979,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26590r465636_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Security System Extension" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26590r465636_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1079" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1079" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224912">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224912r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224912r852322_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000440</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit System - System Integrity successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4060,14 +4009,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000471-GPOS-00215, SRG-OS-000471-GPO
           <xccdf:fixtext fixref="F-26591r465639_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit System Integrity" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26591r465639_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1081" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1081" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224913">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224913r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224913r852323_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-AU-000450</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit System - System Integrity failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -4090,7 +4039,7 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000471-GPOS-00215, SRG-OS-000471-GPO
           <xccdf:fixtext fixref="F-26592r465642_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit System Integrity" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26592r465642_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1082" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1082" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4114,7 +4063,7 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000471-GPOS-00215, SRG-OS-000471-GPO
           <xccdf:fixtext fixref="F-26593r465645_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Control Panel &gt;&gt; Personalization &gt;&gt; "Prevent enabling lock screen slide show" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26593r465645_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:69" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:69" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4140,7 +4089,7 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000471-GPOS-00215, SRG-OS-000471-GPO
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and " SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-26594r465648_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:148" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:148" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4168,7 +4117,7 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-26595r465651_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_MSS_IPv6_source_routing_protection_level_var" export-name="oval:mil.disa.stig.windows:var:108400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1084" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1084" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4196,7 +4145,7 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-26596r465654_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ip_source_routing_protection_level_var" export-name="oval:mil.disa.stig.windows:var:108500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1085" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1085" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4224,14 +4173,14 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-26597r465657_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_icmp_redirects_var" export-name="oval:mil.disa.stig.windows:var:108600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1086" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1086" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224919">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224919r569186_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224919r852324_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000070</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to ignore NetBIOS name release requests except from WINS servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring the system to ignore name release requests, except from WINS servers, prevents a denial of service (DoS) attack. The DoS consists of sending a NetBIOS name release request to the server for each entry in the server's cache, causing a response delay in the normal operation of the server's WINS resolution capability.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4252,7 +4201,7 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-26598r465660_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_no_name_release_on_demand_var" export-name="oval:mil.disa.stig.windows:var:108700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1087" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1087" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4276,14 +4225,14 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fixtext fixref="F-26599r465663_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Network &gt;&gt; Lanman Workstation &gt;&gt; "Enable insecure guest logons" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26599r465663_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1273" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1273" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224921">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224921r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224921r857251_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000090</xccdf:version>
           <xccdf:title>Hardened UNC paths must be defined to require mutual authentication and integrity for at least the \\*\SYSVOL and \\*\NETLOGON shares.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Additional security requirements are applied to Universal Naming Convention (UNC) paths specified in hardened UNC paths before allowing access to them. This aids in preventing tampering with or spoofing of connections to these paths.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4308,7 +4257,7 @@ Value Name: \\*\NETLOGON
 Value: RequireMutualAuthentication=1, RequireIntegrity=1</xccdf:fixtext>
           <xccdf:fix id="F-26600r465666_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:19" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:19" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4335,7 +4284,7 @@ Enabling "Include command line data for process creation events" will record the
           <xccdf:fixtext fixref="F-26601r465669_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Audit Process Creation &gt;&gt; "Include command line in process creation events" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26601r465669_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1258" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1258" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4362,7 +4311,7 @@ Enabling "Include command line data for process creation events" will record the
 If this needs to be corrected or a more secure setting is desired, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Early Launch Antimalware &gt;&gt; "Boot-Start Driver Initialization Policy" to "Not Configured" or "Enabled" with any option other than "All" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26603r465675_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1089" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1089" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4387,7 +4336,7 @@ If this needs to be corrected or a more secure setting is desired, configure the
           <xccdf:fixtext fixref="F-26604r465678_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Group Policy &gt;&gt; "Configure registry policy processing" to "Enabled" with the option "Process even if the Group Policy objects have not changed" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26604r465678_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1090" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1090" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4397,7 +4346,7 @@ If this needs to be corrected or a more secure setting is desired, configure the
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224926r569186_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000160</xccdf:version>
           <xccdf:title>Downloading print driver packages over HTTP must be prevented.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature. Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and will prevent uncontrolled updates to the system. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature. Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and will prevent uncontrolled updates to the system.
 
 This setting prevents the computer from downloading print driver packages over HTTP.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -4415,7 +4364,7 @@ This setting prevents the computer from downloading print driver packages over H
           <xccdf:fix id="F-26605r465681_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_downloading_of_print_drivers_over_http_var" export-name="oval:mil.disa.stig.windows:var:109100" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1091" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1091" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4443,7 +4392,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
           <xccdf:fix id="F-26606r465684_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_printing_over_http_var" export-name="oval:mil.disa.stig.windows:var:109200" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1092" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1092" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4467,7 +4416,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
           <xccdf:fixtext fixref="F-26607r465687_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Logon &gt;&gt; "Do not display network selection UI" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26607r465687_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:66" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:66" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4493,7 +4442,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
           <xccdf:fix id="F-26608r465690_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_on_battery_var" export-name="oval:mil.disa.stig.windows:var:109400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1094" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1094" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4519,7 +4468,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
           <xccdf:fix id="F-26609r465693_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_plugged_var" export-name="oval:mil.disa.stig.windows:var:109500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1095" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1095" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4547,14 +4496,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-26610r465696_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_program_inventory_var" export-name="oval:mil.disa.stig.windows:var:109600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1096" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1096" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224932">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224932r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224932r852325_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000250</xccdf:version>
           <xccdf:title>AutoPlay must be turned off for non-volume devices.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing AutoPlay to execute may introduce malicious code to a system. AutoPlay begins reading from a drive as soon as media is inserted into the drive. As a result, the setup file of programs or music on audio media may start. This setting will disable AutoPlay for non-volume devices, such as Media Transfer Protocol (MTP) devices.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4573,14 +4522,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-26611r465699_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_autoplay_for_non_volume_devices_var" export-name="oval:mil.disa.stig.windows:var:109700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1097" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1097" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224933">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224933r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224933r852326_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000260</xccdf:version>
           <xccdf:title>The default AutoRun behavior must be configured to prevent AutoRun commands.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing AutoRun commands to execute may introduce malicious code to a system. Configuring this setting prevents AutoRun commands from executing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4599,14 +4548,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-26612r465702_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_default_behavior_for_autorun_var" export-name="oval:mil.disa.stig.windows:var:109800" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1098" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1098" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224934">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224934r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224934r852327_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000270</xccdf:version>
           <xccdf:title>AutoPlay must be disabled for all drives.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing AutoPlay to execute may introduce malicious code to a system. AutoPlay begins reading from a drive as soon media is inserted into the drive. As a result, the setup file of programs or music on audio media may start. By default, AutoPlay is disabled on removable drives, such as the floppy disk drive (but not the CD-ROM drive) and on network drives. Enabling this policy disables AutoPlay on all drives.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4624,7 +4573,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fixtext fixref="F-26613r465705_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; AutoPlay Policies &gt;&gt; "Turn off AutoPlay" to "Enabled" with "All Drives" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26613r465705_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1099" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1099" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4650,7 +4599,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-26614r465708_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_enumerate_administrator_accounts_on_elevation_var" export-name="oval:mil.disa.stig.windows:var:110400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1104" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1104" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4674,14 +4623,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fixtext fixref="F-26615r465711_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Data Collection and Preview Builds&gt;&gt; "Allow Telemetry" to "Enabled" with "0 - Security [Enterprise Only]" or "1 - Basic" selected in "Options".</xccdf:fixtext>
           <xccdf:fix id="F-26615r465711_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:24" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:224936" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224937">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224937r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224937r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000300</xccdf:version>
           <xccdf:title>The Application event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4700,14 +4649,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-26616r465714_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_application_log_size_var" export-name="oval:mil.disa.stig.windows:var:110500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1105" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1105" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224938">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224938r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224938r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000310</xccdf:version>
           <xccdf:title>The Security event log size must be configured to 196608 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4726,14 +4675,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-26617r465717_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_security_log_size_var" export-name="oval:mil.disa.stig.windows:var:110600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1106" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1106" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224939">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224939r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224939r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000320</xccdf:version>
           <xccdf:title>The System event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4752,7 +4701,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-26618r465720_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_system_log_size_var" export-name="oval:mil.disa.stig.windows:var:110700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1107" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1107" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4777,14 +4726,14 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fixtext fixref="F-26619r465723_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; File Explorer &gt;&gt; "Configure Windows SmartScreen" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26619r465723_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1108" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1108" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224941">
         <xccdf:title>SRG-OS-000433-GPOS-00192</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224941r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224941r852331_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000340</xccdf:version>
           <xccdf:title>Explorer Data Execution Prevention must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Data Execution Prevention provides additional protection by performing checks on memory to help prevent malicious code from running. This setting will prevent Data Execution Prevention from being turned off for File Explorer.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4805,7 +4754,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-26620r465726_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_data_execution_prevention_for_explorer_var" export-name="oval:mil.disa.stig.windows:var:110900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1109" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1109" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4833,7 +4782,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-26621r465729_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_heap_termination_corruption_var" export-name="oval:mil.disa.stig.windows:var:111000" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1110" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1110" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4861,14 +4810,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-26622r465732_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_shell_protocol_protected_mode_var" export-name="oval:mil.disa.stig.windows:var:111100" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1111" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1111" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224944">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224944r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224944r852332_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000370</xccdf:version>
           <xccdf:title>Passwords must not be saved in the Remote Desktop Client.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Saving passwords in the Remote Desktop Client could allow an unauthorized user to establish a remote desktop session to another system. The system must be configured to prevent users from saving passwords in the Remote Desktop Client.
@@ -4889,7 +4838,7 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fix id="F-26623r465735_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_passwords_to_be_saved_var" export-name="oval:mil.disa.stig.windows:var:111200" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1112" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1112" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4915,14 +4864,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fix id="F-26624r465738_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_drive_redirection_var" export-name="oval:mil.disa.stig.windows:var:111300" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1113" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1113" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224946">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224946r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224946r852333_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000390</xccdf:version>
           <xccdf:title>Remote Desktop Services must always prompt a client for passwords upon connection.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting controls the ability of users to supply passwords automatically as part of their remote desktop connection. Disabling this setting would allow anyone to use the stored credentials in a connection item to connect to the terminal server.
@@ -4943,14 +4892,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fix id="F-26625r465741_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_always_prompt_for_password_upon_connection_var" export-name="oval:mil.disa.stig.windows:var:111400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1114" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1114" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224947">
         <xccdf:title>SRG-OS-000250-GPOS-00093</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224947r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224947r877394_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000400</xccdf:version>
           <xccdf:title>The Remote Desktop Session Host must require secure Remote Procedure Call (RPC) communications.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing unsecure RPC communication exposes the system to man-in-the-middle attacks and data disclosure attacks. A man-in-the-middle attack occurs when an intruder captures packets between a client and server and modifies them before allowing the packets to be exchanged. Usually the attacker will modify the information in the packets in an attempt to cause either the client or server to reveal sensitive information.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4969,14 +4918,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fix id="F-26626r465744_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_secure_rpc_communication_var" export-name="oval:mil.disa.stig.windows:var:111500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1115" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1115" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224948">
         <xccdf:title>SRG-OS-000250-GPOS-00093</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224948r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224948r877394_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000410</xccdf:version>
           <xccdf:title>Remote Desktop Services must be configured with the client connection encryption set to High Level.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Remote connections must be encrypted to prevent interception of data or sensitive information. Selecting "High Level" will ensure encryption of Remote Desktop Services sessions in both directions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4995,7 +4944,7 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fix id="F-26627r465747_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_set_client_connection_encryption_level_var" export-name="oval:mil.disa.stig.windows:var:111600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1116" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1116" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5021,7 +4970,7 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fix id="F-26628r465750_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prevent_downloading_of_enclosures_var" export-name="oval:mil.disa.stig.windows:var:111700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1117" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1117" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5049,7 +4998,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-26630r465756_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_on_basic_feed_authentication_over_http_var" export-name="oval:mil.disa.stig.windows:var:111800" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1118" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1118" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5073,14 +5022,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-26631r465759_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Search &gt;&gt; "Allow indexing of encrypted files" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26631r465759_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1262" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1262" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224953">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224953r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224953r852334_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000450</xccdf:version>
           <xccdf:title>Users must be prevented from changing installation options.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Installation options for applications are typically controlled by administrators. This setting prevents users from changing installation options that may bypass security features.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5099,14 +5048,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-26632r465762_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_user_control_over_installs_var" export-name="oval:mil.disa.stig.windows:var:111900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1119" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1119" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224954">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224954r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224954r852335_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000460</xccdf:version>
           <xccdf:title>The Windows Installer Always install with elevated privileges option must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Standard user accounts must not be granted elevated privileges. Enabling Windows Installer to elevate privileges when installing applications can allow malicious persons and applications to gain full control of a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5124,7 +5073,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-26633r465765_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Installer &gt;&gt; "Always install with elevated privileges" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26633r465765_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1120" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1120" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5152,14 +5101,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-26634r465768_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prevent_internet_explorer_security_prompt_for_windows_installer_scripts_var" export-name="oval:mil.disa.stig.windows:var:112100" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1121" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1121" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224956">
         <xccdf:title>SRG-OS-000480-GPOS-00229</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224956r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224956r877377_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000480</xccdf:version>
           <xccdf:title>Automatically signing in the last interactive user after a system-initiated restart must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Windows can be configured to automatically sign the user back in after a Windows Update restart. Some protections are in place to help ensure this is done in a secure fashion; however, disabling this will prevent the caching of credentials for this purpose and also ensure the user is aware of the restart.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5176,7 +5125,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-26635r465771_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Logon Options &gt;&gt; "Sign-in last interactive user automatically after a system-initiated restart" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26635r465771_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:65" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:65" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5202,14 +5151,14 @@ Enabling PowerShell script block logging will record detailed information from t
           <xccdf:fixtext fixref="F-26636r465774_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows PowerShell &gt;&gt; "Turn on PowerShell Script Block Logging" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26636r465774_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:137" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:137" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224958">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224958r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224958r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000500</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain-text passwords that could be used to compromise a system. Disabling Basic authentication will reduce this potential.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5227,14 +5176,14 @@ Enabling PowerShell script block logging will record detailed information from t
           <xccdf:fixtext fixref="F-26637r465777_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Client &gt;&gt; "Allow Basic authentication" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26637r465777_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1123" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1123" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224959">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224959r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224959r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000510</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised. Windows remote management connections must be encrypted to prevent this.
@@ -5256,14 +5205,14 @@ Satisfies: SRG-OS-000393-GPOS-00173, SRG-OS-000394-GPOS-00174&lt;/VulnDiscussion
           <xccdf:fix id="F-26638r465780_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_winrm_client_allow_unencrypted_traffic_var" export-name="oval:mil.disa.stig.windows:var:112400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1124" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1124" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224960">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224960r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224960r877395_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000520</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) client must not use Digest authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Digest authentication is not as strong as other options and may be subject to man-in-the-middle attacks. Disallowing Digest authentication will reduce this potential.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5281,14 +5230,14 @@ Satisfies: SRG-OS-000393-GPOS-00173, SRG-OS-000394-GPOS-00174&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26639r465783_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Client &gt;&gt; "Disallow Digest authentication" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26639r465783_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1125" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1125" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224961">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224961r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224961r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000530</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain-text passwords that could be used to compromise a system. Disabling Basic authentication will reduce this potential.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5306,14 +5255,14 @@ Satisfies: SRG-OS-000393-GPOS-00173, SRG-OS-000394-GPOS-00174&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26640r465786_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Service &gt;&gt; "Allow Basic authentication" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26640r465786_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1126" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1126" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224962">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224962r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224962r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000540</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised. Windows remote management connections must be encrypted to prevent this.
@@ -5334,14 +5283,14 @@ Satisfies: SRG-OS-000393-GPOS-00173, SRG-OS-000394-GPOS-00174&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26641r465789_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Service &gt;&gt; "Allow unencrypted traffic" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26641r465789_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1127" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1127" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224963">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224963r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224963r852338_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-CC-000550</xccdf:version>
           <xccdf:title>The Windows Remote Management (WinRM) service must not store RunAs credentials.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storage of administrative credentials could allow unauthorized access. Disallowing the storage of RunAs credentials for Windows Remote Management will prevent them from being used with plug-ins.
@@ -5361,14 +5310,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26642r465792_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Service &gt;&gt; "Disallow WinRM from storing RunAs credentials" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26642r465792_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1128" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1128" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224965">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224965r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224965r852340_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000020</xccdf:version>
           <xccdf:title>Kerberos user logon restrictions must be enforced.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether the Kerberos Key Distribution Center (KDC) validates every request for a session ticket against the user rights policy of the target computer. The policy is enabled by default, which is the most secure setting for validating that access to target resources is not circumvented.
@@ -5390,14 +5339,14 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26644r465798_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Policies &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Enforce user logon restrictions" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26644r465798_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1130" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1130" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224966">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224966r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224966r852341_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000030</xccdf:version>
           <xccdf:title>The Kerberos service ticket maximum lifetime must be limited to 600 minutes or less.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting determines the maximum amount of time (in minutes) that a granted session ticket can be used to access a particular service. Session tickets are used only to authenticate new connections with servers. Ongoing operations are not interrupted if the session ticket used to authenticate the connection expires during the connection.
@@ -5419,14 +5368,14 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26645r465801_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Policies &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Maximum lifetime for service ticket" to a maximum of "600" minutes, but not "0", which equates to "Ticket doesn't expire".</xccdf:fixtext>
           <xccdf:fix id="F-26645r465801_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1131" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1131" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224967">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224967r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224967r852342_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000040</xccdf:version>
           <xccdf:title>The Kerberos user ticket lifetime must be limited to 10 hours or less.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;In Kerberos, there are two types of tickets: Ticket Granting Tickets (TGTs) and Service Tickets. Kerberos tickets have a limited lifetime so the time an attacker has to implement an attack is limited. This policy controls how long TGTs can be renewed. With Kerberos, the user's initial authentication to the domain controller results in a TGT, which is then used to request Service Tickets to resources. Upon startup, each computer gets a TGT before requesting a service ticket to the domain controller and any other computers it needs to access. For services that start up under a specified user account, users must always get a TGT first and then get Service Tickets to all computers and services accessed.
@@ -5448,14 +5397,14 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26646r465804_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Policies &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Maximum lifetime for user ticket" to a maximum of "10" hours but not "0", which equates to "Ticket doesn't expire".</xccdf:fixtext>
           <xccdf:fix id="F-26646r465804_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1132" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1132" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224968">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224968r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224968r852343_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000050</xccdf:version>
           <xccdf:title>The Kerberos policy user ticket renewal maximum lifetime must be limited to seven days or less.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting determines the period of time (in days) during which a user's Ticket Granting Ticket (TGT) may be renewed. This security configuration limits the amount of time an attacker has to crack the TGT and gain access.
@@ -5477,14 +5426,14 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26647r465807_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Policies &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Maximum lifetime for user ticket renewal" to a maximum of "7" days or less.</xccdf:fixtext>
           <xccdf:fix id="F-26647r465807_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1133" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1133" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224969">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224969r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224969r852344_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000060</xccdf:version>
           <xccdf:title>The computer clock synchronization tolerance must be limited to 5 minutes or less.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting determines the maximum time difference (in minutes) that Kerberos will tolerate between the time on a client's clock and the time on a server's clock while still considering the two clocks synchronous. In order to prevent replay attacks, Kerberos uses timestamps as part of its protocol definition. For timestamps to work properly, the clocks of the client and the server need to be in sync as much as possible.
@@ -5506,14 +5455,14 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26648r465810_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Maximum tolerance for computer clock synchronization" to a maximum of "5" minutes or less.</xccdf:fixtext>
           <xccdf:fix id="F-26648r465810_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1134" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1134" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224970">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224970r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224970r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000070</xccdf:version>
           <xccdf:title>Permissions on the Active Directory data files must only allow System and Administrators access.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Improper access permissions for directory data-related files could allow unauthorized users to read, modify, or delete directory data or audit trails.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5524,7 +5473,7 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
             <dc:subject>Microsoft Windows Server 2016</dc:subject>
             <dc:identifier>4205</dc:identifier>
           </xccdf:reference>
-          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_Server_2016_DC" />
+          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_DomainController" />
           <xccdf:ident system="http://cyber.mil/legacy">SV-88021</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-73369</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002235</xccdf:ident>
@@ -5537,14 +5486,14 @@ BUILTIN\Administrators:(I)(F)
 (F) - full access</xccdf:fixtext>
           <xccdf:fix id="F-26649r465813_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1135" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:224970" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224987">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224987r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224987r852359_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000240</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit DS Access - Directory Service Access successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5568,14 +5517,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26666r465864_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; DS Access &gt;&gt; "Directory Service Access" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26666r465864_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1152" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1152" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224988">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224988r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224988r852360_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000250</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit DS Access - Directory Service Access failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5599,14 +5548,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26667r465867_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; DS Access &gt;&gt; "Directory Service Access" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26667r465867_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1153" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1153" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224989">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224989r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224989r852361_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000260</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to audit DS Access - Directory Service Changes successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5630,45 +5579,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-26668r465870_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; DS Access &gt;&gt; "Directory Service Changes" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26668r465870_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1154" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-224990">
-        <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224990r569186_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000270</xccdf:version>
-          <xccdf:title>Windows Server 2016 must be configured to audit DS Access - Directory Service Changes failures.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
-
-Audit Directory Service Changes records events related to changes made to objects in Active Directory Domain Services.
-
-Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPOS-00207, SRG-OS-000468-GPOS-00212&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Microsoft Windows Server 2016</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Microsoft Windows Server 2016</dc:subject>
-            <dc:identifier>4205</dc:identifier>
-          </xccdf:reference>
-          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_Server_2016_DC" />
-          <xccdf:ident system="http://cce.mitre.org">CCE-46701-9</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">SV-88093</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">V-73441</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002234</xccdf:ident>
-          <xccdf:fixtext fixref="F-26669r465873_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; DS Access &gt;&gt; "Directory Service Changes" with "Failure" selected.</xccdf:fixtext>
-          <xccdf:fix id="F-26669r465873_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1155" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1154" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224995">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224995r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224995r852364_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000320</xccdf:version>
           <xccdf:title>Domain controllers must require LDAP access signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unsigned network traffic is susceptible to man-in-the-middle attacks, where an intruder captures packets between the server and the client and modifies them before forwarding them to the client. In the case of an LDAP server, this means that an attacker could cause a client to make decisions based on false records from the LDAP directory. The risk of an attacker pulling this off can be decreased by implementing strong physical security measures to protect the network infrastructure. Furthermore, implementing Internet Protocol security (IPsec) authentication header mode (AH), which performs mutual authentication and packet integrity for Internet Protocol (IP) traffic, can make all types of man-in-the-middle attacks extremely difficult.
@@ -5690,7 +5608,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26674r465888_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain controller: LDAP server signing requirements" to "Require signing".</xccdf:fixtext>
           <xccdf:fix id="F-26674r465888_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1160" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1160" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5716,7 +5634,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26675r465891_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain controller: Refuse machine account password changes" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26675r465891_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1161" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1161" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5725,7 +5643,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224997r569186_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000340</xccdf:version>
-          <xccdf:title>The Access this computer from the network user right must only be assigned to the Administrators, Authenticated Users, and 
+          <xccdf:title>The Access this computer from the network user right must only be assigned to the Administrators, Authenticated Users, and
 Enterprise Domain Controllers groups on domain controllers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
@@ -5749,14 +5667,14 @@ Accounts with the "Access this computer from the network" right may access resou
 - Enterprise Domain Controllers</xccdf:fixtext>
           <xccdf:fix id="F-26676r465894_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1162" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1162" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-224998">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224998r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-224998r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000350</xccdf:version>
           <xccdf:title>The Add workstations to domain user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5779,7 +5697,7 @@ Accounts with the "Add workstations to domain" right may add computers to a doma
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26677r465897_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1163" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1163" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5809,7 +5727,7 @@ Accounts with the "Allow log on through Remote Desktop Services" user right can 
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26678r465900_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1164" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1164" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5841,7 +5759,7 @@ The Guests group must be assigned this right to prevent unauthenticated access.&
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-26679r465903_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1165" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1165" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5873,7 +5791,7 @@ The Guests group must be assigned to prevent unauthenticated access.&lt;/VulnDis
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-26680r465906_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1166" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1166" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5903,7 +5821,7 @@ Incorrect configurations could prevent services from starting and result in a de
           <xccdf:fixtext fixref="F-26681r465909_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Deny log on as a service" to include no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-26681r465909_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1167" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1167" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -5935,14 +5853,14 @@ The Guests group must be assigned this right to prevent unauthenticated access.&
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-26682r465912_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1168" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1168" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225004">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225004r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225004r852366_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000410</xccdf:version>
           <xccdf:title>The Deny log on through Remote Desktop Services user right on domain controllers must be configured to prevent unauthenticated access.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5967,14 +5885,14 @@ The Guests group must be assigned this right to prevent unauthenticated access.&
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-26683r465915_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1169" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1169" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225005">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225005r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225005r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-DC-000420</xccdf:version>
           <xccdf:title>The Enable computer and user accounts to be trusted for delegation user right must only be assigned to the Administrators group on domain controllers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5997,14 +5915,14 @@ The "Enable computer and user accounts to be trusted for delegation" user right 
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26684r465918_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1170" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1170" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225008">
         <xccdf:title>SRG-OS-000134-GPOS-00068</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225008r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225008r857258_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000020</xccdf:version>
           <xccdf:title>Local administrator accounts must have their privileged token filtered to prevent elevated privileges from being used over the network on domain systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A compromised local administrator account can provide means for an attacker to move laterally between domain systems.
@@ -6022,19 +5940,19 @@ With User Account Control enabled, filtering the privileged token for local admi
           <xccdf:ident system="http://cyber.mil/legacy">V-73495</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-88147</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001084</xccdf:ident>
-          <xccdf:fixtext fixref="F-26687r465927_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; MS Security Guide &gt;&gt; "Apply UAC restrictions to local accounts on network logons" to "Enabled".
+          <xccdf:fixtext fixref="F-26687r857257_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; MS Security Guide &gt;&gt; "Apply UAC restrictions to local accounts on network logons" to "Enabled".
 
-This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and " SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
-          <xccdf:fix id="F-26687r465927_fix" />
+This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
+          <xccdf:fix id="F-26687r857257_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1172" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1172" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225009">
         <xccdf:title>SRG-OS-000095-GPOS-00049</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225009r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225009r857260_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000030</xccdf:version>
           <xccdf:title>Local users on domain-joined computers must not be enumerated.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The username is one part of logon credentials that could be used to gain access to a system. Preventing the enumeration of users limits this information to authorized personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6053,14 +5971,14 @@ This policy setting requires the installation of the SecGuide custom templates i
           <xccdf:fixtext fixref="F-26688r465930_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Logon &gt;&gt; "Enumerate local users on domain-joined computers" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26688r465930_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1173" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1173" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225010">
         <xccdf:title>SRG-OS-000379-GPOS-00164</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225010r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225010r877039_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000040</xccdf:version>
           <xccdf:title>Unauthenticated Remote Procedure Call (RPC) clients must be restricted from connecting to the RPC server.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unauthenticated RPC clients may allow anonymous access to sensitive information. Configuring RPC to restrict unauthenticated RPC clients from connecting to the RPC server will prevent anonymous connections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6080,14 +5998,14 @@ This policy setting requires the installation of the SecGuide custom templates i
           <xccdf:fixtext fixref="F-26689r465933_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Remote Procedure Call &gt;&gt; "Restrict Unauthenticated RPC clients" to "Enabled" with "Authenticated" selected.</xccdf:fixtext>
           <xccdf:fix id="F-26689r465933_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1174" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1174" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225011">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225011r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225011r857264_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000050</xccdf:version>
           <xccdf:title>Caching of logon credentials must be limited.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The default Windows configuration caches the last logon credentials for users who log on interactively to a system. This feature is provided for system availability reasons, such as the user's machine being disconnected from the network or domain controllers being unavailable. Even though the credential cache is well protected, if a system is attacked, an unauthorized individual may isolate the password to a domain user account using a password-cracking program and gain access to the domain.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6106,14 +6024,14 @@ This policy setting requires the installation of the SecGuide custom templates i
           <xccdf:fixtext fixref="F-26690r465936_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive Logon: Number of previous logons to cache (in case Domain Controller is not available)" to "4" logons or less.</xccdf:fixtext>
           <xccdf:fix id="F-26690r465936_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1175" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1175" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225013">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225013r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225013r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000310</xccdf:version>
           <xccdf:title>Remote calls to the Security Account Manager (SAM) must be restricted to Administrators.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The Windows Security Account Manager (SAM) stores users' passwords. Restricting Remote Procedure Call (RPC) connections to the SAM to Administrators helps protect those credentials.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6130,7 +6048,8 @@ This policy setting requires the installation of the SecGuide custom templates i
           <xccdf:ident system="http://cyber.mil/legacy">SV-88341</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-73677</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002235</xccdf:ident>
-          <xccdf:fixtext fixref="F-26692r465942_fix">Navigate to the policy Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Restrict clients allowed to make remote calls to SAM". 
+          <xccdf:fixtext fixref="F-26692r857269_fix">Navigate to the policy Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Restrict clients allowed to make remote calls to SAM".
+
 Select "Edit Security" to configure the "Security descriptor:".
 
 Add "Administrators" in "Group or user names:" if it is not already listed (this is the default).
@@ -6142,18 +6061,18 @@ Select "Allow" for "Remote Access" in "Permissions for "Administrators".
 Click "OK".
 
 The "Security descriptor:" must be populated with "O:BAG:BAD:(A;;RC;;;BA) for the policy to be enforced.</xccdf:fixtext>
-          <xccdf:fix id="F-26692r465942_fix" />
+          <xccdf:fix id="F-26692r857269_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1210" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1210" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225014">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225014r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225014r857272_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000340</xccdf:version>
-          <xccdf:title>The Access this computer from the network user right must only be assigned to the Administrators and Authenticated Users groups on member servers.</xccdf:title>
+          <xccdf:title>The "Access this computer from the network" user right must only be assigned to the Administrators and Authenticated Users groups on member servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 Accounts with the "Access this computer from the network" user right may access resources on the system, and this right must be limited to those requiring it.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6176,16 +6095,16 @@ Accounts with the "Access this computer from the network" user right may access 
 - Authenticated Users</xccdf:fixtext>
           <xccdf:fix id="F-26693r465945_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1176" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1176" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225015">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225015r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225015r857274_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000370</xccdf:version>
-          <xccdf:title>The Deny access to this computer from the network user right on member servers must be configured to prevent access from highly privileged domain accounts and local accounts on domain systems, and from unauthenticated access on all systems.</xccdf:title>
+          <xccdf:title>The "Deny access to this computer from the network" user right on member servers must be configured to prevent access from highly privileged domain accounts and local accounts on domain systems and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Deny access to this computer from the network" user right defines the accounts that are prevented from logging on from the network.
@@ -6221,16 +6140,16 @@ All Systems:
 Note: These are built-in security groups. "Local account" is more restrictive but may cause issues on servers such as systems that provide failover clustering.</xccdf:fixtext>
           <xccdf:fix id="F-26694r465948_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1177" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1177" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225016">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225016r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225016r857276_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000380</xccdf:version>
-          <xccdf:title>The Deny log on as a batch job user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems and from unauthenticated access on all systems.</xccdf:title>
+          <xccdf:title>The "Deny log on as a batch job" user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Deny log on as a batch job" user right defines accounts that are prevented from logging on to the system as a batch job, such as Task Scheduler.
@@ -6261,14 +6180,14 @@ All Systems:
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-26695r465951_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1178" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1178" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225017">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225017r819695_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225017r890505_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000390</xccdf:version>
           <xccdf:title>The "Deny log on as a service" user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems. No other groups or accounts must be assigned this right.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -6285,9 +6204,7 @@ Incorrect configurations could prevent services from starting and result in a de
             <dc:subject>Microsoft Windows Server 2016</dc:subject>
             <dc:identifier>4205</dc:identifier>
           </xccdf:reference>
-          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_Server_2016_Standalone" />
-          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_Server_2016_MS" />
-          <xccdf:ident system="http://cce.mitre.org">CCE-47121-9</xccdf:ident>
+          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_MemberServer" />
           <xccdf:ident system="http://cyber.mil/legacy">V-73767</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-88431</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000213</xccdf:ident>
@@ -6298,16 +6215,16 @@ Domain systems:
 - Domain Admins Group</xccdf:fixtext>
           <xccdf:fix id="F-26696r465954_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1179" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:225017" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225018">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225018r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225018r857278_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000400</xccdf:version>
-          <xccdf:title>The Deny log on locally user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems and from unauthenticated access on all systems.</xccdf:title>
+          <xccdf:title>The "Deny log on locally" user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Deny log on locally" user right defines accounts that are prevented from logging on interactively.
@@ -6338,16 +6255,16 @@ All Systems:
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-26697r465957_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1180" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1180" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225019">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225019r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225019r860023_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000410</xccdf:version>
-          <xccdf:title>The Deny log on through Remote Desktop Services user right on member servers must be configured to prevent access from highly privileged domain accounts and all local accounts on domain systems and from unauthenticated access on all systems.</xccdf:title>
+          <xccdf:title>The "Deny log on through Remote Desktop Services" user right on member servers must be configured to prevent access from highly privileged domain accounts and all local accounts on domain systems and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Deny log on through Remote Desktop Services" user right defines the accounts that are prevented from logging on using Remote Desktop Services.
@@ -6383,16 +6300,16 @@ All Systems:
 Note: "Local account" is referring to the Windows built-in security group.</xccdf:fixtext>
           <xccdf:fix id="F-26698r465960_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1181" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1181" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225020">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225020r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225020r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-MS-000420</xccdf:version>
-          <xccdf:title>The Enable computer and user accounts to be trusted for delegation user right must not be assigned to any groups or accounts on member servers.</xccdf:title>
+          <xccdf:title>The "Enable computer and user accounts to be trusted for delegation" user right must not be assigned to any groups or accounts on member servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Enable computer and user accounts to be trusted for delegation" user right allows the "Trusted for Delegation" setting to be changed. This could allow unauthorized users to impersonate other users.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6412,14 +6329,14 @@ The "Enable computer and user accounts to be trusted for delegation" user right 
           <xccdf:fixtext fixref="F-26699r465963_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Enable computer and user accounts to be trusted for delegation" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-26699r465963_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1182" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1182" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225021">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225021r819698_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225021r890508_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-PK-000010</xccdf:version>
           <xccdf:title>The DoD Root CA certificates must be installed in the Trusted Root Store.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.
@@ -6435,23 +6352,23 @@ Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-88269</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-73605</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-26700r819697_fix">Install the DoD Root CA certificates:
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
+          <xccdf:fixtext fixref="F-26700r890507_fix">Install the DoD Root CA certificates:
 DoD Root CA 3
 DoD Root CA 4
 DoD Root CA 5
 
-The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-26700r819697_fix" />
+The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. Certificate bundles published by the PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-26700r890507_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1101" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:225021" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225022">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225022r819701_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225022r894338_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-PK-000020</xccdf:version>
           <xccdf:title>The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.
@@ -6468,25 +6385,22 @@ Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">V-73607</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-26701r819700_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
+          <xccdf:fixtext fixref="F-26701r890510_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
 
-Issued To - Issued By - Thumbprint                                                             
-DoD Root CA 3 - DoD Interoperability Root CA 2 - AC06108CA348CC03B53795C64BF84403C1DBD341
+Issued To - Issued By - Thumbprint
+DoD Root CA 3 - DoD Interoperability Root CA 2 - 49CBE933151872E17C8EAE7F0ABA97FB610F6477
 
-Issued To - Issued By - Thumbprint 
-DoD Root CA 3 - DoD Interoperability Root CA 2 - 49CBE933151872E17C8EAE7F0ABA97FB610F6477                         
-
-The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files</xccdf:fixtext>
-          <xccdf:fix id="F-26701r819700_fix" />
+The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. Certificate bundles published by the PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-26701r890510_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1102" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:225022" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225023">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225023r569271_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225023r890514_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-PK-000030</xccdf:version>
           <xccdf:title>The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.
@@ -6503,15 +6417,17 @@ Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-88273</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
-          <xccdf:fixtext fixref="F-26702r603194_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
+          <xccdf:fixtext fixref="F-26702r890513_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
 
-Issued To - Issued By - Thumbprint
-DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2 - AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9
+Subject: CN=DoD Root CA 3, OU=PKI, OU=DoD, O=U.S. Government, C=US
+Issuer: CN=US DoD CCEB Interoperability Root CA 2, OU=PKI, OU=DoD, O=U.S. Government, C=US
+Thumbprint: 9B74964506C7ED9138070D08D5F8B969866560C8
+NotAfter: 7/18/2025
 
-The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-26702r603194_fix" />
+The certificates can be installed using the InstallRoot tool. The tool and user guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. Certificate bundles published by the PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-26702r890513_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1103" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:225023" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6537,7 +6453,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-26703r465975_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_guest_account_status_var" export-name="oval:mil.disa.stig.windows:var:118301" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1183" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1183" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6563,7 +6479,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fix id="F-26704r465978_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_limit_blank_password_use_var" export-name="oval:mil.disa.stig.windows:var:118400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1184" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1184" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6588,7 +6504,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fixtext fixref="F-26705r465981_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Accounts: Rename administrator account" to a name other than "Administrator".</xccdf:fixtext>
           <xccdf:fix id="F-26705r465981_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1185" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1185" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6613,7 +6529,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
           <xccdf:fixtext fixref="F-26706r465984_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Accounts: Rename guest account" to a name other than "Guest".</xccdf:fixtext>
           <xccdf:fix id="F-26706r465984_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1186" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1186" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6623,7 +6539,7 @@ The certificates can be installed using the InstallRoot tool. The tool and user 
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225028r569186_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000050</xccdf:version>
           <xccdf:title>Audit policy using subcategories must be enabled.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
 This setting allows administrators to enable more precise auditing capabilities.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2016</dc:title>
@@ -6639,14 +6555,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fixtext fixref="F-26707r465987_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Audit: Force audit policy subcategory settings (Windows Vista or later) to override audit policy category settings" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26707r465987_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1187" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1187" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225029">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225029r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225029r852378_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000080</xccdf:version>
           <xccdf:title>The setting Domain member: Digitally encrypt or sign secure channel data (always) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted. If this policy is enabled, outgoing secure channel traffic will be encrypted and signed.
@@ -6667,14 +6583,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26708r465990_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Digitally encrypt or sign secure channel data (always)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26708r465990_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1188" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1188" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225030">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225030r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225030r852379_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000090</xccdf:version>
           <xccdf:title>The setting Domain member: Digitally encrypt secure channel data (when possible) must be configured to enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted. If this policy is enabled, outgoing secure channel traffic will be encrypted.
@@ -6695,14 +6611,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26709r465993_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Digitally encrypt secure channel data (when possible)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26709r465993_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1189" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1189" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225031">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225031r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225031r852380_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000100</xccdf:version>
           <xccdf:title>The setting Domain member: Digitally sign secure channel data (when possible) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but the channel is not integrity checked. If this policy is enabled, outgoing secure channel traffic will be signed.
@@ -6723,14 +6639,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26710r465996_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Digitally sign secure channel data (when possible)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26710r465996_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1190" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1190" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225032">
         <xccdf:title>SRG-OS-000379-GPOS-00164</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225032r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225032r877039_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000110</xccdf:version>
           <xccdf:title>The computer account password must not be prevented from being reset.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Computer account passwords are changed automatically on a regular basis. Disabling automatic password changes can make the system more vulnerable to malicious access. Frequent password changes can be a significant safeguard for the system. A new password for the computer account will be generated every 30 days.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6748,7 +6664,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26711r465999_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Disable machine account password changes" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26711r465999_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1191" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1191" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6775,14 +6691,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
 Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Maximum machine account password age" to "30" or less (excluding "0", which is unacceptable).</xccdf:fixtext>
           <xccdf:fix id="F-26712r466002_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1192" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1192" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225034">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225034r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225034r852382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000130</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to require a strong session key.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A computer connecting to a domain controller will establish a secure channel. The secure channel connection may be subject to compromise, such as hijacking or eavesdropping, if strong session keys are not used to establish the connection. Requiring strong session keys enforces 128-bit encryption between systems.
@@ -6803,7 +6719,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26713r466005_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Require strong (Windows 2000 or Later) session key" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26713r466005_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1193" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1193" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6821,14 +6737,13 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
             <dc:subject>Microsoft Windows Server 2016</dc:subject>
             <dc:identifier>4205</dc:identifier>
           </xccdf:reference>
-          <xccdf:ident system="http://cce.mitre.org">CCE-46768-8</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-73645</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-88309</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000057</xccdf:ident>
           <xccdf:fixtext fixref="F-26714r466008_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive logon: Machine inactivity limit" to "900" seconds or less, excluding "0" which is effectively disabled.</xccdf:fixtext>
           <xccdf:fix id="F-26714r466008_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1194" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:225035" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -6853,14 +6768,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26717r466017_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive logon: Smart card removal behavior" to "Lock Workstation" or "Force Logoff".</xccdf:fixtext>
           <xccdf:fix id="F-26717r466017_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1197" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1197" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225039">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225039r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225039r852383_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000190</xccdf:version>
           <xccdf:title>The setting Microsoft network client: Digitally sign communications (always) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations. Digitally signed SMB packets aid in preventing man-in-the-middle attacks. If this policy is enabled, the SMB client will only communicate with an SMB server that performs SMB packet signing.
@@ -6881,14 +6796,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26718r466020_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft network client: Digitally sign communications (always)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26718r466020_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1198" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1198" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225040">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225040r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225040r852384_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000200</xccdf:version>
           <xccdf:title>The setting Microsoft network client: Digitally sign communications (if server agrees) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations. If this policy is enabled, the SMB client will request packet signing when communicating with an SMB server that is enabled or required to perform SMB packet signing.
@@ -6909,14 +6824,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26719r466023_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft network client: Digitally sign communications (if server agrees)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26719r466023_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1199" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1199" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225041">
         <xccdf:title>SRG-OS-000074-GPOS-00042</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225041r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225041r877396_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000210</xccdf:version>
           <xccdf:title>Unencrypted passwords must not be sent to third-party Server Message Block (SMB) servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Some non-Microsoft SMB servers only support unencrypted (plain-text) password authentication. Sending plain-text passwords across the network when authenticating to an SMB server reduces the overall security of the environment. Check with the vendor of the SMB server to determine if there is a way to support encrypted password authentication.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6934,14 +6849,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26720r466026_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft Network Client: Send unencrypted password to third-party SMB servers" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26720r466026_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1200" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1200" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225042">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225042r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225042r852385_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000230</xccdf:version>
           <xccdf:title>The setting Microsoft network server: Digitally sign communications (always) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations. Digitally signed SMB packets aid in preventing man-in-the-middle attacks. If this policy is enabled, the SMB server will only communicate with an SMB client that performs SMB packet signing.
@@ -6962,14 +6877,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26721r466029_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft network server: Digitally sign communications (always)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26721r466029_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1202" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1202" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225043">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225043r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225043r852386_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000240</xccdf:version>
           <xccdf:title>The setting Microsoft network server: Digitally sign communications (if client agrees) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations. Digitally signed SMB packets aid in preventing man-in-the-middle attacks. If this policy is enabled, the SMB server will negotiate SMB packet signing as requested by the client.
@@ -6990,7 +6905,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26722r466032_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft network server: Digitally sign communications (if client agrees)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26722r466032_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1203" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1203" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7015,7 +6930,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26724r466038_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Do not allow anonymous enumeration of SAM accounts" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26724r466038_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1205" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1205" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7040,7 +6955,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26725r466041_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Do not allow anonymous enumeration of SAM accounts and shares" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26725r466041_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1206" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1206" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7065,7 +6980,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26726r466044_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Let everyone permissions apply to anonymous users" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26726r466044_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1208" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1208" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7090,7 +7005,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26727r466047_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Restrict anonymous access to Named Pipes and Shares" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26727r466047_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1209" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1209" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7115,7 +7030,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26728r466050_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Allow Local System to use computer identity for NTLM" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26728r466050_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1211" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1211" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7140,7 +7055,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26729r466053_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Allow LocalSystem NULL session fallback" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26729r466053_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1212" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1212" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7165,7 +7080,7 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26730r466056_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Allow PKU2U authentication requests to this computer to use online identities" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26730r466056_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1213" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1213" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7193,19 +7108,19 @@ Note: Organizations with domain controllers running earlier versions of Windows 
 
 AES128_HMAC_SHA1
 AES256_HMAC_SHA1
-Future encryption types   
+Future encryption types
 
 Note: Organizations with domain controllers running earlier versions of Windows where RC4 encryption is enabled, selecting "The other domain supports Kerberos AES Encryption" on domain trusts, may be required to allow client communication across the trust relationship.</xccdf:fixtext>
           <xccdf:fix id="F-26731r466059_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1214" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1214" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225053">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225053r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225053r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000360</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to prevent the storage of the LAN Manager hash of passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The LAN Manager hash uses a weak encryption algorithm and there are several tools available that use this hash to retrieve account passwords. This setting controls whether a LAN Manager hash of the password is stored in the SAM the next time the password is changed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7223,17 +7138,17 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fixtext fixref="F-26732r466062_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Do not store LAN Manager hash value on next password change" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26732r466062_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1215" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1215" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225054">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225054r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225054r857283_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000380</xccdf:version>
           <xccdf:title>The LAN Manager authentication level must be set to send NTLMv2 response only and to refuse LM and NTLM.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;The Kerberos v5 authentication protocol is the default for authentication of users who are logging on to domain accounts. NTLM, which is less secure, is retained in later Windows versions for compatibility with clients and servers that are running earlier versions of Windows or applications that still use it. It is also used to authenticate logons to standalone computers that are running later versions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:description>&lt;VulnDiscussion&gt;The Kerberos v5 authentication protocol is the default for authentication of users who are logging on to domain accounts. NTLM, which is less secure, is retained in later Windows versions for compatibility with clients and servers that are running earlier versions of Windows or applications that still use it. It is also used to authenticate logons to standalone or nondomain-joined computers that are running later versions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2016</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -7248,7 +7163,7 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fixtext fixref="F-26733r466065_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: LAN Manager authentication level" to "Send NTLMv2 response only. Refuse LM &amp; NTLM".</xccdf:fixtext>
           <xccdf:fix id="F-26733r466065_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1217" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1217" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7273,7 +7188,7 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fixtext fixref="F-26734r466068_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: LDAP client signing requirements" to "Negotiate signing" at a minimum.</xccdf:fixtext>
           <xccdf:fix id="F-26734r466068_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1218" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1218" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7298,7 +7213,7 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fixtext fixref="F-26735r466071_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) clients" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-26735r466071_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1219" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1219" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7323,7 +7238,7 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fixtext fixref="F-26736r466074_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) servers" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-26736r466074_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1220" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1220" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7354,14 +7269,14 @@ Both the holders of a digital certificate and the issuing authority must protect
           <xccdf:fixtext fixref="F-26737r466077_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "System cryptography: Force strong key protection for user keys stored on the computer" to "User must enter a password each time they use a key".</xccdf:fixtext>
           <xccdf:fix id="F-26737r466077_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1221" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1221" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225059">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225059r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225059r877398_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000430</xccdf:version>
           <xccdf:title>Windows Server 2016 must be configured to use FIPS-compliant algorithms for encryption, hashing, and signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting ensures the system uses algorithms that are FIPS-compliant for encryption, hashing, and signing. FIPS-compliant algorithms meet specific standards established by the U.S. Government and must be the algorithms used for all OS encryption functions.
@@ -7382,7 +7297,7 @@ Satisfies: SRG-OS-000033-GPOS-00014, SRG-OS-000478-GPOS-00223&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26738r466080_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "System cryptography: Use FIPS compliant algorithms for encryption, hashing, and signing" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26738r466080_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1222" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1222" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7407,14 +7322,14 @@ Satisfies: SRG-OS-000033-GPOS-00014, SRG-OS-000478-GPOS-00223&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26739r466083_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "System objects: Strengthen default permissions of internal system objects (e.g., Symbolic Links)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26739r466083_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1224" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1224" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225061">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225061r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225061r852388_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000460</xccdf:version>
           <xccdf:title>User Account Control approval mode for the built-in Administrator must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized. This setting configures the built-in Administrator account so that it runs in Admin Approval Mode.
@@ -7434,7 +7349,7 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26740r466086_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Admin Approval Mode for the Built-in Administrator account" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26740r466086_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1225" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1225" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7459,7 +7374,7 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26741r466089_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Allow UIAccess applications to prompt for elevation without using the secure desktop" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-26741r466089_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1226" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1226" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7486,14 +7401,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
 The more secure option for this setting, "Prompt for credentials on the secure desktop", would also be acceptable.</xccdf:fixtext>
           <xccdf:fix id="F-26742r466092_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1227" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1227" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225064">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225064r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225064r852389_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000490</xccdf:version>
           <xccdf:title>User Account Control must automatically deny standard user requests for elevation.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized. This setting controls the behavior of elevation when requested by a standard user account.
@@ -7513,7 +7428,7 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26743r466095_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Behavior of the elevation prompt for standard users" to "Automatically deny elevation requests".</xccdf:fixtext>
           <xccdf:fix id="F-26743r466095_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1228" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1228" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7538,7 +7453,7 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26744r466098_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Detect application installations and prompt for elevation" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26744r466098_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1229" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1229" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7563,14 +7478,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26745r466101_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Only elevate UIAccess applications that are installed in secure locations" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26745r466101_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1230" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1230" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225067">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225067r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225067r852390_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-SO-000520</xccdf:version>
           <xccdf:title>User Account Control must run all administrators in Admin Approval Mode, enabling UAC.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized. This setting enables UAC.
@@ -7590,7 +7505,7 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26746r466104_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Run all administrators in Admin Approval Mode" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26746r466104_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1231" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1231" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7615,14 +7530,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-26747r466107_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Virtualize file and registry write failures to per-user locations" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-26747r466107_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1232" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1232" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225070">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225070r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225070r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000010</xccdf:version>
           <xccdf:title>The Access Credential Manager as a trusted caller user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7642,14 +7557,14 @@ Accounts with the "Access Credential Manager as a trusted caller" user right may
           <xccdf:fixtext fixref="F-26749r466113_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Access Credential Manager as a trusted caller" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-26749r466113_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1236" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1236" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225071">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225071r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225071r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000030</xccdf:version>
           <xccdf:title>The Act as part of the operating system user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7669,7 +7584,7 @@ Accounts with the "Act as part of the operating system" user right can assume th
           <xccdf:fixtext fixref="F-26750r466116_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Act as part of the operating system" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-26750r466116_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1237" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1237" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7698,14 +7613,14 @@ Accounts with the "Allow log on locally" user right can log on interactively to 
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26751r466119_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1238" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1238" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225073">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225073r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225073r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000070</xccdf:version>
           <xccdf:title>The Back up files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7727,14 +7642,14 @@ Accounts with the "Back up files and directories" user right can circumvent file
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26752r466122_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1239" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1239" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225074">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225074r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225074r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000080</xccdf:version>
           <xccdf:title>The Create a pagefile user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7756,14 +7671,14 @@ Accounts with the "Create a pagefile" user right can change the size of a pagefi
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26753r466125_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1240" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1240" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225076">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225076r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225076r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000100</xccdf:version>
           <xccdf:title>The Create global objects user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7788,14 +7703,14 @@ Accounts with the "Create global objects" user right can create objects that are
 - Network Service</xccdf:fixtext>
           <xccdf:fix id="F-26755r466130_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1242" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1242" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225077">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225077r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225077r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000110</xccdf:version>
           <xccdf:title>The Create permanent shared objects user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7815,14 +7730,14 @@ Accounts with the "Create permanent shared objects" user right could expose sens
           <xccdf:fixtext fixref="F-26756r466133_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create permanent shared objects" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-26756r466133_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1243" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1243" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225078">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225078r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225078r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000120</xccdf:version>
           <xccdf:title>The Create symbolic links user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7846,14 +7761,14 @@ Accounts with the "Create symbolic links" user right can create pointers to othe
 Systems that have the Hyper-V role will also have "Virtual Machines" given this user right. If this needs to be added manually, enter it as "NT Virtual Machine\Virtual Machines".</xccdf:fixtext>
           <xccdf:fix id="F-26757r466136_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1244" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1244" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225079">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225079r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225079r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000130</xccdf:version>
           <xccdf:title>The Debug programs user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7875,14 +7790,14 @@ Accounts with the "Debug programs" user right can attach a debugger to any proce
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26758r466139_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1245" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1245" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225080">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225080r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225080r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000200</xccdf:version>
           <xccdf:title>The Force shutdown from a remote system user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7904,14 +7819,14 @@ Accounts with the "Force shutdown from a remote system" user right can remotely 
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26759r466142_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1246" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1246" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225081">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225081r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225081r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000210</xccdf:version>
           <xccdf:title>The Generate security audits user right must only be assigned to Local Service and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7934,14 +7849,14 @@ The "Generate security audits" user right specifies users and processes that can
 - Network Service</xccdf:fixtext>
           <xccdf:fix id="F-26760r466145_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1247" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1247" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225082">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225082r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225082r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000220</xccdf:version>
           <xccdf:title>The Impersonate a client after authentication user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7966,14 +7881,14 @@ The "Impersonate a client after authentication" user right allows a program to i
 - Network Service</xccdf:fixtext>
           <xccdf:fix id="F-26761r466148_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1248" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1248" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225083">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225083r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225083r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000230</xccdf:version>
           <xccdf:title>The Increase scheduling priority user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -7995,14 +7910,14 @@ Accounts with the "Increase scheduling priority" user right can change a schedul
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26762r466151_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1249" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1249" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225084">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225084r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225084r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000240</xccdf:version>
           <xccdf:title>The Load and unload device drivers user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -8024,14 +7939,14 @@ The "Load and unload device drivers" user right allows a user to load device dri
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26763r466154_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1250" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1250" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225085">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225085r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225085r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000250</xccdf:version>
           <xccdf:title>The Lock pages in memory user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -8051,14 +7966,14 @@ The "Lock pages in memory" user right allows physical memory to be assigned to p
           <xccdf:fixtext fixref="F-26764r466157_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Lock pages in memory" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-26764r466157_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1251" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1251" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225086">
         <xccdf:title>SRG-OS-000057-GPOS-00027</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225086r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225086r852405_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000260</xccdf:version>
           <xccdf:title>The Manage auditing and security log user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -8086,14 +8001,14 @@ Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPO
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26765r466160_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1252" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1252" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225087">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225087r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225087r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000270</xccdf:version>
           <xccdf:title>The Modify firmware environment values user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -8115,14 +8030,14 @@ Accounts with the "Modify firmware environment values" user right can change har
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26766r466163_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1253" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1253" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225088">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225088r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225088r891712_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000280</xccdf:version>
           <xccdf:title>The Perform volume maintenance tasks user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -8135,23 +8050,22 @@ Accounts with the "Perform volume maintenance tasks" user right can manage volum
             <dc:subject>Microsoft Windows Server 2016</dc:subject>
             <dc:identifier>4205</dc:identifier>
           </xccdf:reference>
-          <xccdf:ident system="http://cce.mitre.org">CCE-46126-9</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-88461</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-73797</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002235</xccdf:ident>
-          <xccdf:fixtext fixref="F-26767r466166_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Perform volume maintenance tasks" to include only the following accounts or groups:
+          <xccdf:fixtext fixref="F-26767r890516_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; Perform volume maintenance tasks to include only the following accounts or groups:
 
 - Administrators</xccdf:fixtext>
-          <xccdf:fix id="F-26767r466166_fix" />
+          <xccdf:fix id="F-26767r890516_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1254" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2016:def:225088" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225089">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225089r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225089r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000290</xccdf:version>
           <xccdf:title>The Profile single process user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -8173,14 +8087,14 @@ Accounts with the "Profile single process" user right can monitor non-system pro
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26768r466169_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1255" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1255" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225091">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225091r569186_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225091r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000090</xccdf:version>
           <xccdf:title>The Create a token object user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -8200,14 +8114,14 @@ The "Create a token object" user right allows a process to create an access toke
           <xccdf:fixtext fixref="F-26771r466176_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create a token object" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-26771r466176_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1241" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1241" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225092">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225092r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225092r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000300</xccdf:version>
           <xccdf:title>The Restore files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -8229,14 +8143,14 @@ Accounts with the "Restore files and directories" user right can circumvent file
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26772r466179_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1256" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1256" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-225093">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225093r569186_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-225093r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN16-UR-000310</xccdf:version>
           <xccdf:title>The Take ownership of files or other objects user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -8258,18 +8172,18 @@ Accounts with the "Take ownership of files or other objects" user right can take
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-26773r466182_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1257" href="U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:1257" href="U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
     </xccdf:Benchmark>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2022-05-01T21:48:27">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2023-03-28T17:41:26">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-05-01T21:48:27</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:25</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.windows:def:4595" version="1" class="compliance">
@@ -8656,16 +8570,177 @@ Accounts with the "Take ownership of files or other objects" user right can take
             <criterion test_ref="oval:mil.disa.fso.windows:tst:497501" comment="Audit - Audit Policy Change - Success and Failure" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4984" version="2" class="compliance">
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253303" version="2">
           <metadata>
-            <title>Event Viewer must be protected from unauthorized modification and deletion</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-            </affected>
-            <description>Verify the permissions on Event Viewer only allow TrustedInstaller permissions to change or modify.</description>
+            <title>Passwords must, at a minimum, be 14 characters.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25330300" comment="Verifies 'Minimum password length' is set to at least '14' characters" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253393" version="2">
+          <metadata>
+            <title>Windows Telemetry must not be configured to Full.</title>
+            <description />
           </metadata>
           <criteria>
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:498400" comment="Eventvwr.exe: Read and Execute rights for Administrators, System, Users, All Application Packages" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25339300" comment="Verifies 'Allow Diagnostic Data' is set to 'Diagnostic Data Off (Not recommended)' or 'Send Required Diagnostic Data' selected in 'Options:'" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253427" version="1">
+          <metadata>
+            <title>The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342700" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342701" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342702" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253429" version="3">
+          <metadata>
+            <title>The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342900" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253430" version="2">
+          <metadata>
+            <title>The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25343000" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253444" version="1">
+          <metadata>
+            <title>The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.windows:tst:25344400" comment="The machine inactivity limit is set to 15 minutes or less" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253493" version="2">
+          <metadata>
+            <title>The "Deny log on as a service" user right on Windows domain-joined workstations must be configured to prevent access from highly privileged domain accounts.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25349300" comment="Deny log on as a service - Domain Admins" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25349301" comment="Deny log on as a service - Enterprise Admins" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253503" version="1">
+          <metadata>
+            <title>The "Perform volume maintenance tasks" user right must only be assigned to the Administrators group.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25350300" comment="Perform volume maintenance tasks - Administrators" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254296" version="1">
+          <metadata>
+            <title>Windows permissions for the Application event log must prevent access by non-privileged accounts.</title>
+            <description />
+          </metadata>
+          <criteria operator="OR">
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429601" comment="The Application event log must have at least default permissions. Strict Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334002" negate="true" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429600" comment="The Application event log must have at least default permissions. Built Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334002" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254297" version="1">
+          <metadata>
+            <title>Windows permissions for the Security event log must prevent access by non-privileged accounts.</title>
+            <description />
+          </metadata>
+          <criteria operator="OR">
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429701" comment="The Security event log must have at least default permissions. Strict Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334102" negate="true" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429700" comment="The Security event log must have at least default permissions. Built Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334102" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254298" version="1">
+          <metadata>
+            <title>Windows permissions for the System event log must prevent access by non-privileged accounts.</title>
+            <description />
+          </metadata>
+          <criteria operator="OR">
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429801" comment="The System event log must have at least default permissions. Strict Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334202" negate="true" comment="The System event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429800" comment="The System event log must have at least default permissions. Built Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334202" comment="The System event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254299" version="1">
+          <metadata>
+            <title>Windows Event Viewer must be protected from unauthorized modification and deletion.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25429900" comment="Eventvwr.exe: Read and Execute rights for Administrators, System, Users, All Application Packages" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254391" version="1">
+          <metadata>
+            <title>Windows permissions on the Active Directory data files must only allow System and Administrators access.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439100" comment="Database log files: NT Authority\SYSTEM has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439101" comment="Database log files: BUILTIN\Administrators has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439102" comment="Database log files: No other permissions" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439103" comment="DSA Database file: NT Authority\SYSTEM has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439104" comment="DSA Database file: BUILTIN\Administrators has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439105" comment="DSA Database file: No other permissions" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439106" comment="DSA Working Directory: NT Authority\SYSTEM has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439107" comment="DSA Working Directory: BUILTIN\Administrators has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439108" comment="DSA Working Directory: No other permissions" />
+          </criteria>
+        </definition>
+        <definition class="inventory" id="oval:mil.disa.stig.win:def:100004" version="2">
+          <metadata>
+            <title>The system is a Windows Domain Member Server</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server</platform>
+            </affected>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:10000400" />
+          </criteria>
+        </definition>
+        <definition class="inventory" id="oval:mil.disa.stig.win:def:100005" version="2">
+          <metadata>
+            <title>The system is a Windows Domain Controller</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server</platform>
+            </affected>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:10000500" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:19" version="3" class="compliance">
@@ -8684,20 +8759,6 @@ Accounts with the "Take ownership of files or other objects" user right can take
               <criterion test_ref="oval:mil.disa.stig.windows:tst:1900" comment="Mutual Authentication and Integrity for \\*\SYSVOL" />
               <criterion test_ref="oval:mil.disa.stig.windows:tst:1901" comment="Mutual Authentication and Integrity for \\*\NETLOGON" />
             </criteria>
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:24" version="4" class="compliance">
-          <metadata>
-            <title>Windows Telemetry must be configured to the lowest level of data sent to Microsoft.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Windows Telemetry must be configured to the lowest level of data sent to Microsoft.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:2400" comment="AllowTelemetry = 0 or 1" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:65" version="2" class="compliance">
@@ -8781,20 +8842,6 @@ Accounts with the "Take ownership of files or other objects" user right can take
           <criteria operator="OR" comment="Audit - Other System Events - Success">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:11800" comment="Audit - Other System Events - Success only" />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:11801" comment="Audit - Other System Events - Success and Failure" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:119" version="1" class="compliance">
-          <metadata>
-            <title>WN10-AU-000055</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The system must be configured to audit Logon/Logoff - Account Lockout successes.</description>
-          </metadata>
-          <criteria operator="OR" comment="Audit - Special Logon - Success">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:11900" comment="Audit - Account Lockout - Success only" />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:11901" comment="Audit - Account Lockout - Success and Failure" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:137" version="3" class="compliance">
@@ -9017,20 +9064,6 @@ Accounts with the "Take ownership of files or other objects" user right can take
             <criterion test_ref="oval:mil.disa.stig.windows:tst:101600" comment="Verifies 'Minimum Password Age' is set to at least '1' day" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1017" version="1" class="compliance">
-          <metadata>
-            <title>Minimum Password Length</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference source="DISA" ref_id="73321" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-46914-8" />
-            <description>Passwords must, at a minimum, be 14 characters.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:101700" comment="Verifies 'Minimum password length' is set to at least '14' characters" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:1018" version="1" class="compliance">
           <metadata>
             <title>Microsoft Strong Password Filtering</title>
@@ -9156,19 +9189,6 @@ Accounts with the "Take ownership of files or other objects" user right can take
           <criteria operator="OR">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:104501" comment="Check to make sure the Telnet Client server feature is not present." />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:104502" comment="Check to make sure the Telnet Client server feature is disabled." />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1054" version="3" class="compliance">
-          <metadata>
-            <title>Event Viewer must be protected from unauthorized modification and deletion. Windows 2016.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference source="DISA" ref_id="72135" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <description>Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data.</description>
-          </metadata>
-          <criteria operator="AND">
-            <extend_definition definition_ref="oval:mil.disa.fso.windows:def:4984" comment="Windows2012 audit authentication policy change check." />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:1055" version="1" class="compliance">
@@ -9688,43 +9708,6 @@ Accounts with the "Take ownership of files or other objects" user right can take
             <criterion test_ref="oval:mil.disa.stig.windows:tst:109900" comment="Verifies 'Turn off AutoPlay' is set to 'Enabled' with 'All Drives' selected" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1101" version="3" class="compliance">
-          <metadata>
-            <title>WN16-PK-000010 - The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.</description>
-          </metadata>
-          <criteria operator="AND">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:4200" comment="Verifies the DoD Root CA certificates are installed in the Trusted Root Store." />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1102" version="4" class="compliance">
-          <metadata>
-            <title>WN16-PK-000020 - The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:110200" comment="DoD Interoperability Root CA 1 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:110201" comment="DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1103" version="4" class="compliance">
-          <metadata>
-            <title>WN16-PK-000030 - The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
-          </metadata>
-          <criteria>
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:110300" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:1104" version="1" class="compliance">
           <metadata>
             <title>WN16-CC-000280</title>
@@ -10144,56 +10127,6 @@ Accounts with the "Take ownership of files or other objects" user right can take
             <criterion test_ref="oval:mil.disa.stig.windows:tst:113400" comment="Kerberos Policy - Maximum tolerance for computer clock synchronization - 5 minutes or less" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1135" version="2" class="compliance">
-          <metadata>
-            <title>Active Directory data files must have proper access control permissions.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Active Directory data files must have proper access control permissions.</description>
-          </metadata>
-          <criteria operator="OR" comment="IF system is a DC, THEN do the permission checks.">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1010" negate="true" comment="System is a DC." />
-            <criteria operator="AND">
-              <criteria comment="Database log files path permissions OK" operator="OR">
-                <criteria comment="Database log files path permissions OK using SCC" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113500" comment="Database log files: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113501" comment="Database log files: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113502" comment="Database log files: No other permissions" />
-                </criteria>
-                <criteria comment="Database log files path permissions OK using McAfee products" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113506" comment="Database log files: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113507" comment="Database log files: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113508" comment="Database log files: No other permissions" />
-                </criteria>
-              </criteria>
-              <criteria comment="DSA Database file and files in the same folder permissions OK" operator="OR">
-                <criteria comment="DSA Database file and path permissions OK using SCC" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113503" comment="DSA Database file: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113504" comment="DSA Database file: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113505" comment="DSA Database file: No other permissions" />
-                </criteria>
-                <criteria comment="DSA Database file and path permissions OK using McAfee products" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113509" comment="DSA Database file: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113510" comment="DSA Database file: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113511" comment="DSA Database file: No other permissions" />
-                </criteria>
-              </criteria>
-              <criteria comment="DSA Working Directory permissions OK" operator="OR">
-                <criteria comment="DSA Working Directory permissions OK using SCC" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113512" comment="DSA Working Directory: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113513" comment="DSA Working Directory: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113514" comment="DSA Working Directory: No other permissions" />
-                </criteria>
-                <criteria comment="DSA Working Directory permissions OK using McAfee products" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113515" comment="DSA Working Directory: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113516" comment="DSA Working Directory: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113517" comment="DSA Working Directory: No other permissions" />
-                </criteria>
-              </criteria>
-            </criteria>
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:1152" version="3" class="compliance">
           <metadata>
             <title>Audit - Directory Service Access - Success</title>
@@ -10239,22 +10172,6 @@ Accounts with the "Take ownership of files or other objects" user right can take
           <criteria operator="OR" comment="IF system is a DC, THEN check Audit - Directory Service Changes - Success">
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1010" negate="true" comment="System is a DC." />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:115400" comment="Audit - Directory Service Changes - Success only" />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:115401" comment="Audit - Directory Service Changes - Success and Failure" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1155" version="2" class="compliance">
-          <metadata>
-            <title>Audit - Directory Service Changes - Failure</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference source="DISA" ref_id="73441" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-46701-9" />
-            <description>The system must be configured to audit DS Access - Directory Service Changes failures.</description>
-          </metadata>
-          <criteria operator="OR" comment="IF system is a DC, THEN check for Audit - Directory Service Changes - Failure">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1010" negate="true" comment="System is a DC." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:115500" comment="Audit - Directory Service Changes - Failure only" />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:115401" comment="Audit - Directory Service Changes - Success and Failure" />
           </criteria>
         </definition>
@@ -10563,35 +10480,6 @@ Accounts with the "Take ownership of files or other objects" user right can take
             </criteria>
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1179" version="2" class="compliance">
-          <metadata>
-            <title>WN16-MS-000390 - The "Deny log on as a service" user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems. No other groups or accounts must be assigned this right.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference source="DISA" ref_id="26484" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-47121-9" />
-            <description>Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
-
-The "Deny log on as a service" user right defines accounts that are denied logon as a service.
-
-In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower-trust systems helps mitigate the risk of privilege escalation from credential theft attacks, which could lead to the compromise of an entire domain.
-
-Incorrect configurations could prevent services from starting and result in a denial of service.</description>
-          </metadata>
-          <criteria operator="OR">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1010" negate="false" comment="IF system is a DC" />
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:117705" comment="IF system is a standalone server" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:117900" comment="Deny log on as a service - None" />
-            </criteria>
-            <criteria operator="AND">
-              <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1171" negate="false" comment="If the system is a domain joined member server" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:117901" comment="Deny log on as a service - Domain Admins" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:117902" comment="Deny log on as a service - Enterprise Admins" />
-            </criteria>
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:1180" version="1" class="compliance">
           <metadata>
             <title>Deny log on locally - Member and Standalone Server</title>
@@ -10810,19 +10698,6 @@ Incorrect configurations could prevent services from starting and result in a de
           </metadata>
           <criteria operator="AND">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:119300" comment="Verifies 'Domain member: Require strong (Windows 2000 or later) session key' is set to 'Enabled'" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1194" version="2" class="compliance">
-          <metadata>
-            <title>WN16-SO-000140</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference ref_id="CCE-46768-8" source="http://cce.mitre.org" />
-            <description>The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:4202" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:1197" version="1" class="compliance">
@@ -11518,20 +11393,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <criterion test_ref="oval:mil.disa.stig.windows:tst:125300" comment="Modify firmware environment values - Administrators" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1254" version="1" class="compliance">
-          <metadata>
-            <title>WN16-UR-000280</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference source="DISA" ref_id="73797" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-46126-9" />
-            <description>The Perform volume maintenance tasks user right must only be assigned to the Administrators group.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:125400" comment="Perform volume maintenance tasks - Administrators" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:1255" version="1" class="compliance">
           <metadata>
             <title>WN16-UR-000290</title>
@@ -11657,25 +11518,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:118" comment="Audit - Other System Events - Success" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1264" version="1" class="compliance">
-          <metadata>
-            <title>Permissions for the Security event log must prevent access by non-privileged accounts.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The Security event log may disclose sensitive information or be susceptible to tampering if proper permissions are not applied.</description>
-          </metadata>
-          <criteria operator="OR">
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:126401" comment="The Security event log must have at least default permissions. Strict Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:126402" negate="true" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:126400" comment="The Security event log must have at least default permissions. Built Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:126402" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:1265" version="1" class="compliance">
           <metadata>
             <title>WN16-00-000400</title>
@@ -11698,18 +11540,6 @@ Incorrect configurations could prevent services from starting and result in a de
           </metadata>
           <criteria comment="Determine if Windows PowerShell 2.0 feature is not installed">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:126600" comment="Verifies the Windows PowerShell 2.0 Engine server feature is not installed" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1267" version="2" class="compliance">
-          <metadata>
-            <title>WN16-AU-000220</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Windows Server 2016 must be configured to audit Logon/Logoff - Account Lockout successes.</description>
-          </metadata>
-          <criteria comment="Audit - Account Lockout - Success">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:119" comment="Is Audit - Logon/Logoff - Account Lockout set to audit successes" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:1268" version="2" class="compliance">
@@ -11735,44 +11565,6 @@ Incorrect configurations could prevent services from starting and result in a de
           </metadata>
           <criteria operator="AND" comment="Audit - Process Creation - Success">
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:117" comment="Audit System - Other System Events failures" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1270" version="2" class="compliance">
-          <metadata>
-            <title>Permissions for the Application event log must prevent access by non-privileged accounts.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The Application event log may be susceptible to tampering if proper permissions are not applied.</description>
-          </metadata>
-          <criteria operator="OR">
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127001" comment="The Application event log must have at least default permissions. Strict Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127002" negate="true" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127000" comment="The Application event log must have at least default permissions. Built Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127002" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1271" version="1" class="compliance">
-          <metadata>
-            <title>Permissions for the System event log must prevent access by non-privileged accounts.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The System event log may be susceptible to tampering if proper permissions are not applied.</description>
-          </metadata>
-          <criteria operator="OR">
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127101" comment="The System event log must have at least default permissions. Strict Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127102" negate="true" comment="The System event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127100" comment="The System event log must have at least default permissions. Built Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127102" comment="The System event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:1273" version="1" class="compliance">
@@ -11815,36 +11607,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <criterion test_ref="oval:mil.disa.stig.windows:tst:127501" comment="Audit - Other Object Access Events - Success and Failure" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:4200" version="2" class="compliance">
-          <metadata>
-            <title>DoD Root CA Certificates</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The DoD Root CA certificates must be installed in the Trusted Root Store.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420001" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420002" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420003" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:4202" version="1" class="compliance">
-          <metadata>
-            <title>Machine Inactivity Limit</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420200" comment="Verifies 'Interactive logon: Machine inactivity limit' is set to '900' seconds or less" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:4203" version="1" class="compliance">
           <metadata>
             <title>Insecure logons to an SMB server must be disabled.</title>
@@ -11856,6 +11618,186 @@ Incorrect configurations could prevent services from starting and result in a de
           </metadata>
           <criteria operator="AND">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:420300" comment="Verifies 'Enable insecure guest logons' is set to 'Disabled'" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:224872" version="1">
+          <metadata>
+            <title>WN16-AC-000070 - Windows Server 2016 minimum password length must be configured to 14 characters.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Information systems not protected with strong password schemes (including passwords of minimum length) provide the opportunity for anyone to crack the password, thus gaining access to the system and compromising the device, information, or the local network.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253303" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:224877" version="1">
+          <metadata>
+            <title>WN16-AU-000030 - Permissions for the Application event log must prevent access by non-privileged accounts.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The Application event log may be susceptible to tampering if proper permissions are not applied.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254296" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:224878" version="1">
+          <metadata>
+            <title>WN16-AU-000040 - Permissions for the Security event log must prevent access by non-privileged accounts.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The Security event log may disclose sensitive information or be susceptible to tampering if proper permissions are not applied.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254297" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:224879" version="1">
+          <metadata>
+            <title>WN16-AU-000050 - Permissions for the System event log must prevent access by non-privileged accounts.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The System event log may be susceptible to tampering if proper permissions are not applied.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254298" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:224880" version="1">
+          <metadata>
+            <title>WN16-AU-000060 - Event Viewer must be protected from unauthorized modification and deletion.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information.
+
+Operating systems providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user enjoys in order to make access decisions regarding the modification or deletion of audit tools.
+
+Satisfies: SRG-OS-000257-GPOS-00098, SRG-OS-000258-GPOS-00099</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254299" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:224936" version="1">
+          <metadata>
+            <title>WN16-CC-000290 - Windows Telemetry must be configured to Security or Basic.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Some features may communicate with the vendor, sending system information or downloading data or components for the feature. Limiting this capability will prevent potentially sensitive information from being sent outside the enterprise. The "Security" option for Telemetry configures the lowest amount of data, effectively none outside of the Malicious Software Removal Tool (MSRT), Defender, and telemetry client settings. "Basic" sends basic diagnostic and usage data and may be required to support some Microsoft services.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253393" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:224970" version="1">
+          <metadata>
+            <title>WN16-DC-000070 - Permissions on the Active Directory data files must only allow System and Administrators access.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Improper access permissions for directory data-related files could allow unauthorized users to read, modify, or delete directory data or audit trails.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254391" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:225017" version="1">
+          <metadata>
+            <title>WN16-MS-000390 - The "Deny log on as a service" user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems. No other groups or accounts must be assigned this right.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
+
+The "Deny log on as a service" user right defines accounts that are denied logon as a service.
+
+In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower-trust systems helps mitigate the risk of privilege escalation from credential theft attacks, which could lead to the compromise of an entire domain.
+
+Incorrect configurations could prevent services from starting and result in a denial of service.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253493" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:225021" version="1">
+          <metadata>
+            <title>WN16-PK-000010 - The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root Certificate Authorities (CAs). The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.
+
+Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253427" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:225022" version="1">
+          <metadata>
+            <title>WN16-PK-000020 - The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.
+
+Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253429" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:225023" version="1">
+          <metadata>
+            <title>WN16-PK-000030 - The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.
+
+Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253430" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:225035" version="1">
+          <metadata>
+            <title>WN16-SO-000140 - The machine inactivity limit must be set to 15 minutes, locking the system with the screen saver.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Unattended systems are susceptible to unauthorized use and should be locked when unattended. The screen saver should be set at a maximum of 15 minutes and be password protected. This protects critical and sensitive data from exposure to unauthorized personnel with physical access to the computer.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253444" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2016:def:225088" version="1">
+          <metadata>
+            <title>WN16-UR-000280 - The Perform volume maintenance tasks user right must only be assigned to the Administrators group.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2016</platform>
+            </affected>
+            <description>Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
+
+Accounts with the "Perform volume maintenance tasks" user right can manage volume and disk configurations. This could be used to delete volumes, resulting in data loss or a denial of service.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253503" />
           </criteria>
         </definition>
       </definitions>
@@ -12040,9 +11982,117 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.fso.windows:obj:466400" />
           <state state_ref="oval:mil.disa.fso.windows:ste:497501" />
         </auditeventpolicysubcategories_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:498400" version="1" comment="Eventvwr.exe: Only Read and Execute rights for users other than TrustedInstaller" check_existence="any_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:498404" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:498408" />
+        <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" id="oval:mil.disa.stig.win:tst:10000400" comment="The system is a Windows Domain Member Server" version="1">
+          <object object_ref="oval:mil.disa.stig.win:obj:10000100" />
+          <state state_ref="oval:mil.disa.stig.win:ste:10000400" />
+        </wmi57_test>
+        <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" state_operator="OR" id="oval:mil.disa.stig.win:tst:10000500" comment="The system is a Windows Domain Controller" version="1">
+          <object object_ref="oval:mil.disa.stig.win:obj:10000100" />
+          <state state_ref="oval:mil.disa.stig.win:ste:10000500" />
+          <state state_ref="oval:mil.disa.stig.win:ste:10000501" />
+        </wmi57_test>
+        <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25330300" version="2" comment="'Minimum password length' is set to at least '14' characters" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000002" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25330300" />
+        </passwordpolicy_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25334002" version="1" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25334002" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000016" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25334102" version="1" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25334102" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000016" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25334202" version="1" comment="The System event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25334202" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000016" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25339300" version="2" comment="'Allow Diagnostic Data' is set to 'Enabled' with 'Diagnostic Data Off (Not recommended)' or 'Send Required Diagnostic Data' selected in 'Options:'" check_existence="at_least_one_exists" check="all" state_operator="OR">
+          <object object_ref="oval:mil.disa.stig.win:obj:25339300" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000000" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000001" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342700" version="2" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342700" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342701" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342705" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342702" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342710" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342900" version="2" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342900" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25343000" version="2" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25343000" />
+        </registry_test>
+        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25349300" version="1" comment="Deny log on as a service - Domain Admins" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000003" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25349300" />
+        </accesstoken_test>
+        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25349301" version="1" comment="Deny log on as a service - Enterprise Admins" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000004" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25349300" />
+        </accesstoken_test>
+        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25350300" version="1" comment="Perform volume maintenance tasks - Administrators" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000009" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25350300" />
+        </accesstoken_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429600" version="1" comment="The Application event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429600" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429601" version="1" comment="The Application event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429601" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429700" version="1" comment="The Security event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429700" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429701" version="1" comment="The Security event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429701" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429800" version="1" comment="The System event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429800" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429801" version="1" comment="The System event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429801" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429900" version="1" comment="Eventvwr.exe: Only Read and Execute rights for users other than TrustedInstaller" check_existence="any_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429903" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25429901" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439100" version="1" comment="Database log files: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439102" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439101" version="1" comment="Database log files: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439103" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439102" version="1" comment="Database log files: No other permissions" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439104" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439103" version="1" comment="DSA Database file: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439105" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439104" version="1" comment="DSA Database file: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439106" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439105" version="1" comment="DSA Database file: No other permissions" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439107" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439106" version="1" comment="DSA Working Directory: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439108" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439107" version="1" comment="DSA Working Directory: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439109" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439108" version="1" comment="DSA Working Directory: No other permissions" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439110" />
         </fileeffectiverights53_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:1900" version="1" comment="Mutual Authentication and Integrity for \\*\SYSVOL" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:1900" />
@@ -12057,11 +12107,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <state state_ref="oval:mil.disa.stig.windows:ste:1901" />
           <state state_ref="oval:mil.disa.stig.windows:ste:1902" />
           <state state_ref="oval:mil.disa.stig.windows:ste:1903" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:2400" version="2" comment="AllowTelemetry = 0 or 1" check_existence="at_least_one_exists" check="all" state_operator="OR">
-          <object object_ref="oval:mil.disa.stig.windows:obj:2400" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:2400" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:2401" />
         </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:6500" version="1" comment="Verifies 'Sign-in last interactive user automatically after a system-initiated restart' is set to 'Disabled'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:6500" />
@@ -12095,10 +12140,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11801" version="1" comment="'Audit Other System Events' is set to 'Success' and 'Failure'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
           <state state_ref="oval:mil.disa.stig.windows:ste:11801" />
-        </auditeventpolicysubcategories_test>
-        <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11900" version="1" comment="'Audit Account Lockout' is set to 'Success'" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:11900" />
         </auditeventpolicysubcategories_test>
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11901" version="1" comment="'Audit Account Lockout' is set to 'Success' and 'Failure'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
@@ -12178,10 +12219,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:101600" version="1" comment="'Minimum Password Age' is set to at least '1' day" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:101500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:101600" />
-        </passwordpolicy_test>
-        <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:101700" version="1" comment="'Minimum password length' is set to at least '14' characters" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:101500" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:101700" />
         </passwordpolicy_test>
         <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:101800" version="1" comment="'Password must meet complexity requirements' is set to 'Enabled'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:101500" />
@@ -12302,15 +12339,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:109900" version="1" comment="'Turn off AutoPlay' is set to 'Enabled' with 'All Drives' selected" check_existence="all_exist" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:109900" />
           <state state_ref="oval:mil.disa.stig.windows:ste:109900" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:110200" version="2" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:110200" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:110201" version="1" comment="DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:110205" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:110300" version="1" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:110300" />
         </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:110400" version="1" comment="'Enumerate administrator accounts on elevation' is set to 'Disabled'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:110400" />
@@ -12444,72 +12472,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:113400" />
           <state state_ref="oval:mil.disa.stig.windows:ste:113400" />
         </wmi57_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113500" version="1" comment="Database log files: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113502" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113501" version="1" comment="Database log files: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113503" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113502" version="1" comment="Database log files: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113504" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113503" version="1" comment="DSA Database file: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113505" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113504" version="1" comment="DSA Database file: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113506" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113505" version="1" comment="DSA Database file: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113507" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113506" version="1" comment="Database log files: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113508" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113507" version="1" comment="Database log files: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113509" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113508" version="1" comment="Database log files: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113510" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113509" version="1" comment="DSA Database file and all other files in the same directory: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113511" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113510" version="1" comment="DSA Database file and all other files in the same directory: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113512" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113511" version="1" comment="DSA Database file and all other files in the same directory: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113513" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113512" version="1" comment="DSA Working Directory: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113514" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113513" version="1" comment="DSA Working Directory: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113515" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113514" version="1" comment="DSA Working Directory: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113516" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113515" version="1" comment="DSA Working Directory: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113517" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113516" version="1" comment="DSA Working Directory: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113518" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113517" version="1" comment="DSA Working Directory: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113519" />
-        </fileeffectiverights53_test>
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:115200" version="1" comment="Audit - Directory Service Access - Success only" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:105500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:115200" />
@@ -12529,10 +12491,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:115401" version="1" comment="Audit - Directory Service Changes - Success and Failure" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:105500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:115401" />
-        </auditeventpolicysubcategories_test>
-        <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:115500" version="1" comment="Audit - Directory Service Changes - Failure only" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:105500" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:115500" />
         </auditeventpolicysubcategories_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:116000" version="1" comment="'Domain Controller: LDAP Server signing requirements' is set to 'Require signing'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:116000" />
@@ -12637,18 +12595,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:117802" version="2" check="at least one" comment="Deny log on as a batch job - Enterprise Admins">
           <object object_ref="oval:mil.disa.stig.windows:obj:117702" />
           <state state_ref="oval:mil.disa.stig.windows:ste:117800" />
-        </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:117900" version="1" check="all" comment="Deny log on as a service - None">
-          <object object_ref="oval:mil.disa.stig.windows:obj:117900" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:117900" />
-        </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:117901" version="2" check="at least one" comment="Deny log on as a service - Domain Admins">
-          <object object_ref="oval:mil.disa.stig.windows:obj:117701" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:117901" />
-        </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:117902" version="2" check="at least one" comment="Deny log on as a service - Enterprise Admins">
-          <object object_ref="oval:mil.disa.stig.windows:obj:117702" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:117901" />
         </accesstoken_test>
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:118000" version="1" check="all" comment="Deny log on locally - Guests">
           <object object_ref="oval:mil.disa.stig.windows:obj:117700" />
@@ -12934,10 +12880,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:125300" />
           <state state_ref="oval:mil.disa.stig.windows:ste:125300" />
         </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:125400" version="1" check="all" comment="Perform volume maintenance tasks - Administrators">
-          <object object_ref="oval:mil.disa.stig.windows:obj:125400" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:125400" />
-        </accesstoken_test>
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:125500" version="1" check="all" comment="Profile single process - Administrators">
           <object object_ref="oval:mil.disa.stig.windows:obj:125500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:125500" />
@@ -12954,16 +12896,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:126200" />
           <state state_ref="oval:mil.disa.stig.windows:ste:126200" />
         </registry_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:126400" version="1" comment="The Security event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:126400" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:126401" version="1" comment="The Security event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:126401" />
-        </fileeffectiverights53_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:126402" version="1" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:126402" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:5104" />
-        </registry_test>
         <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:126500" version="1" comment="TFTP Client feature is not installed" check_existence="all_exist" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:126500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:126500" />
@@ -12972,26 +12904,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:126500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:126600" />
         </wmi57_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127000" version="2" comment="The Application event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127000" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127001" version="2" comment="The Application event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127001" />
-        </fileeffectiverights53_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127002" version="1" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127002" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:5104" />
-        </registry_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127100" version="1" comment="The System event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127100" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127101" version="1" comment="The System event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127101" />
-        </fileeffectiverights53_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127102" version="1" comment="The System event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127102" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:5104" />
-        </registry_test>
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127400" version="1" comment="'Audit Other Object Access Events' is set to 'Success'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:105500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:127400" />
@@ -13004,31 +12916,17 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:105500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:127501" />
         </auditeventpolicysubcategories_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420001" version="1" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420005" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420002" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420010" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420003" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420015" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420200" version="1" comment="'Interactive logon: Machine inactivity limit' is set to '900' seconds or less" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420200" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:420200" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:420201" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420300" version="1" comment="'Enable insecure guest logons' is set to 'Disabled'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:420300" />
           <state state_ref="oval:mil.disa.stig.windows:ste:420300" />
         </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:25344400" version="1" comment="The machine inactivity limit is set to 15 minutes or less" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.windows:obj:25344400" />
+          <state state_ref="oval:mil.disa.stig.windows:ste:25344400" />
+          <state state_ref="oval:mil.disa.stig.windows:ste:25344401" />
+        </registry_test>
       </tests>
       <objects>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:388601" version="2" comment="System Root Directory Registry Object">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
-          <name datatype="string">SystemRoot</name>
-        </registry_object>
         <auditeventpolicysubcategories_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:394100" version="1" comment="Audit event subcategories policy" />
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:459400" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
@@ -13101,17 +12999,349 @@ Incorrect configurations could prevent services from starting and result in a de
           <key datatype="string">SOFTWARE\Policies\Microsoft\Cryptography</key>
           <name datatype="string">ForceKeyProtection</name>
         </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:498401" version="1" comment="Event Viewer Rights">
-          <path var_ref="oval:mil.disa.fso.windows:var:498401" var_check="at least one" datatype="string" />
+        <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:10000100" version="1">
+          <namespace>root\cimv2</namespace>
+          <wql>SELECT DomainRole FROM win32_computersystem</wql>
+        </wmi57_object>
+        <passwordpolicy_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000002" version="1" />
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000003" version="1">
+          <security_principle datatype="string" operation="pattern match">^(?i)(.+\\)?Domain Admins$</security_principle>
+        </accesstoken_object>
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000004" version="1">
+          <security_principle datatype="string" operation="pattern match">^(?i)(.+\\)?Enterprise Admins$</security_principle>
+        </accesstoken_object>
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000008" version="1" comment="All security principles">
+          <security_principle operation="pattern match">.+</security_principle>
+        </accesstoken_object>
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000009" version="1" comment="Administrators">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.win:obj:20000008</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000005</filter>
+          </set>
+        </accesstoken_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000015" version="1" comment="System Root Directory">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name datatype="string">SystemRoot</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334001" version="1" comment="The Application event log. Built filepath.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334001" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334002" version="1" comment="path Application.evtx">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\Application</key>
+          <name datatype="string">file</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334004" version="1" comment="The Application event log. Strict filepath, as listed.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334002" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334101" version="1" comment="The Security event log. Built filepath.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334101" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334102" version="1" comment="path Security.evtx">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\Security</key>
+          <name datatype="string">file</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334104" version="1" comment="The Security event log. Strict filepath, as listed.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334102" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334201" version="1" comment="The System event log. Built filepath.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334201" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334202" version="1" comment="path System.evtx">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\System</key>
+          <name datatype="string">file</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334204" version="1" comment="The System event log. Strict filepath, as listed.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334202" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25339300" version="1">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\DataCollection</key>
+          <name datatype="string">AllowTelemetry</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342700" version="2">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342701</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342702</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342701" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342703</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342704</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342702" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342703" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342704" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342705" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342706</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342707</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342706" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342708</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342709</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342707" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342708" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342709" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342710" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342711</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342712</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342711" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342713</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342714</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342712" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342713" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342714" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342900" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342901</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342904</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342901" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342902</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342903</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342902" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342903" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342904" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343000" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343001</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343004</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343001" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343002</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343003</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343002" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343003" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343004" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429600" version="1" comment="Permissions of Application event log, minus those allowed. Built filepath.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334001</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429601" version="1" comment="Permissions of Application event log, minus those allowed. Strict filepath, as listed.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334004</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429700" version="1" comment="Permissions of Security event log, minus those allowed. Built filepath.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334101</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429701" version="1" comment="Permissions of Security event log, minus those allowed. Strict filepath, as listed.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334104</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429800" version="1" comment="Permissions of System event log, minus those allowed. Built filepath.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334201</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429801" version="1" comment="Permissions of System event log, minus those allowed. Strict filepath, as listed.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334204</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429901" version="1" comment="System Root Directory Registry Object">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name datatype="string">SystemRoot</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429902" version="3" comment="Event Viewer Rights">
+          <path var_ref="oval:mil.disa.stig.win:var:25429900" var_check="at least one" datatype="string" />
           <filename datatype="string">Eventvwr.exe</filename>
           <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
         </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:498404" version="1" comment="Eventvwr Rights except for TrustedInstaller">
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429903" version="1" comment="Eventvwr Rights except for TrustedInstaller">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:498401</object_reference>
-            <filter>oval:mil.disa.fso.windows:ste:498402</filter>
+            <object_reference>oval:mil.disa.stig.win:obj:25429902</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:25429900</filter>
           </set>
         </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439100" version="1" comment="Database log files path">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
+          <name datatype="string" operation="equals">Database log files path</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439101" version="1" comment="DSA Database file">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
+          <name datatype="string" operation="equals">DSA Database file</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439102" version="4" comment="Database log files - SYSTEM permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439100" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-18</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439103" version="4" comment="Database log files - Administrators permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439100" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439104" version="4" comment="Database log files - Other permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439100" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439100</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439101</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439103</filter>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439105" version="4" comment="Files in the same directory as the DSA Database - SYSTEM permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439101" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-18</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439106" version="4" comment="Files in the same directory as the DSA Database - Administrators permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439101" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439107" version="4" comment="Files in the same directory as the DSA Database - Other permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439101" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439100</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439101</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439103</filter>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439108" version="4" comment="Files in the DSA Working Directory - SYSTEM permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439102" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-18</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439109" version="4" comment="Files in the DSA Working Directory - Administrators permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439102" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439110" version="4" comment="Files in the DSA Working Directory - Other permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439102" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439100</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439101</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439103</filter>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439111" version="1" comment="DSA Working Directory">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
+          <name datatype="string" operation="equals">DSA Working Directory</name>
+        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:1900" version="1" comment="Hardened Path Config for \\*\SYSVOL">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths</key>
@@ -13121,11 +13351,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths</key>
           <name datatype="string">\\*\NETLOGON</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:2400" version="2" comment="AllowTelemetry">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\DataCollection</key>
-          <name datatype="string">AllowTelemetry</name>
         </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:6500" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
@@ -13296,87 +13521,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <key datatype="string">SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer</key>
           <name datatype="string">NoDriveTypeAutoRun</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110200" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:110201</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:110204</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110201" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:110202</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:110203</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110202" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110203" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110204" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110205" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:110206</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:110209</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110206" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:110207</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:110208</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110207" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110208" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110209" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110300" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:110301</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:110304</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110301" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:110302</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:110303</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110302" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110303" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110304" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:110400" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\CredUI</key>
@@ -13517,129 +13661,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <namespace datatype="string">root\rsop\computer</namespace>
           <wql datatype="string">SELECT setting FROM RSOP_SecuritySettingNumeric WHERE KeyName='MaxClockSkew'</wql>
         </wmi57_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113500" version="1" comment="Database log files path">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
-          <name datatype="string" operation="equals">Database log files path</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113501" version="1" comment="DSA Database file">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
-          <name datatype="string" operation="equals">DSA Database file</name>
-        </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113502" version="2" comment="Database log files - SYSTEM permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113503" version="2" comment="Database log files - Administrators permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113504" version="2" comment="Database log files - Other permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113505" version="2" comment="Files in the same directory as the DSA Database - SYSTEM permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113506" version="2" comment="Files in the same directory as the DSA Database - Administrators permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113507" version="2" comment="Files in the same directory as the DSA Database - Other permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113508" version="2" comment="Database log files - SYSTEM permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113509" version="2" comment="Database log files - Administrators permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113510" version="2" comment="Database log files - Other permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113511" version="1" comment="Files in the same directory as the DSA Database - SYSTEM permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113512" version="1" comment="Files in the same directory as the DSA Database - Administrators permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113513" version="1" comment="Files in the same directory as the DSA Database - Other permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113514" version="1" comment="Files in the DSA Working Directory - SYSTEM permissions, SCC">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113515" version="1" comment="Files in the DSA Working Directory - Administrators permissions, SCC">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113516" version="1" comment="Files in the DSA Working Directory - Other permissions, SCC">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113517" version="1" comment="Files in the DSA Working Directory - SYSTEM permissions, McAfee tools">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113518" version="1" comment="Files in the DSA Working Directory - Administrators permissions, McAfee tools">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113519" version="1" comment="Files in the DSA Working Directory - Other permissions, McAfee tools">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113520" version="1" comment="DSA Working Directory">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
-          <name datatype="string" operation="equals">DSA Working Directory</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:116000" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
@@ -13750,9 +13771,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </accesstoken_object>
         <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:117712" version="1" comment="Domain Admins strict">
           <security_principle datatype="string" operation="equals">Domain Admins</security_principle>
-        </accesstoken_object>
-        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:117900" version="1" comment="All security principles">
-          <security_principle datatype="string" operation="pattern match">.*</security_principle>
         </accesstoken_object>
         <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:118200" version="1" comment="All security principles">
           <security_principle datatype="string" operation="pattern match">.*</security_principle>
@@ -14044,15 +14062,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:125301" version="1" comment="All security principles">
           <security_principle datatype="string" operation="pattern match">.*</security_principle>
         </accesstoken_object>
-        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:125400" version="1" comment="Filter for Administrators">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
-            <object_reference>oval:mil.disa.stig.windows:obj:125401</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:125401</filter>
-          </set>
-        </accesstoken_object>
-        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:125401" version="1" comment="All security principles">
-          <security_principle datatype="string" operation="pattern match">.*</security_principle>
-        </accesstoken_object>
         <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:125500" version="1" comment="Filter for Administrators">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
             <object_reference>oval:mil.disa.stig.windows:obj:125501</object_reference>
@@ -14085,193 +14094,19 @@ Incorrect configurations could prevent services from starting and result in a de
           <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\Windows Search</key>
           <name datatype="string">AllowIndexingEncryptedStoresOrItems</name>
         </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126400" version="1" comment="Permissions of Security event log, minus those allowed. Built filepath.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:126403</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126401" version="1" comment="Permissions of Security event log, minus those allowed. Strict filepath, as listed.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:126404</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126402" version="1" comment="path Security.evtx">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\Security</key>
-          <name datatype="string">File</name>
-        </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126403" version="1" comment="The Security event log. Built filepath.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:126400" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126404" version="1" comment="The Security event log. Strict filepath, as listed.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:126401" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
         <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126500" version="1" comment="Select the ids from 'Get-WindowsFeature | Where Installed'">
           <namespace datatype="string">root\cimv2</namespace>
           <wql datatype="string" operation="equals">SELECT id FROM win32_serverfeature</wql>
         </wmi57_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127000" version="1" comment="Permissions of Application event log, minus those allowed. Built filepath.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:127003</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127001" version="1" comment="Permissions of Application event log, minus those allowed. Strict filepath, as listed.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:127004</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127002" version="1" comment="path Application.evtx">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\Application</key>
-          <name datatype="string">File</name>
-        </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127003" version="1" comment="The Application event log. Built filepath.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:127000" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127004" version="1" comment="The Application event log. Strict filepath, as listed.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:127001" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127100" version="1" comment="Permissions of System event log, minus those allowed. Built filepath.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:127103</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127101" version="1" comment="Permissions of System event log, minus those allowed. Strict filepath, as listed.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:127104</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127102" version="1" comment="path System.evtx">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\System</key>
-          <name datatype="string">File</name>
-        </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127103" version="1" comment="The System event log. Built filepath.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:127100" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127104" version="1" comment="The System event log. Strict filepath, as listed.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:127101" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420005" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420006</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420009</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420006" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420007</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420008</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420007" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420008" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420009" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420010" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420011</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420014</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420011" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420012</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420013</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420012" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420013" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420014" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420015" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420016</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420019</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420016" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420017</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420018</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420017" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420018" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420019" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420200" version="1">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">Software\Microsoft\Windows\CurrentVersion\Policies\System</key>
-          <name datatype="string">InactivityTimeoutSecs</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420300" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation</key>
           <name datatype="string">AllowInsecureGuestAuth</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:25344400" version="1">
+          <hive datatype="string" operation="case insensitive equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="case insensitive equals">Software\Microsoft\Windows\CurrentVersion\Policies\System</key>
+          <name datatype="string" operation="case insensitive equals">InactivityTimeoutSecs</name>
         </registry_object>
       </objects>
       <states>
@@ -14408,10 +14243,60 @@ Incorrect configurations could prevent services from starting and result in a de
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:497501" version="2" comment="Audit - Audit Policy Change - Success and Failure">
           <authorization_policy_change datatype="string" operation="equals">AUDIT_SUCCESS_FAILURE</authorization_policy_change>
         </auditeventpolicysubcategories_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498402" version="1" comment="TrustedInstaller">
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:10000400" comment="Domain Member Server" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="domainrole">3</field>
+          </result>
+        </wmi57_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:10000500" comment="Backup Domain Controller" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="domainrole">4</field>
+          </result>
+        </wmi57_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:10000501" comment="Primary Domain Controller" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="domainrole">5</field>
+          </result>
+        </wmi57_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000000" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">0</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000001" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">1</value>
+        </registry_state>
+        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000005" version="1">
+          <security_principle datatype="string" operation="case insensitive equals">Administrators</security_principle>
+        </accesstoken_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000011" version="1" comment="Event Log process account. Deterministically built with respect to service name.">
+          <trustee_sid datatype="string">S-1-5-80-880578595-1860270145-482643319-2788375705-1540778122</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000012" version="1" comment="SYSTEM account.">
+          <trustee_sid datatype="string">S-1-5-18</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000013" version="1" comment="Administrators account.">
+          <trustee_sid datatype="string">S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000014" version="1" comment="LOCAL SERVICE account, the owner.">
+          <trustee_sid datatype="string">S-1-5-19</trustee_sid>
+        </fileeffectiverights53_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000016" version="1" comment="%SystemRoot% environment variable.">
+          <value datatype="string" operation="pattern match">^(?i)%SystemRoot%.*$</value>
+        </registry_state>
+        <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25330300" version="2" comment="Minimum Password Length is greater than or equal to 14">
+          <min_passwd_len operation="greater than or equal" datatype="int">14</min_passwd_len>
+        </passwordpolicy_state>
+        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25349300" version="1" comment="Deny log on as a service">
+          <sedenyservicelogonright datatype="boolean" operation="equals">1</sedenyservicelogonright>
+        </accesstoken_state>
+        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25350300" version="1" comment="Perform volume maintenance tasks">
+          <semanagevolumeprivilege datatype="boolean">0</semanagevolumeprivilege>
+        </accesstoken_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25429900" version="1" comment="TrustedInstaller">
           <trustee_sid operation="equals" datatype="string">S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464</trustee_sid>
         </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498408" version="1" comment="No Rights except Read and Execute">
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25429901" version="1" comment="No Rights except Read and Execute">
           <standard_delete datatype="boolean" operation="equals" entity_check="all">false</standard_delete>
           <standard_write_dac datatype="boolean" operation="equals" entity_check="all">false</standard_write_dac>
           <standard_write_owner datatype="boolean" operation="equals" entity_check="all">false</standard_write_owner>
@@ -14421,6 +14306,50 @@ Incorrect configurations could prevent services from starting and result in a de
           <file_write_ea datatype="boolean" operation="equals" entity_check="all">false</file_write_ea>
           <file_delete_child datatype="boolean" operation="equals" entity_check="all">false</file_delete_child>
           <file_write_attributes datatype="boolean" operation="equals" entity_check="all">false</file_write_attributes>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25439100" version="1" comment="Administrators Rights">
+          <trustee_sid>S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25439101" version="1" comment="Local System Rights">
+          <trustee_sid>S-1-5-18</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25439102" version="1" comment="Full Rights">
+          <standard_delete datatype="boolean">true</standard_delete>
+          <standard_read_control datatype="boolean">true</standard_read_control>
+          <standard_write_dac datatype="boolean">true</standard_write_dac>
+          <standard_write_owner datatype="boolean">true</standard_write_owner>
+          <standard_synchronize datatype="boolean">true</standard_synchronize>
+          <generic_read datatype="boolean">true</generic_read>
+          <generic_write datatype="boolean">true</generic_write>
+          <generic_execute datatype="boolean">true</generic_execute>
+          <file_read_data datatype="boolean">true</file_read_data>
+          <file_write_data datatype="boolean">true</file_write_data>
+          <file_append_data datatype="boolean">true</file_append_data>
+          <file_read_ea datatype="boolean">true</file_read_ea>
+          <file_write_ea datatype="boolean">true</file_write_ea>
+          <file_execute datatype="boolean">true</file_execute>
+          <file_delete_child datatype="boolean">true</file_delete_child>
+          <file_read_attributes datatype="boolean">true</file_read_attributes>
+          <file_write_attributes datatype="boolean">true</file_write_attributes>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25439103" version="1" comment="No Rights">
+          <standard_delete datatype="boolean">false</standard_delete>
+          <standard_read_control datatype="boolean">false</standard_read_control>
+          <standard_write_dac datatype="boolean">false</standard_write_dac>
+          <standard_write_owner datatype="boolean">false</standard_write_owner>
+          <standard_synchronize datatype="boolean">false</standard_synchronize>
+          <generic_read datatype="boolean">false</generic_read>
+          <generic_write datatype="boolean">false</generic_write>
+          <generic_execute datatype="boolean">false</generic_execute>
+          <file_read_data datatype="boolean">false</file_read_data>
+          <file_write_data datatype="boolean">false</file_write_data>
+          <file_append_data datatype="boolean">false</file_append_data>
+          <file_read_ea datatype="boolean">false</file_read_ea>
+          <file_write_ea datatype="boolean">false</file_write_ea>
+          <file_execute datatype="boolean">false</file_execute>
+          <file_delete_child datatype="boolean">false</file_delete_child>
+          <file_read_attributes datatype="boolean">false</file_read_attributes>
+          <file_write_attributes datatype="boolean">false</file_write_attributes>
         </fileeffectiverights53_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:1900" version="2" comment="RequireMutualAuthentication=1">
           <type>reg_sz</type>
@@ -14437,17 +14366,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:1903" version="2" comment="No RequireIntegrity!=1">
           <type>reg_sz</type>
           <value datatype="string" entity_check="none satisfy" operation="pattern match">(^| *, *)RequireIntegrity=(?!1( *, *|$))</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:2400" version="1" comment="AllowTelemetry = 0 (reg_dword)">
-          <type>reg_dword</type>
-          <value datatype="int">0</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:2401" version="1" comment="AllowTelemetry = 1 (reg_dword)">
-          <type>reg_dword</type>
-          <value datatype="int">1</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:5104" version="2" comment="%SystemRoot% environment variable.">
-          <value datatype="string" operation="pattern match">^%[Ss][Yy][Ss][Tt][Ee][Mm][Rr][Oo][Oo][Tt]%.*$</value>
         </registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:6500" version="1" comment="DisableAutomaticRestartSignOn = 1 (reg_dword)">
           <type>reg_dword</type>
@@ -14478,9 +14396,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </auditeventpolicysubcategories_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11801" version="1" comment="'Other System Events' is set to 'Success' and 'Failure'">
           <other_system_events datatype="string">AUDIT_SUCCESS_FAILURE</other_system_events>
-        </auditeventpolicysubcategories_state>
-        <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11900" version="1" comment="'Account Lockout' is set to 'Success'">
-          <account_lockout datatype="string">AUDIT_SUCCESS</account_lockout>
         </auditeventpolicysubcategories_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11901" version="1" comment="'Account Lockout' is set to 'Success' and 'Failure'">
           <account_lockout datatype="string">AUDIT_SUCCESS_FAILURE</account_lockout>
@@ -14561,9 +14476,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </passwordpolicy_state>
         <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:101600" version="1" comment="Minimum Password Age is greater than or equal to variable">
           <min_passwd_age datatype="int" operation="greater than or equal" var_ref="oval:mil.disa.stig.windows:var:101600" />
-        </passwordpolicy_state>
-        <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:101700" version="1" comment="Minimum Password Length is greater than or equal to variable">
-          <min_passwd_len operation="greater than or equal" datatype="int" var_ref="oval:mil.disa.stig.windows:var:101700" />
         </passwordpolicy_state>
         <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:101800" version="1" comment="Password Complexity equals variable">
           <password_complexity datatype="boolean" var_ref="oval:mil.disa.stig.windows:var:101800" />
@@ -14798,50 +14710,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" datatype="int" operation="less than or equal" name="setting">5</field>
           </result>
         </wmi57_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:113500" version="1" comment="Administrators Rights">
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:113501" version="1" comment="Local System Rights">
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:113502" version="1" comment="Full Rights">
-          <standard_delete datatype="boolean">true</standard_delete>
-          <standard_read_control datatype="boolean">true</standard_read_control>
-          <standard_write_dac datatype="boolean">true</standard_write_dac>
-          <standard_write_owner datatype="boolean">true</standard_write_owner>
-          <standard_synchronize datatype="boolean">true</standard_synchronize>
-          <generic_read datatype="boolean">true</generic_read>
-          <generic_write datatype="boolean">true</generic_write>
-          <generic_execute datatype="boolean">true</generic_execute>
-          <file_read_data datatype="boolean">true</file_read_data>
-          <file_write_data datatype="boolean">true</file_write_data>
-          <file_append_data datatype="boolean">true</file_append_data>
-          <file_read_ea datatype="boolean">true</file_read_ea>
-          <file_write_ea datatype="boolean">true</file_write_ea>
-          <file_execute datatype="boolean">true</file_execute>
-          <file_delete_child datatype="boolean">true</file_delete_child>
-          <file_read_attributes datatype="boolean">true</file_read_attributes>
-          <file_write_attributes datatype="boolean">true</file_write_attributes>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:113503" version="1" comment="No Rights">
-          <standard_delete datatype="boolean">false</standard_delete>
-          <standard_read_control datatype="boolean">false</standard_read_control>
-          <standard_write_dac datatype="boolean">false</standard_write_dac>
-          <standard_write_owner datatype="boolean">false</standard_write_owner>
-          <standard_synchronize datatype="boolean">false</standard_synchronize>
-          <generic_read datatype="boolean">false</generic_read>
-          <generic_write datatype="boolean">false</generic_write>
-          <generic_execute datatype="boolean">false</generic_execute>
-          <file_read_data datatype="boolean">false</file_read_data>
-          <file_write_data datatype="boolean">false</file_write_data>
-          <file_append_data datatype="boolean">false</file_append_data>
-          <file_read_ea datatype="boolean">false</file_read_ea>
-          <file_write_ea datatype="boolean">false</file_write_ea>
-          <file_execute datatype="boolean">false</file_execute>
-          <file_delete_child datatype="boolean">false</file_delete_child>
-          <file_read_attributes datatype="boolean">false</file_read_attributes>
-          <file_write_attributes datatype="boolean">false</file_write_attributes>
-        </fileeffectiverights53_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:115200" version="1" comment="Audit - Directory Service Access - Success only">
           <directory_service_access datatype="string" operation="equals">AUDIT_SUCCESS</directory_service_access>
         </auditeventpolicysubcategories_state>
@@ -14856,9 +14724,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </auditeventpolicysubcategories_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:115401" version="1" comment="Audit - Directory Service Changes - Success and Failure">
           <directory_service_changes datatype="string" operation="equals">AUDIT_SUCCESS_FAILURE</directory_service_changes>
-        </auditeventpolicysubcategories_state>
-        <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:115500" version="1" comment="Audit - Directory Service Changes - Failure only">
-          <directory_service_changes datatype="string" operation="equals">AUDIT_FAILURE</directory_service_changes>
         </auditeventpolicysubcategories_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:116000" version="1" comment="Reg_Dword type and value equals 2">
           <type>reg_dword</type>
@@ -14944,12 +14809,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </wmi57_state>
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:117800" version="1" comment="Deny log on as a batch job">
           <sedenybatchLogonright datatype="boolean" operation="equals">1</sedenybatchLogonright>
-        </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:117900" version="1" comment="Deny log on as a service">
-          <sedenyservicelogonright datatype="boolean" operation="equals">0</sedenyservicelogonright>
-        </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:117901" version="1" comment="Deny log on as a service">
-          <sedenyservicelogonright datatype="boolean" operation="equals">1</sedenyservicelogonright>
         </accesstoken_state>
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:118000" version="1" comment="Deny log on locally">
           <sedenyinteractivelogonright datatype="boolean" operation="equals">1</sedenyinteractivelogonright>
@@ -15247,12 +15106,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:125301" version="1" comment="Administrators">
           <security_principle datatype="string" operation="equals">Administrators</security_principle>
         </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:125400" version="1" comment="Perform volume maintenance tasks">
-          <semanagevolumeprivilege datatype="boolean" operation="equals">0</semanagevolumeprivilege>
-        </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:125401" version="1" comment="Administrators">
-          <security_principle datatype="string" operation="equals">Administrators</security_principle>
-        </accesstoken_state>
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:125500" version="1" comment="Profile single process">
           <seprofilesingleprocessprivilege datatype="boolean" operation="equals">0</seprofilesingleprocessprivilege>
         </accesstoken_state>
@@ -15285,18 +15138,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="id" entity_check="none satisfy" datatype="int">411</field>
           </result>
         </wmi57_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127000" version="1" comment="Event Log process account SID. Deterministically built with respect to service name.">
-          <trustee_sid datatype="string">S-1-5-80-880578595-1860270145-482643319-2788375705-1540778122</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127001" version="1" comment="SYSTEM account SID.">
-          <trustee_sid datatype="string">S-1-5-18</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127002" version="1" comment="Administrators group SID.">
-          <trustee_sid datatype="string">S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127003" version="1" comment="LOCAL SERVICE account SID, the owner.">
-          <trustee_sid datatype="string">S-1-5-19</trustee_sid>
-        </fileeffectiverights53_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127400" version="1" comment="'Other Object Access Events' is set to 'Success'">
           <other_object_access_events datatype="string">AUDIT_SUCCESS</other_object_access_events>
         </auditeventpolicysubcategories_state>
@@ -15306,25 +15147,75 @@ Incorrect configurations could prevent services from starting and result in a de
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127501" version="1" comment="'Other Object Access Events' is set to 'Success' and 'Failure'">
           <other_object_access_events datatype="string">AUDIT_SUCCESS_FAILURE</other_object_access_events>
         </auditeventpolicysubcategories_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:420200" version="1" comment="Reg_Dword type and value is less than or equals 900">
-          <type>reg_dword</type>
-          <value datatype="int" operation="less than or equal">900</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:420201" version="1" comment="Reg_Dword type and value is greater than 0">
-          <type>reg_dword</type>
-          <value datatype="int" operation="greater than">0</value>
-        </registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:420300" version="1" comment="Reg_Dword type and value is 0">
           <type>reg_dword</type>
           <value datatype="int">0</value>
         </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:25344400" version="1">
+          <type>reg_dword</type>
+          <value datatype="int" operation="less than or equal">900</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:25344401" version="1">
+          <type>reg_dword</type>
+          <value datatype="int" operation="greater than">0</value>
+        </registry_state>
       </states>
       <variables>
-        <local_variable id="oval:mil.disa.fso.windows:var:498401" version="1" datatype="string" comment="SystemRoot\System32">
+        <local_variable id="oval:mil.disa.stig.win:var:25334001" version="1" datatype="string" comment="Path to Application.evtx with the SystemRoot environment variable replaced with its value.">
           <concat>
-            <object_component object_ref="oval:mil.disa.fso.windows:obj:388601" item_field="value" />
+            <object_component object_ref="oval:mil.disa.stig.win:obj:20000015" item_field="value" />
+            <regex_capture pattern="^%.*%(.*)$">
+              <object_component object_ref="oval:mil.disa.stig.win:obj:25334002" item_field="value" />
+            </regex_capture>
+          </concat>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334002" version="1" datatype="string" comment="Strict path to Application.evtx.">
+          <regex_capture pattern="^(.*)$">
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25334002" item_field="value" />
+          </regex_capture>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334101" version="1" datatype="string" comment="Path to Security.evtx with the SystemRoot environment variable replaced with its value.">
+          <concat>
+            <object_component object_ref="oval:mil.disa.stig.win:obj:20000015" item_field="value" />
+            <regex_capture pattern="^%.*%(.*)$">
+              <object_component object_ref="oval:mil.disa.stig.win:obj:25334102" item_field="value" />
+            </regex_capture>
+          </concat>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334102" version="1" datatype="string" comment="Strict path to Security.evtx.">
+          <regex_capture pattern="^(.*)$">
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25334102" item_field="value" />
+          </regex_capture>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334201" version="1" datatype="string" comment="Path to System.evtx with the SystemRoot environment variable replaced with its value.">
+          <concat>
+            <object_component object_ref="oval:mil.disa.stig.win:obj:20000015" item_field="value" />
+            <regex_capture pattern="^%.*%(.*)$">
+              <object_component object_ref="oval:mil.disa.stig.win:obj:25334202" item_field="value" />
+            </regex_capture>
+          </concat>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334202" version="1" datatype="string" comment="Strict path to System.evtx.">
+          <regex_capture pattern="^(.*)$">
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25334202" item_field="value" />
+          </regex_capture>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25429900" version="1" datatype="string" comment="SystemRoot\System32">
+          <concat>
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25429901" item_field="value" />
             <literal_component>\System32</literal_component>
           </concat>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25439100" version="1" datatype="string" comment="Database log files path">
+          <object_component object_ref="oval:mil.disa.stig.win:obj:25439100" item_field="value" />
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25439101" version="1" datatype="string" comment="DSA Database working path">
+          <regex_capture pattern="^(.+)\\">
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25439101" item_field="value" />
+          </regex_capture>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25439102" version="1" datatype="string" comment="DSA Working Directory">
+          <object_component object_ref="oval:mil.disa.stig.win:obj:25439111" item_field="value" />
         </local_variable>
         <external_variable id="oval:mil.disa.stig.windows:var:101200" version="1" datatype="int" comment="Account Lockout Threshold">
           <possible_value hint="3_attempts">3</possible_value>
@@ -15349,13 +15240,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <possible_value hint="86400_seconds">86400</possible_value>
           <possible_value hint="172800_seconds">172800</possible_value>
           <possible_value hint="432000_seconds">432000</possible_value>
-        </external_variable>
-        <external_variable id="oval:mil.disa.stig.windows:var:101700" version="1" datatype="int" comment="Minimum Password Length">
-          <possible_value hint="8_characters">8</possible_value>
-          <possible_value hint="9_characters">9</possible_value>
-          <possible_value hint="12_characters">12</possible_value>
-          <possible_value hint="14_characters">14</possible_value>
-          <possible_value hint="15_characters">15</possible_value>
         </external_variable>
         <external_variable id="oval:mil.disa.stig.windows:var:101800" version="1" datatype="boolean" comment="Enforce Password Complexity">
           <possible_value hint="disabled">0</possible_value>
@@ -15483,17 +15367,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <possible_value hint="disabled">0</possible_value>
           <possible_value hint="enabled">1</possible_value>
         </external_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:113500" version="1" datatype="string" comment="Database log files path">
-          <object_component object_ref="oval:mil.disa.stig.windows:obj:113500" item_field="value" />
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:113501" version="2" datatype="string" comment="DSA Database working path">
-          <regex_capture pattern="^(.+)\\">
-            <object_component object_ref="oval:mil.disa.stig.windows:obj:113501" item_field="value" />
-          </regex_capture>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:113502" version="1" datatype="string" comment="DSA Working Directory">
-          <object_component object_ref="oval:mil.disa.stig.windows:obj:113520" item_field="value" />
-        </local_variable>
         <local_variable id="oval:mil.disa.stig.windows:var:118300" version="2" datatype="string" comment="Built-in Guest">
           <object_component object_ref="oval:mil.disa.stig.windows:obj:118301" item_field="trustee_sid" />
         </local_variable>
@@ -15517,54 +15390,15 @@ Incorrect configurations could prevent services from starting and result in a de
             <literal_component>\Guest</literal_component>
           </concat>
         </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:126400" version="2" datatype="string" comment="Path to Security.evtx, with %SystemRoot% variable swapped for its value, usually C:\Windows.">
-          <concat>
-            <object_component object_ref="oval:mil.disa.fso.windows:obj:388601" item_field="value" />
-            <regex_capture pattern="^%.*%(.*)$">
-              <object_component object_ref="oval:mil.disa.stig.windows:obj:126402" item_field="value" />
-            </regex_capture>
-          </concat>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:126401" version="3" datatype="string" comment="Full strict path to Security.evtx.">
-          <regex_capture pattern="^(.*)$">
-            <object_component object_ref="oval:mil.disa.stig.windows:obj:126402" item_field="value" />
-          </regex_capture>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:127000" version="2" datatype="string" comment="Path to Application.evtx with %SystemRoot% variable swapped for its value, usually C:\Windows.">
-          <concat>
-            <object_component object_ref="oval:mil.disa.fso.windows:obj:388601" item_field="value" />
-            <regex_capture pattern="^%.*%(.*)$">
-              <object_component object_ref="oval:mil.disa.stig.windows:obj:127002" item_field="value" />
-            </regex_capture>
-          </concat>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:127001" version="3" datatype="string" comment="Full strict path to Application.evtx">
-          <regex_capture pattern="^(.*)$">
-            <object_component object_ref="oval:mil.disa.stig.windows:obj:127002" item_field="value" />
-          </regex_capture>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:127100" version="2" datatype="string" comment="Path to System.evtx with %SystemRoot% variable swapped for its value, usually C:\Windows.">
-          <concat>
-            <object_component object_ref="oval:mil.disa.fso.windows:obj:388601" item_field="value" />
-            <regex_capture pattern="^%.*%(.*)$">
-              <object_component object_ref="oval:mil.disa.stig.windows:obj:127102" item_field="value" />
-            </regex_capture>
-          </concat>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:127101" version="3" datatype="string" comment="Full strict path to System.evtx.">
-          <regex_capture pattern="^(.*)$">
-            <object_component object_ref="oval:mil.disa.stig.windows:obj:127102" item_field="value" />
-          </regex_capture>
-        </local_variable>
       </variables>
     </oval_definitions>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2022-05-01T21:48:27">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2023-03-28T17:41:26">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-05-01T21:48:27</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:25</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.stig.windows:def:1001" version="2" class="inventory">

--- a/scap/content/guides/disa/stig-ws2019.xml
+++ b/scap/content/guides/disa/stig-ws2019.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
-  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2022-05-01T21:49:43">
+<data-stream-collection xmlns="http://scap.nist.gov/schema/scap/source/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_mil.disa.stig_collection_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark" schematron-version="1.2" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.2 http://scap.nist.gov/schema/xccdf/1.2/xccdf_1.2.xsd http://cpe.mitre.org/dictionary/2.0 http://scap.nist.gov/schema/cpe/2.3/cpe-dictionary_2.3.xsd http://oval.mitre.org/XMLSchema/oval-common-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#independent http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/independent-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#windows http://oval.mitre.org/language/download/schema/version5.10.1/ovaldefinition/complete/windows-definitions-schema.xsd http://scap.nist.gov/schema/scap/source/1.2 http://scap.nist.gov/schema/scap/1.2/scap-source-data-stream_1.2.xsd">
+  <data-stream id="scap_mil.disa.stig_datastream_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark" use-case="CONFIGURATION" scap-version="1.2" timestamp="2023-03-28T17:41:29">
     <dictionaries>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+          <cat:uri name="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
         </cat:catalog>
       </component-ref>
     </dictionaries>
     <checklists>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml">
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-xccdf.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-xccdf.xml">
         <cat:catalog xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-          <cat:uri name="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          <cat:uri name="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" uri="#scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
         </cat:catalog>
       </component-ref>
     </checklists>
     <checks>
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
-      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
+      <component-ref xmlns:xlink="http://www.w3.org/1999/xlink" id="scap_mil.disa.stig_cref_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" xlink:href="#scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" />
     </checks>
   </data-stream>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2022-05-01T21:49:43">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-cpe-dictionary.xml" timestamp="2023-03-28T17:41:29">
     <cpe-list xmlns="http://cpe.mitre.org/dictionary/2.0">
       <cpe-item name="cpe:/o:microsoft:windows_server_2019:-">
         <title>Microsoft Windows Server 2019</title>
-        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.windows:def:2001</check>
+        <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml">oval:mil.disa.stig.windows:def:2001</check>
       </cpe-item>
     </cpe-list>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2022-05-01T21:49:43">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-xccdf.xml" timestamp="2023-03-28T17:41:29">
     <xccdf:Benchmark xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xmlns:xhtml="http://www.w3.org/1999/xhtml" id="xccdf_mil.disa.stig_benchmark_Windows_Server_2019_STIG" xml:lang="en" style="SCAP_1.2">
-      <xccdf:status date="2022-03-01">accepted</xccdf:status>
-      <xccdf:title>Microsoft Windows Server 2019 Security Technical Implementation Guide</xccdf:title>
-      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
+      <xccdf:status date="2023-03-02">accepted</xccdf:status>
+      <xccdf:title>Microsoft Windows Server 2019 STIG SCAP Benchmark</xccdf:title>
+      <xccdf:description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</xccdf:description>
       <xccdf:notice id="terms-of-use" xml:lang="en" />
       <xccdf:front-matter xml:lang="en" />
       <xccdf:rear-matter xml:lang="en" />
@@ -40,31 +40,43 @@
         <dc:publisher>DISA</dc:publisher>
         <dc:source>STIG.DOD.MIL</dc:source>
       </xccdf:reference>
-      <xccdf:plain-text id="release-info">Release: 2.2 Benchmark Date: 31 May 2022</xccdf:plain-text>
-      <xccdf:plain-text id="generator">3.3.0.27375</xccdf:plain-text>
+      <xccdf:plain-text id="release-info">Release: 2.4 Benchmark Date: 11 May 2023</xccdf:plain-text>
+      <xccdf:plain-text id="generator">3.4.0.34222</xccdf:plain-text>
       <xccdf:plain-text id="conventionsVersion">1.10.0</xccdf:plain-text>
       <cpe:platform-specification>
+        <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_MemberServer">
+          <title>Windows Domain Member Server</title>
+          <logical-test negate="false" operator="AND">
+            <check-fact-ref id-ref="oval:mil.disa.stig.win:def:100004" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </logical-test>
+        </platform>
         <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_Server_2019_MS">
           <title xml:lang="en-US">Windows Server 2019 Member Server</title>
           <logical-test negate="false" operator="AND">
-            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:2008" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:2008" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </logical-test>
         </platform>
         <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_Server_2019_DC">
           <title xml:lang="en-US">Windows Server 2019 Domain Controller</title>
           <logical-test negate="false" operator="AND">
-            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:2010" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:2010" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </logical-test>
         </platform>
         <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_Server_2019_Standalone">
           <title xml:lang="en-US">Windows Server 2019 Standalone Server</title>
           <logical-test negate="false" operator="AND">
-            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:2009" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <check-fact-ref id-ref="oval:mil.disa.stig.windows:def:2009" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
+          </logical-test>
+        </platform>
+        <platform xmlns="http://cpe.mitre.org/language/2.0" id="xccdf_mil.disa.stig_platform_Windows_DomainController">
+          <title>Windows Domain Controller</title>
+          <logical-test negate="false" operator="AND">
+            <check-fact-ref id-ref="oval:mil.disa.stig.win:def:100005" system="http://oval.mitre.org/XMLSchema/oval-definitions-5" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </logical-test>
         </platform>
       </cpe:platform-specification>
       <xccdf:platform idref="cpe:/o:microsoft:windows_server_2019:-" />
-      <xccdf:version update="http://iase.disa.mil/stigs">002.002</xccdf:version>
+      <xccdf:version update="http://iase.disa.mil/stigs">002.004</xccdf:version>
       <xccdf:metadata>
         <dc:creator>DISA</dc:creator>
         <dc:publisher>DISA</dc:publisher>
@@ -156,7 +168,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205722" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205724" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205725" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205729" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205730" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205731" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205732" selected="true" />
@@ -205,7 +216,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205791" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205792" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205793" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205794" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205795" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205796" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205797" selected="true" />
@@ -364,7 +374,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205722" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205724" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205725" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205729" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205730" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205731" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205732" selected="true" />
@@ -413,7 +422,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205791" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205792" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205793" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205794" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205795" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205796" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205797" selected="true" />
@@ -572,7 +580,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205722" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205724" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205725" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205729" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205730" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205731" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205732" selected="true" />
@@ -621,7 +628,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205791" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205792" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205793" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205794" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205795" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205796" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205797" selected="true" />
@@ -780,7 +786,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205722" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205724" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205725" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205729" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205730" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205731" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205732" selected="true" />
@@ -829,7 +834,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205791" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205792" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205793" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205794" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205795" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205796" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205797" selected="true" />
@@ -988,7 +992,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205722" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205724" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205725" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205729" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205730" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205731" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205732" selected="true" />
@@ -1037,7 +1040,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205791" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205792" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205793" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205794" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205795" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205796" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205797" selected="true" />
@@ -1196,7 +1198,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205722" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205724" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205725" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205729" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205730" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205731" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205732" selected="true" />
@@ -1245,7 +1246,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205791" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205792" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205793" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205794" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205795" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205796" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205797" selected="true" />
@@ -1404,7 +1404,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205722" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205724" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205725" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205729" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205730" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205731" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205732" selected="true" />
@@ -1453,7 +1452,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205791" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205792" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205793" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205794" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205795" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205796" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205797" selected="true" />
@@ -1612,7 +1610,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205722" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205724" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205725" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205729" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205730" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205731" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205732" selected="true" />
@@ -1661,7 +1658,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205791" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205792" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205793" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205794" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205795" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205796" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205797" selected="true" />
@@ -1820,7 +1816,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205722" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205724" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205725" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205729" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205730" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205731" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205732" selected="true" />
@@ -1869,7 +1864,6 @@
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205791" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205792" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205793" selected="true" />
-        <xccdf:select idref="xccdf_mil.disa.stig_group_V-205794" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205795" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205796" selected="true" />
         <xccdf:select idref="xccdf_mil.disa.stig_group_V-205797" selected="true" />
@@ -1946,66 +1940,64 @@
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_Disable_Slow_Rules">
         <xccdf:title>Disable Slow Rules</xccdf:title>
         <xccdf:description>This profile disables rules known to have poor performance in some environments, such as systems with large numbers of user accounts.</xccdf:description>
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205643r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205643r852417_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205665r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205666r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205669r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205671r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205674r819709_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205671r857331_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205676r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205709r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205744r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205745r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205748r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205749r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205750r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205751r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205752r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205753r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205754r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205755r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205756r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205757r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205758r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205759r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205760r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205761r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205762r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205763r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205764r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205765r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205766r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205767r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205768r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205744r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205745r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205748r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205749r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205750r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205751r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205752r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205753r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205754r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205755r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205756r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205757r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205758r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205759r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205760r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205761r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205762r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205763r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205764r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205766r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205767r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205768r877392_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205909r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205910r569188_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Profile id="xccdf_mil.disa.stig_profile_CAT_I_Only">
         <xccdf:title>CAT I Only</xccdf:title>
         <xccdf:description>This profile only includes rules that are Severity Category I.</xccdf:description>
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205625r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205626r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205627r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205625r852412_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205626r852413_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205627r852414_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205629r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205630r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205630r852416_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205633r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205634r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205635r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205636r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205637r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205636r877398_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205637r877398_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205638r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205639r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205640r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205641r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205642r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205643r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205643r852417_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205644r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205648r819704_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205649r819707_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205650r573797_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205648r890527_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205649r894615_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205650r890530_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205651r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205652r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205655r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205655r877396_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205656r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205659r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205660r569188_rule" selected="false" />
@@ -2016,11 +2008,11 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205668r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205669r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205670r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205671r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205672r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205673r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205674r819709_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205675r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205671r857331_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205672r857333_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205673r857335_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205674r891848_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205675r857337_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205676r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205678r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205679r569188_rule" selected="false" />
@@ -2039,109 +2031,107 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205692r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205693r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205694r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205696r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205696r857322_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205697r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205698r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205702r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205703r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205704r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205705r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205706r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205702r852424_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205703r852425_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205704r852426_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205705r852427_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205706r852428_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205708r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205709r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205712r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205712r877395_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205714r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205715r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205715r857320_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205716r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205717r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205718r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205719r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205720r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205722r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205729r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205730r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205731r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205732r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205733r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205744r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205745r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205747r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205748r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205749r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205751r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205752r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205754r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205755r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205756r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205758r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205759r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205760r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205761r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205762r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205763r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205764r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205765r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205766r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205767r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205768r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205769r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205770r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205771r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205772r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205773r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205774r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205775r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205776r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205777r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205778r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205779r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205780r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205781r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205782r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205783r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205784r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205791r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205792r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205793r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205794r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205795r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205796r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205797r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205798r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205801r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205808r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205809r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205810r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205811r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205812r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205813r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205814r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205815r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205816r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205817r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205819r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205820r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205821r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205822r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205823r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205824r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205825r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205826r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205827r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205828r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205830r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205732r852430_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205733r860033_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205744r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205745r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205747r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205748r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205749r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205751r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205752r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205754r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205755r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205756r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205758r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205759r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205760r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205761r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205762r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205763r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205764r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205765r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205766r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205767r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205768r877392_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205769r852470_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205770r852471_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205771r852472_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205772r852473_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205773r852474_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205774r852475_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205775r852476_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205776r852477_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205777r852478_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205778r852479_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205779r852480_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205780r852481_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205781r852482_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205782r852483_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205783r852484_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205784r852485_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205791r852492_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205792r852493_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205793r852494_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205795r852496_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205796r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205797r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205798r877391_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205801r852502_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205808r852510_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205809r852511_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205810r852512_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205811r852513_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205812r852514_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205813r852515_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205814r877039_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205815r877039_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205816r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205817r877382_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205819r852521_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205820r852522_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205821r852523_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205822r852524_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205823r852525_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205824r852526_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205825r852527_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205826r852528_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205827r852529_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205828r852530_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205830r852532_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205832r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205833r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205835r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205836r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205837r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205838r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205842r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205842r877466_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205858r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205859r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205860r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205861r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205862r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205862r857311_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205863r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205865r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205866r569188_rule" selected="false" />
@@ -2154,7 +2144,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205873r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205874r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205876r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205906r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205906r857326_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205909r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205910r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205911r569188_rule" selected="false" />
@@ -2167,7 +2157,7 @@
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205921r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205922r569188_rule" selected="false" />
         <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205923r569188_rule" selected="false" />
-        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205925r569188_rule" selected="false" />
+        <xccdf:select idref="xccdf_mil.disa.stig_rule_SV-205925r877377_rule" selected="false" />
       </xccdf:Profile>
       <xccdf:Value id="xccdf_mil.disa.stig_value_winrm_client_allow_unencrypted_traffic_var" type="number" operator="equals">
         <xccdf:title>WinRM Client: Allow unencrypted traffic</xccdf:title>
@@ -2281,16 +2271,6 @@
         <xccdf:value>0</xccdf:value>
         <xccdf:value selector="disabled">0</xccdf:value>
         <xccdf:value selector="enabled">1</xccdf:value>
-      </xccdf:Value>
-      <xccdf:Value id="xccdf_mil.disa.stig_value_password_minimum_length_var" type="number" operator="greater than or equal">
-        <xccdf:title>Minimum Password Length</xccdf:title>
-        <xccdf:description>The minimum number of characters required for a password</xccdf:description>
-        <xccdf:value>14</xccdf:value>
-        <xccdf:value selector="8_characters">8</xccdf:value>
-        <xccdf:value selector="9_characters">9</xccdf:value>
-        <xccdf:value selector="12_characters">12</xccdf:value>
-        <xccdf:value selector="14_characters">14</xccdf:value>
-        <xccdf:value selector="15_characters">15</xccdf:value>
       </xccdf:Value>
       <xccdf:Value id="xccdf_mil.disa.stig_value_password_minimum_age_var" type="number" operator="greater than or equal">
         <xccdf:title>Minimum Password Age</xccdf:title>
@@ -2451,7 +2431,7 @@
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205625">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205625r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205625r852412_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000100</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Account Management - Security Group Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -2477,14 +2457,14 @@ Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPO
           <xccdf:fixtext fixref="F-5890r354794_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit Security Group Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-5890r354794_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2033" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2033" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205626">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205626r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205626r852413_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000110</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Account Management - User Account Management successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -2510,14 +2490,14 @@ Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPO
           <xccdf:fixtext fixref="F-5891r354797_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit User Account Management" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-5891r354797_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2034" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2034" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205627">
         <xccdf:title>SRG-OS-000004-GPOS-00004</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205627r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205627r852414_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000120</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Account Management - User Account Management failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -2543,7 +2523,7 @@ Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPO
           <xccdf:fixtext fixref="F-5892r354800_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit User Account Management" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-5892r354800_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2035" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2035" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2568,14 +2548,14 @@ Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPO
           <xccdf:fix id="F-5894r354806_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_threshold_var" export-name="oval:mil.disa.stig.windows:var:101200" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2014" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2014" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205630">
         <xccdf:title>SRG-OS-000021-GPOS-00005</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205630r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205630r852416_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AC-000030</xccdf:version>
           <xccdf:title>Windows Server 2019 must have the period of time before the bad logon counter is reset configured to 15 minutes or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system. This parameter specifies the period of time that must pass after failed logon attempts before the counter is reset to "0". The smaller this value is, the less effective the account lockout feature will be in protecting the local system.
@@ -2596,7 +2576,7 @@ Satisfies: SRG-OS-000021-GPOS-00005, SRG-OS-000329-GPOS-00128&lt;/VulnDiscussion
           <xccdf:fix id="F-5895r354809_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_account_lockout_reset_counter_var" export-name="oval:mil.disa.stig.windows:var:101300" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2015" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2015" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2624,7 +2604,7 @@ Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000029-GPOS-00010, SRG-OS-000031-GPO
           <xccdf:fixtext fixref="F-5898r354818_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive logon: Machine inactivity limit" to "900" seconds or less, excluding "0" which is effectively disabled.</xccdf:fixtext>
           <xccdf:fix id="F-5898r354818_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2137" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205633" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2653,7 +2633,7 @@ Satisfies: SRG-OS-000032-GPOS-00013, SRG-OS-000470-GPOS-00214, SRG-OS-000472-GPO
           <xccdf:fixtext fixref="F-5899r354821_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-5899r354821_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2038" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2038" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2682,14 +2662,14 @@ Satisfies: SRG-OS-000032-GPOS-00013, SRG-OS-000470-GPOS-00214, SRG-OS-000472-GPO
           <xccdf:fixtext fixref="F-5900r354824_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Logon" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-5900r354824_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2039" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2039" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205636">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205636r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205636r877398_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000370</xccdf:version>
           <xccdf:title>Windows Server 2019 Remote Desktop Services must require secure Remote Procedure Call (RPC) communications.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing unsecure RPC communication exposes the system to man-in-the-middle attacks and data disclosure attacks. A man-in-the-middle attack occurs when an intruder captures packets between a client and server and modifies them before allowing the packets to be exchanged. Usually the attacker will modify the information in the packets in an attempt to cause either the client or server to reveal sensitive information.
@@ -2710,14 +2690,14 @@ Satisfies: SRG-OS-000033-GPOS-00014, SRG-OS-000250-GPOS-00093&lt;/VulnDiscussion
           <xccdf:fix id="F-5901r354827_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_secure_rpc_communication_var" export-name="oval:mil.disa.stig.windows:var:111500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2081" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2081" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205637">
         <xccdf:title>SRG-OS-000033-GPOS-00014</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205637r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205637r877398_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000380</xccdf:version>
           <xccdf:title>Windows Server 2019 Remote Desktop Services must be configured with the client connection encryption set to High Level.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Remote connections must be encrypted to prevent interception of data or sensitive information. Selecting "High Level" will ensure encryption of Remote Desktop Services sessions in both directions.
@@ -2738,7 +2718,7 @@ Satisfies: SRG-OS-000033-GPOS-00014, SRG-OS-000250-GPOS-00093&lt;/VulnDiscussion
           <xccdf:fix id="F-5902r354830_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_set_client_connection_encryption_level_var" export-name="oval:mil.disa.stig.windows:var:111600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2082" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2082" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2764,7 +2744,7 @@ Enabling "Include command line data for process creation events" will record the
           <xccdf:fixtext fixref="F-5903r354833_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Audit Process Creation &gt;&gt; "Include command line in process creation events" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5903r354833_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2193" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2193" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2790,7 +2770,7 @@ Enabling PowerShell script block logging will record detailed information from t
           <xccdf:fixtext fixref="F-5904r354836_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows PowerShell &gt;&gt; "Turn on PowerShell Script Block Logging" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5904r354836_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2209" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2209" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2826,7 +2806,7 @@ The default location is the "%SystemRoot%\System32\winevt\Logs" folder.
 If the location of the logs has been changed, when adding Eventlog to the permissions, it must be entered as "NT Service\Eventlog".</xccdf:fixtext>
           <xccdf:fix id="F-5905r354839_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2205" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205640" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2862,7 +2842,7 @@ The default location is the "%SystemRoot%\System32\winevt\Logs" folder.
 If the location of the logs has been changed, when adding Eventlog to the permissions, it must be entered as "NT Service\Eventlog".</xccdf:fixtext>
           <xccdf:fix id="F-5906r354842_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2199" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205641" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2898,14 +2878,14 @@ The default location is the "%SystemRoot%\System32\winevt\Logs" folder.
 If the location of the logs has been changed, when adding Eventlog to the permissions, it must be entered as "NT Service\Eventlog".</xccdf:fixtext>
           <xccdf:fix id="F-5907r354845_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2206" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205642" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205643">
         <xccdf:title>SRG-OS-000057-GPOS-00027</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205643r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205643r852417_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000170</xccdf:version>
           <xccdf:title>Windows Server 2019 Manage auditing and security log user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -2932,7 +2912,7 @@ Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPO
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-5908r354848_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2187" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2187" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -2942,7 +2922,7 @@ Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPO
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205644r569188_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000050</xccdf:version>
           <xccdf:title>Windows Server 2019 must force audit policy subcategory settings to override audit policy category settings.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
 This setting allows administrators to enable more precise auditing capabilities.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2019</dc:title>
@@ -2957,14 +2937,14 @@ This setting allows administrators to enable more precise auditing capabilities.
           <xccdf:fixtext fixref="F-5909r354851_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Audit: Force audit policy subcategory settings (Windows Vista or later) to override audit policy category settings" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5909r354851_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2130" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2130" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205648">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205648r819704_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205648r890527_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-PK-000010</xccdf:version>
           <xccdf:title>Windows Server 2019 must have the DoD Root Certificate Authority (CA) certificates installed in the Trusted Root Store.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root CAs. The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.
@@ -2980,23 +2960,23 @@ Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-103573</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-93487</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-5913r819703_fix">Install the DoD Root CA certificates:
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
+          <xccdf:fixtext fixref="F-5913r890526_fix">Install the DoD Root CA certificates:
 DoD Root CA 3
 DoD Root CA 4
 DoD Root CA 5
 
-The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-5913r819703_fix" />
+The InstallRoot tool is available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. Certificate bundles published by the PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-5913r890526_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2067" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205648" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205649">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205649r819707_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205649r894615_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-PK-000020</xccdf:version>
           <xccdf:title>Windows Server 2019 must have the DoD Interoperability Root Certificate Authority (CA) cross-certificates installed in the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.
@@ -3012,28 +2992,26 @@ Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">V-93489</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-103575</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002440</xccdf:ident>
-          <xccdf:fixtext fixref="F-5914r819706_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
+          <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
+          <xccdf:fixtext fixref="F-5914r894340_fix">Install the DoD Interoperability Root CA cross-certificates on unclassified systems.
 
 Issued To - Issued By - Thumbprint
 
 DoD Root CA 3 - DoD Interoperability Root CA 2 - 49CBE933151872E17C8EAE7F0ABA97FB610F6477
 
-DoD Root CA 3 - DoD Interoperability Root CA 2 - AC06108CA348CC03B53795C64BF84403C1DBD341
-
 Administrators should run the Federal Bridge Certification Authority (FBCA) Cross-Certificate Removal Tool once as an administrator and once as the current user.
 
 The FBCA Cross-Certificate Remover Tool and User Guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-5914r819706_fix" />
+          <xccdf:fix id="F-5914r894340_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2068" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205649" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205650">
         <xccdf:title>SRG-OS-000066-GPOS-00034</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205650r573797_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205650r890530_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-PK-000030</xccdf:version>
           <xccdf:title>Windows Server 2019 must have the US DoD CCEB Interoperability Root CA cross-certificates in the Untrusted Certificates Store on unclassified systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.
@@ -3050,20 +3028,18 @@ Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182&lt;/VulnDiscussion
           <xccdf:ident system="http://cyber.mil/legacy">SV-103577</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000185</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002470</xccdf:ident>
-          <xccdf:fixtext fixref="F-5915r603250_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
+          <xccdf:fixtext fixref="F-5915r890529_fix">Install the US DoD CCEB Interoperability Root CA cross-certificate on unclassified systems.
 
 Issued To - Issued By - Thumbprint
 
-DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2 - AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9
-
-DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2 - 929BF3196896994C0A201DF4A5B71F603FEFBF2E
+DoD Root CA 3 - US DoD CCEB Interoperability Root CA 2 - 9B74964506C7ED9138070D08D5F8B969866560C8
 
 Administrators should run the Federal Bridge Certification Authority (FBCA) Cross-Certificate Removal Tool once as an administrator and once as the current user.
 
-The FBCA Cross-Certificate Remover Tool and User Guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files.</xccdf:fixtext>
-          <xccdf:fix id="F-5915r603250_fix" />
+The FBCA Cross-Certificate Remover Tool and User Guide are available on Cyber Exchange at https://cyber.mil/pki-pke/tools-configuration-files. Certificate bundles published by the PKI can be found at https://crl.gds.disa.mil/.</xccdf:fixtext>
+          <xccdf:fix id="F-5915r890529_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2069" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205650" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3093,7 +3069,7 @@ Both the holders of a digital certificate and the issuing authority must protect
           <xccdf:fixtext fixref="F-5916r354872_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "System cryptography: Force strong key protection for user keys stored on the computer" to "User must enter a password each time they use a key".</xccdf:fixtext>
           <xccdf:fix id="F-5916r354872_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2160" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2160" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3123,14 +3099,14 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fix id="F-5917r354875_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_complexity_var" export-name="oval:mil.disa.stig.windows:var:101800" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2020" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2020" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205653">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205653r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205653r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AC-000090</xccdf:version>
           <xccdf:title>Windows Server 2019 reversible password encryption must be disabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storing passwords using reversible encryption is essentially the same as storing clear-text versions of the passwords, which are easily compromised. For this reason, this policy must never be enabled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3148,14 +3124,14 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fix id="F-5918r354878_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_reversible_encryption_var" export-name="oval:mil.disa.stig.windows:var:101900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2021" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2021" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205654">
         <xccdf:title>SRG-OS-000073-GPOS-00041</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205654r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205654r877397_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000300</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to prevent the storage of the LAN Manager hash of passwords.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The LAN Manager hash uses a weak encryption algorithm and there are several tools available that use this hash to retrieve account passwords. This setting controls whether a LAN Manager hash of the password is stored in the SAM the next time the password is changed.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3172,14 +3148,14 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fixtext fixref="F-5919r354881_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Do not store LAN Manager hash value on next password change" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5919r354881_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2155" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2155" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205655">
         <xccdf:title>SRG-OS-000074-GPOS-00042</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205655r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205655r877396_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000180</xccdf:version>
           <xccdf:title>Windows Server 2019 unencrypted passwords must not be sent to third-party Server Message Block (SMB) servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Some non-Microsoft SMB servers only support unencrypted (plain-text) password authentication. Sending plain-text passwords across the network when authenticating to an SMB server reduces the overall security of the environment. Check with the vendor of the SMB server to determine if there is a way to support encrypted password authentication.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3196,7 +3172,7 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fixtext fixref="F-5920r354884_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft Network Client: Send unencrypted password to third-party SMB servers" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-5920r354884_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2143" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2143" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3221,7 +3197,7 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fix id="F-5921r354887_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_age_var" export-name="oval:mil.disa.stig.windows:var:101600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2018" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2018" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3246,7 +3222,7 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fix id="F-5924r354896_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_maximum_age_var" export-name="oval:mil.disa.stig.windows:var:101500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2017" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2017" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3271,7 +3247,7 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fix id="F-5925r354899_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_enforce_history_var" export-name="oval:mil.disa.stig.windows:var:101400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2016" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2016" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3295,8 +3271,7 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fixtext fixref="F-5927r354905_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Password Policy &gt;&gt; "Minimum password length" to "14" characters.</xccdf:fixtext>
           <xccdf:fix id="F-5927r354905_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-export value-id="xccdf_mil.disa.stig_value_password_minimum_length_var" export-name="oval:mil.disa.stig.windows:var:101700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2019" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205662" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3320,7 +3295,7 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
           <xccdf:fixtext fixref="F-5928r354908_fix">Format volumes to use NTFS or ReFS.</xccdf:fixtext>
           <xccdf:fix id="F-5928r354908_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2022" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2022" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3329,7 +3304,7 @@ Satisfies: SRG-OS-000069-GPOS-00037, SRG-OS-000070-GPOS-00038, SRG-OS-000071-GPO
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205665r569188_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000340</xccdf:version>
-          <xccdf:title>Windows Server 2019 Access this computer from the network user right must only be assigned to the Administrators, Authenticated Users, and 
+          <xccdf:title>Windows Server 2019 Access this computer from the network user right must only be assigned to the Administrators, Authenticated Users, and
 Enterprise Domain Controllers groups on domain controllers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
@@ -3352,7 +3327,7 @@ Accounts with the "Access this computer from the network" right may access resou
 - Enterprise Domain Controllers</xccdf:fixtext>
           <xccdf:fix id="F-5930r354914_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2106" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2106" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3381,7 +3356,7 @@ Accounts with the "Allow log on through Remote Desktop Services" user right can 
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-5931r354917_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2108" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2108" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3412,7 +3387,7 @@ The Guests group must be assigned this right to prevent unauthenticated access.&
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-5932r354920_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2109" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2109" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3443,7 +3418,7 @@ The Guests group must be assigned to prevent unauthenticated access.&lt;/VulnDis
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-5933r354923_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2110" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2110" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3472,7 +3447,7 @@ Incorrect configurations could prevent services from starting and result in a de
           <xccdf:fixtext fixref="F-5934r354926_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Deny log on as a service" to include no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-5934r354926_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2111" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2111" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3503,16 +3478,16 @@ The Guests group must be assigned this right to prevent unauthenticated access.&
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-5935r354929_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2112" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2112" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205671">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205671r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205671r857331_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000070</xccdf:version>
-          <xccdf:title>Windows Server 2019 Access this computer from the network user right must only be assigned to the Administrators and Authenticated Users groups on domain-joined member servers and standalone systems.</xccdf:title>
+          <xccdf:title>Windows Server 2019 "Access this computer from the network" user right must only be assigned to the Administrators and Authenticated Users groups on domain-joined member servers and standalone or nondomain-joined systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 Accounts with the "Access this computer from the network" user right may access resources on the system, and this right must be limited to those requiring it.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -3534,16 +3509,16 @@ Accounts with the "Access this computer from the network" user right may access 
 - Authenticated Users</xccdf:fixtext>
           <xccdf:fix id="F-5936r354932_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2119" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2119" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205672">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205672r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205672r857333_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000080</xccdf:version>
-          <xccdf:title>Windows Server 2019 Deny access to this computer from the network user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts and local accounts and from unauthenticated access on all systems.</xccdf:title>
+          <xccdf:title>Windows Server 2019 "Deny access to this computer from the network" user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts and local accounts and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Deny access to this computer from the network" user right defines the accounts that are prevented from logging on from the network.
@@ -3578,16 +3553,16 @@ All Systems:
 Note: These are built-in security groups. "Local account" is more restrictive but may cause issues on servers such as systems that provide failover clustering.</xccdf:fixtext>
           <xccdf:fix id="F-5937r354935_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2120" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2120" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205673">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205673r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205673r857335_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000090</xccdf:version>
-          <xccdf:title>Windows Server 2019 Deny log on as a batch job user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts and from unauthenticated access on all systems.</xccdf:title>
+          <xccdf:title>Windows Server 2019 "Deny log on as a batch job" user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Deny log on as a batch job" user right defines accounts that are prevented from logging on to the system as a batch job, such as Task Scheduler.
@@ -3617,14 +3592,14 @@ All Systems:
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-5938r354938_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2121" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2121" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205674">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205674r819709_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205674r891848_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000100</xccdf:version>
           <xccdf:title>Windows Server 2019 "Deny log on as a service" user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts. No other groups or accounts must be assigned this right.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -3641,8 +3616,7 @@ Incorrect configurations could prevent services from starting and result in a de
             <dc:subject>Microsoft Windows Server 2019</dc:subject>
             <dc:identifier>2907</dc:identifier>
           </xccdf:reference>
-          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_Server_2019_Standalone" />
-          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_Server_2019_MS" />
+          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_MemberServer" />
           <xccdf:ident system="http://cyber.mil/legacy">SV-103101</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-93013</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-000213</xccdf:ident>
@@ -3653,16 +3627,16 @@ Domain systems:
 - Domain Admins Group</xccdf:fixtext>
           <xccdf:fix id="F-5939r354941_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2122" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205674" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205675">
         <xccdf:title>SRG-OS-000080-GPOS-00048</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205675r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205675r857337_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000110</xccdf:version>
-          <xccdf:title>Windows Server 2019 Deny log on locally user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts and from unauthenticated access on all systems.</xccdf:title>
+          <xccdf:title>Windows Server 2019 "Deny log on locally" user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Deny log on locally" user right defines accounts that are prevented from logging on interactively.
@@ -3692,7 +3666,7 @@ All Systems:
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-5940r354944_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2123" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2123" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3720,7 +3694,7 @@ Accounts with the "Allow log on locally" user right can log on interactively to 
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-5941r354947_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2173" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2173" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3758,7 +3732,7 @@ Deselect "Fax Server" on the "Roles" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-5943r354953_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2024" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2024" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3796,7 +3770,7 @@ Deselect "Peer Name Resolution Protocol" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-5944r354956_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2026" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2026" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3834,7 +3808,7 @@ Deselect "Simple TCP/IP Services" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-5945r354959_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2027" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2027" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3872,7 +3846,7 @@ Deselect "TFTP Client" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-5946r354962_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2200" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2200" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3917,7 +3891,7 @@ Deselect "SMB 1.0/CIFS File Sharing Support" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-5947r354965_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2194" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2194" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3945,7 +3919,7 @@ The system must be restarted for the change to take effect.
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-5948r354968_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2195" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2195" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -3973,7 +3947,7 @@ The system must be restarted for the changes to take effect.
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-5949r354971_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2196" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2196" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4011,7 +3985,7 @@ Deselect "Windows PowerShell 2.0 Engine" under "Windows PowerShell" on the "Feat
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-5950r354974_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2201" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2201" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4035,7 +4009,7 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fixtext fixref="F-5951r354977_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Control Panel &gt;&gt; Personalization &gt;&gt; "Prevent enabling lock screen slide show" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5951r354977_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2216" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2216" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4061,7 +4035,7 @@ Click "Next" and "Remove" as prompted.</xccdf:fixtext>
 This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and " SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
           <xccdf:fix id="F-5952r354980_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2210" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2210" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4071,7 +4045,7 @@ This policy setting requires the installation of the SecGuide custom templates i
         <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205688r569188_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000150</xccdf:version>
           <xccdf:title>Windows Server 2019 downloading print driver packages over HTTP must be turned off.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature. Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and will prevent uncontrolled updates to the system. 
+          <xccdf:description>&lt;VulnDiscussion&gt;Some features may communicate with the vendor, sending system information or downloading data or components for the feature. Turning off this capability will prevent potentially sensitive information from being sent outside the enterprise and will prevent uncontrolled updates to the system.
 
 This setting prevents the computer from downloading print driver packages over HTTP.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
@@ -4088,7 +4062,7 @@ This setting prevents the computer from downloading print driver packages over H
           <xccdf:fix id="F-5953r354983_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_downloading_of_print_drivers_over_http_var" export-name="oval:mil.disa.stig.windows:var:109100" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2059" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2059" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4115,7 +4089,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
           <xccdf:fix id="F-5954r354986_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_printing_over_http_var" export-name="oval:mil.disa.stig.windows:var:109200" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2060" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2060" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4139,7 +4113,7 @@ This setting prevents the client computer from printing over HTTP, which allows 
           <xccdf:fixtext fixref="F-5955r354989_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Logon &gt;&gt; "Do not display network selection UI" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5955r354989_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2215" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2215" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4166,7 +4140,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
           <xccdf:fix id="F-5956r354992_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_program_inventory_var" export-name="oval:mil.disa.stig.windows:var:109600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2063" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2063" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4192,7 +4166,7 @@ This setting will prevent the Program Inventory from collecting data about a sys
 Windows 2019 includes duplicate policies for this setting. It can also be configured under Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Defender SmartScreen &gt;&gt; Explorer.</xccdf:fixtext>
           <xccdf:fix id="F-5957r354995_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2074" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2074" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4219,7 +4193,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-5958r354998_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_on_basic_feed_authentication_over_http_var" export-name="oval:mil.disa.stig.windows:var:111800" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2084" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2084" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4243,14 +4217,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-5959r355001_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Search &gt;&gt; "Allow indexing of encrypted files" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-5959r355001_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2197" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2197" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205696">
         <xccdf:title>SRG-OS-000095-GPOS-00049</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205696r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205696r857322_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000030</xccdf:version>
           <xccdf:title>Windows Server 2019 local users on domain-joined member servers must not be enumerated.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The username is one part of logon credentials that could be used to gain access to a system. Preventing the enumeration of users limits this information to authorized personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4268,7 +4242,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-5961r355007_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Logon &gt;&gt; "Enumerate local users on domain-joined computers" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-5961r355007_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2116" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2116" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4306,7 +4280,7 @@ Deselect "FTP Server" under "Web Server (IIS)" on the "Roles" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-5962r355010_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2025" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2025" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4344,14 +4318,14 @@ Deselect "Telnet Client" on the "Features" page.
 Click "Next" and "Remove" as prompted.</xccdf:fixtext>
           <xccdf:fix id="F-5963r355013_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2028" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2028" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205702">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205702r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205702r852424_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000020</xccdf:version>
           <xccdf:title>Windows Server 2019 Kerberos user logon restrictions must be enforced.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This policy setting determines whether the Kerberos Key Distribution Center (KDC) validates every request for a session ticket against the user rights policy of the target computer. The policy is enabled by default, which is the most secure setting for validating that access to target resources is not circumvented.
@@ -4372,14 +4346,14 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-5967r355025_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Policies &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Enforce user logon restrictions" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5967r355025_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2094" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2094" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205703">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205703r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205703r852425_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000030</xccdf:version>
           <xccdf:title>Windows Server 2019 Kerberos service ticket maximum lifetime must be limited to 600 minutes or less.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting determines the maximum amount of time (in minutes) that a granted session ticket can be used to access a particular service. Session tickets are used only to authenticate new connections with servers. Ongoing operations are not interrupted if the session ticket used to authenticate the connection expires during the connection.
@@ -4400,14 +4374,14 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-5968r355028_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Policies &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Maximum lifetime for service ticket" to a maximum of "600" minutes, but not "0", which equates to "Ticket doesn't expire".</xccdf:fixtext>
           <xccdf:fix id="F-5968r355028_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2095" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2095" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205704">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205704r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205704r852426_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000040</xccdf:version>
           <xccdf:title>Windows Server 2019 Kerberos user ticket lifetime must be limited to 10 hours or less.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;In Kerberos, there are two types of tickets: Ticket Granting Tickets (TGTs) and Service Tickets. Kerberos tickets have a limited lifetime so the time an attacker has to implement an attack is limited. This policy controls how long TGTs can be renewed. With Kerberos, the user's initial authentication to the domain controller results in a TGT, which is then used to request Service Tickets to resources. Upon startup, each computer gets a TGT before requesting a service ticket to the domain controller and any other computers it needs to access. For services that start up under a specified user account, users must always get a TGT first and then get Service Tickets to all computers and services accessed.
@@ -4428,14 +4402,14 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-5969r355031_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Policies &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Maximum lifetime for user ticket" to a maximum of "10" hours but not "0", which equates to "Ticket doesn't expire".</xccdf:fixtext>
           <xccdf:fix id="F-5969r355031_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2096" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2096" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205705">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205705r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205705r852427_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000050</xccdf:version>
           <xccdf:title>Windows Server 2019 Kerberos policy user ticket renewal maximum lifetime must be limited to seven days or less.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting determines the period of time (in days) during which a user's Ticket Granting Ticket (TGT) may be renewed. This security configuration limits the amount of time an attacker has to crack the TGT and gain access.
@@ -4456,14 +4430,14 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-5970r355034_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Policies &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Maximum lifetime for user ticket renewal" to a maximum of "7" days or less.</xccdf:fixtext>
           <xccdf:fix id="F-5970r355034_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2097" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2097" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205706">
         <xccdf:title>SRG-OS-000112-GPOS-00057</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205706r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205706r852428_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000060</xccdf:version>
           <xccdf:title>Windows Server 2019 computer clock synchronization tolerance must be limited to five minutes or less.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting determines the maximum time difference (in minutes) that Kerberos will tolerate between the time on a client's clock and the time on a server's clock while still considering the two clocks synchronous. In order to prevent replay attacks, Kerberos uses timestamps as part of its protocol definition. For timestamps to work properly, the clocks of the client and the server need to be in sync as much as possible.
@@ -4484,7 +4458,7 @@ Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-5971r355037_fix">Configure the policy value in the Default Domain Policy for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Account Policies &gt;&gt; Kerberos Policy &gt;&gt; "Maximum tolerance for computer clock synchronization" to a maximum of "5" minutes or less.</xccdf:fixtext>
           <xccdf:fix id="F-5971r355037_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2098" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2098" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4516,7 +4490,7 @@ Future encryption types
 Note: Organizations with domain controllers running earlier versions of Windows where RC4 encryption is enabled, selecting "The other domain supports Kerberos AES Encryption" on domain trusts, may be required to allow client communication across the trust relationship.</xccdf:fixtext>
           <xccdf:fix id="F-5973r355043_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2154" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2154" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4541,14 +4515,14 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fix id="F-5974r355046_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_guest_account_status_var" export-name="oval:mil.disa.stig.windows:var:118301" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2126" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2126" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205711">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205711r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205711r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000470</xccdf:version>
           <xccdf:title>Windows Server 2019 Windows Remote Management (WinRM) client must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain-text passwords that could be used to compromise a system. Disabling Basic authentication will reduce this potential.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4565,14 +4539,14 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fixtext fixref="F-5976r355052_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Client &gt;&gt; "Allow Basic authentication" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-5976r355052_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2088" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2088" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205712">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205712r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205712r877395_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000490</xccdf:version>
           <xccdf:title>Windows Server 2019 Windows Remote Management (WinRM) client must not use Digest authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Digest authentication is not as strong as other options and may be subject to man-in-the-middle attacks. Disallowing Digest authentication will reduce this potential.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4589,14 +4563,14 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fixtext fixref="F-5977r355055_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Client &gt;&gt; "Disallow Digest authentication" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5977r355055_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2090" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2090" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205713">
         <xccdf:title>SRG-OS-000125-GPOS-00065</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205713r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205713r877395_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000500</xccdf:version>
           <xccdf:title>Windows Server 2019 Windows Remote Management (WinRM) service must not use Basic authentication.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Basic authentication uses plain-text passwords that could be used to compromise a system. Disabling Basic authentication will reduce this potential.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -4613,7 +4587,7 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fixtext fixref="F-5978r355058_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Service &gt;&gt; "Allow Basic authentication" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-5978r355058_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2091" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2091" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4638,14 +4612,14 @@ Note: Organizations with domain controllers running earlier versions of Windows 
           <xccdf:fix id="F-5979r355061_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_enumerate_administrator_accounts_on_elevation_var" export-name="oval:mil.disa.stig.windows:var:110400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2070" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2070" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205715">
         <xccdf:title>SRG-OS-000134-GPOS-00068</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205715r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205715r857320_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000020</xccdf:version>
           <xccdf:title>Windows Server 2019 local administrator accounts must have their privileged token filtered to prevent elevated privileges from being used over the network on domain-joined member servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A compromised local administrator account can provide means for an attacker to move laterally between domain systems.
@@ -4662,12 +4636,12 @@ With User Account Control enabled, filtering the privileged token for local admi
           <xccdf:ident system="http://cyber.mil/legacy">V-93519</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">SV-103605</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-001084</xccdf:ident>
-          <xccdf:fixtext fixref="F-5980r355064_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; MS Security Guide &gt;&gt; "Apply UAC restrictions to local accounts on network logons" to "Enabled".
+          <xccdf:fixtext fixref="F-5980r857319_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; MS Security Guide &gt;&gt; "Apply UAC restrictions to local accounts on network logons" to "Enabled".
 
-This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and " SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
-          <xccdf:fix id="F-5980r355064_fix" />
+This policy setting requires the installation of the SecGuide custom templates included with the STIG package. "SecGuide.admx" and "SecGuide.adml" must be copied to the \Windows\PolicyDefinitions and \Windows\PolicyDefinitions\en-US directories respectively.</xccdf:fixtext>
+          <xccdf:fix id="F-5980r857319_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2115" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2115" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4691,7 +4665,7 @@ This policy setting requires the installation of the SecGuide custom templates i
           <xccdf:fixtext fixref="F-5981r355067_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Allow UIAccess applications to prompt for elevation without using the secure desktop" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-5981r355067_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2164" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2164" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4717,7 +4691,7 @@ This policy setting requires the installation of the SecGuide custom templates i
 The more secure option for this setting, "Prompt for credentials on the secure desktop", would also be acceptable.</xccdf:fixtext>
           <xccdf:fix id="F-5982r355070_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2165" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2165" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4741,7 +4715,7 @@ The more secure option for this setting, "Prompt for credentials on the secure d
           <xccdf:fixtext fixref="F-5983r355073_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Detect application installations and prompt for elevation" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5983r355073_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2167" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2167" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4765,7 +4739,7 @@ The more secure option for this setting, "Prompt for credentials on the secure d
           <xccdf:fixtext fixref="F-5984r355076_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Only elevate UIAccess applications that are installed in secure locations" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5984r355076_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2168" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2168" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4789,7 +4763,7 @@ The more secure option for this setting, "Prompt for credentials on the secure d
           <xccdf:fixtext fixref="F-5985r355079_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Virtualize file and registry write failures to per-user locations" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5985r355079_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2170" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2170" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4814,7 +4788,7 @@ The more secure option for this setting, "Prompt for credentials on the secure d
           <xccdf:fix id="F-5987r355085_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_drive_redirection_var" export-name="oval:mil.disa.stig.windows:var:111300" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2079" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2079" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4838,7 +4812,7 @@ The more secure option for this setting, "Prompt for credentials on the secure d
           <xccdf:fixtext fixref="F-5989r355091_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Do not allow anonymous enumeration of SAM accounts and shares" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5989r355091_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2147" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2147" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4862,36 +4836,7 @@ The more secure option for this setting, "Prompt for credentials on the secure d
           <xccdf:fixtext fixref="F-5990r355094_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Restrict anonymous access to Named Pipes and Shares" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-5990r355094_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2149" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-205729">
-        <xccdf:title>SRG-OS-000240-GPOS-00090</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205729r569188_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000150</xccdf:version>
-          <xccdf:title>Windows Server 2019 must be configured to audit Logon/Logoff - Account Lockout successes.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
-
-Account Lockout events can be used to identify potentially malicious logon attempts.
-
-Satisfies: SRG-OS-000240-GPOS-00090, SRG-OS-000470-GPOS-00214&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Microsoft Windows Server 2019</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Microsoft Windows Server 2019</dc:subject>
-            <dc:identifier>2907</dc:identifier>
-          </xccdf:reference>
-          <xccdf:ident system="http://cyber.mil/legacy">SV-103075</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">V-92987</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-001404</xccdf:ident>
-          <xccdf:fixtext fixref="F-5994r355106_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Account Lockout" with "Success" selected.</xccdf:fixtext>
-          <xccdf:fix id="F-5994r355106_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2202" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2149" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4920,7 +4865,7 @@ Satisfies: SRG-OS-000240-GPOS-00090, SRG-OS-000470-GPOS-00214&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-5995r355109_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Account Lockout" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-5995r355109_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2203" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2203" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -4954,14 +4899,14 @@ Administrators, SYSTEM, Users, ALL APPLICATION PACKAGES, ALL RESTRICTED APPLICAT
 The default location is the "%SystemRoot%\System32" folder.</xccdf:fixtext>
           <xccdf:fix id="F-5996r355112_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2029" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205731" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205732">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205732r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205732r852430_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000410</xccdf:version>
           <xccdf:title>Windows Server 2019 Deny log on through Remote Desktop Services user right on domain controllers must be configured to prevent unauthenticated access.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -4985,16 +4930,16 @@ The Guests group must be assigned this right to prevent unauthenticated access.&
 - Guests Group</xccdf:fixtext>
           <xccdf:fix id="F-5997r355115_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2113" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2113" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205733">
         <xccdf:title>SRG-OS-000297-GPOS-00115</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205733r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205733r860033_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000120</xccdf:version>
-          <xccdf:title>Windows Server 2019 Deny log on through Remote Desktop Services user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts and all local accounts and from unauthenticated access on all systems.</xccdf:title>
+          <xccdf:title>Windows Server 2019 "Deny log on through Remote Desktop Services" user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts and all local accounts and from unauthenticated access on all systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Deny log on through Remote Desktop Services" user right defines the accounts that are prevented from logging on using Remote Desktop Services.
@@ -5029,14 +4974,14 @@ All Systems:
 Note: "Local account" is referring to the Windows built-in security group.</xccdf:fixtext>
           <xccdf:fix id="F-5998r355118_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2124" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2124" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205739">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205739r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205739r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000070</xccdf:version>
           <xccdf:title>Windows Server 2019 permissions on the Active Directory data files must only allow System and Administrators access.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Improper access permissions for directory data-related files could allow unauthorized users to read, modify, or delete directory data or audit trails.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5047,7 +4992,7 @@ Note: "Local account" is referring to the Windows built-in security group.</xccd
             <dc:subject>Microsoft Windows Server 2019</dc:subject>
             <dc:identifier>2907</dc:identifier>
           </xccdf:reference>
-          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_Server_2019_DC" />
+          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_DomainController" />
           <xccdf:ident system="http://cyber.mil/legacy">SV-103117</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-93029</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002235</xccdf:ident>
@@ -5060,14 +5005,14 @@ BUILTIN\Administrators:(I)(F)
 (F) - full access</xccdf:fixtext>
           <xccdf:fix id="F-6004r355136_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2099" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205739" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205744">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205744r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205744r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000350</xccdf:version>
           <xccdf:title>Windows Server 2019 Add workstations to domain user right must only be assigned to the Administrators group on domain controllers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5089,14 +5034,14 @@ Accounts with the "Add workstations to domain" right may add computers to a doma
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6009r355151_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2107" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2107" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205745">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205745r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205745r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000420</xccdf:version>
           <xccdf:title>Windows Server 2019 Enable computer and user accounts to be trusted for delegation user right must only be assigned to the Administrators group on domain controllers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5118,16 +5063,16 @@ The "Enable computer and user accounts to be trusted for delegation" user right 
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6010r355154_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2114" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2114" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205747">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205747r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205747r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000060</xccdf:version>
-          <xccdf:title>Windows Server 2019 must restrict remote calls to the Security Account Manager (SAM) to Administrators on domain-joined member servers and standalone systems.</xccdf:title>
+          <xccdf:title>Windows Server 2019 must restrict remote calls to the Security Account Manager (SAM) to Administrators on domain-joined member servers and standalone or nondomain-joined systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The Windows SAM stores users' passwords. Restricting Remote Procedure Call (RPC) connections to the SAM to Administrators helps protect those credentials.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2019</dc:title>
@@ -5141,7 +5086,8 @@ The "Enable computer and user accounts to be trusted for delegation" user right 
           <xccdf:ident system="http://cyber.mil/legacy">SV-103133</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/legacy">V-93045</xccdf:ident>
           <xccdf:ident system="http://cyber.mil/cci">CCI-002235</xccdf:ident>
-          <xccdf:fixtext fixref="F-6012r355160_fix">Navigate to the policy Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Restrict clients allowed to make remote calls to SAM". 
+          <xccdf:fixtext fixref="F-6012r857328_fix">Navigate to the policy Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Restrict clients allowed to make remote calls to SAM".
+
 Select "Edit Security" to configure the "Security descriptor:".
 
 Add "Administrators" in "Group or user names:" if it is not already listed (this is the default).
@@ -5153,18 +5099,18 @@ Select "Allow" for "Remote Access" in "Permissions for "Administrators".
 Click "OK".
 
 The "Security descriptor:" must be populated with "O:BAG:BAD:(A;;RC;;;BA) for the policy to be enforced.</xccdf:fixtext>
-          <xccdf:fix id="F-6012r355160_fix" />
+          <xccdf:fix id="F-6012r857328_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2150" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2150" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205748">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205748r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205748r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000130</xccdf:version>
-          <xccdf:title>Windows Server 2019 Enable computer and user accounts to be trusted for delegation user right must not be assigned to any groups or accounts on domain-joined member servers and standalone systems.</xccdf:title>
+          <xccdf:title>Windows Server 2019 "Enable computer and user accounts to be trusted for delegation" user right must not be assigned to any groups or accounts on domain-joined member servers and standalone or nondomain-joined systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
 
 The "Enable computer and user accounts to be trusted for delegation" user right allows the "Trusted for Delegation" setting to be changed. This could allow unauthorized users to impersonate other users.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -5183,14 +5129,14 @@ The "Enable computer and user accounts to be trusted for delegation" user right 
           <xccdf:fixtext fixref="F-6013r355163_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Enable computer and user accounts to be trusted for delegation" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-6013r355163_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2125" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2125" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205749">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205749r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205749r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000010</xccdf:version>
           <xccdf:title>Windows Server 2019 Access Credential Manager as a trusted caller user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5209,14 +5155,14 @@ Accounts with the "Access Credential Manager as a trusted caller" user right may
           <xccdf:fixtext fixref="F-6014r355166_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Access Credential Manager as a trusted caller" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-6014r355166_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2171" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2171" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205750">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205750r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205750r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000020</xccdf:version>
           <xccdf:title>Windows Server 2019 Act as part of the operating system user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5235,14 +5181,14 @@ Accounts with the "Act as part of the operating system" user right can assume th
           <xccdf:fixtext fixref="F-6015r355169_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Act as part of the operating system" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-6015r355169_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2172" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2172" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205751">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205751r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205751r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000040</xccdf:version>
           <xccdf:title>Windows Server 2019 Back up files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5263,14 +5209,14 @@ Accounts with the "Back up files and directories" user right can circumvent file
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6016r355172_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2174" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2174" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205752">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205752r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205752r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000050</xccdf:version>
           <xccdf:title>Windows Server 2019 Create a pagefile user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5291,14 +5237,14 @@ Accounts with the "Create a pagefile" user right can change the size of a pagefi
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6017r355175_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2175" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2175" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205753">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205753r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205753r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000060</xccdf:version>
           <xccdf:title>Windows Server 2019 Create a token object user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5317,14 +5263,14 @@ The "Create a token object" user right allows a process to create an access toke
           <xccdf:fixtext fixref="F-6018r355178_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create a token object" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-6018r355178_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2176" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2176" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205754">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205754r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205754r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000070</xccdf:version>
           <xccdf:title>Windows Server 2019 Create global objects user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5348,14 +5294,14 @@ Accounts with the "Create global objects" user right can create objects that are
 - Network Service</xccdf:fixtext>
           <xccdf:fix id="F-6019r355181_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2177" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2177" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205755">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205755r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205755r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000080</xccdf:version>
           <xccdf:title>Windows Server 2019 Create permanent shared objects user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5374,14 +5320,14 @@ Accounts with the "Create permanent shared objects" user right could expose sens
           <xccdf:fixtext fixref="F-6020r355184_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Create permanent shared objects" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-6020r355184_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2178" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2178" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205756">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205756r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205756r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000090</xccdf:version>
           <xccdf:title>Windows Server 2019 Create symbolic links user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5404,14 +5350,14 @@ Accounts with the "Create symbolic links" user right can create pointers to othe
 Systems that have the Hyper-V role will also have "Virtual Machines" given this user right. If this needs to be added manually, enter it as "NT Virtual Machine\Virtual Machines".</xccdf:fixtext>
           <xccdf:fix id="F-6021r355187_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2179" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2179" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205757">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205757r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205757r877392_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000100</xccdf:version>
           <xccdf:title>Windows Server 2019 Debug programs: user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5432,14 +5378,14 @@ Accounts with the "Debug programs" user right can attach a debugger to any proce
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6022r355190_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2180" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2180" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205758">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205758r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205758r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000110</xccdf:version>
           <xccdf:title>Windows Server 2019 Force shutdown from a remote system user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5460,14 +5406,14 @@ Accounts with the "Force shutdown from a remote system" user right can remotely 
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6023r355193_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2181" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2181" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205759">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205759r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205759r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000120</xccdf:version>
           <xccdf:title>Windows Server 2019 Generate security audits user right must only be assigned to Local Service and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5489,14 +5435,14 @@ The "Generate security audits" user right specifies users and processes that can
 - Network Service</xccdf:fixtext>
           <xccdf:fix id="F-6024r355196_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2182" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2182" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205760">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205760r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205760r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000130</xccdf:version>
           <xccdf:title>Windows Server 2019 Impersonate a client after authentication user right must only be assigned to Administrators, Service, Local Service, and Network Service.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5520,14 +5466,14 @@ The "Impersonate a client after authentication" user right allows a program to i
 - Network Service</xccdf:fixtext>
           <xccdf:fix id="F-6025r355199_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2183" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2183" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205761">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205761r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205761r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000140</xccdf:version>
           <xccdf:title>Windows Server 2019 Increase scheduling priority: user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5548,14 +5494,14 @@ Accounts with the "Increase scheduling priority" user right can change a schedul
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6026r355202_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2184" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2184" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205762">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205762r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205762r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000150</xccdf:version>
           <xccdf:title>Windows Server 2019 Load and unload device drivers user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5576,14 +5522,14 @@ The "Load and unload device drivers" user right allows a user to load device dri
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6027r355205_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2185" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2185" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205763">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205763r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205763r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000160</xccdf:version>
           <xccdf:title>Windows Server 2019 Lock pages in memory user right must not be assigned to any groups or accounts.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5602,14 +5548,14 @@ The "Lock pages in memory" user right allows physical memory to be assigned to p
           <xccdf:fixtext fixref="F-6028r355208_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; User Rights Assignment &gt;&gt; "Lock pages in memory" to be defined but containing no entries (blank).</xccdf:fixtext>
           <xccdf:fix id="F-6028r355208_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2186" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2186" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205764">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205764r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205764r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000180</xccdf:version>
           <xccdf:title>Windows Server 2019 Modify firmware environment values user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5630,14 +5576,14 @@ Accounts with the "Modify firmware environment values" user right can change har
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6029r355211_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2188" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2188" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205765">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205765r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205765r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000190</xccdf:version>
           <xccdf:title>Windows Server 2019 Perform volume maintenance tasks user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5658,14 +5604,14 @@ Accounts with the "Perform volume maintenance tasks" user right can manage volum
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6030r355214_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2189" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205765" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205766">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205766r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205766r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000200</xccdf:version>
           <xccdf:title>Windows Server 2019 Profile single process user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5686,14 +5632,14 @@ Accounts with the "Profile single process" user right can monitor non-system pro
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6031r355217_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2190" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2190" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205767">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205767r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205767r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000210</xccdf:version>
           <xccdf:title>Windows Server 2019 Restore files and directories user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5714,14 +5660,14 @@ Accounts with the "Restore files and directories" user right can circumvent file
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6032r355220_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2191" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2191" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205768">
         <xccdf:title>SRG-OS-000324-GPOS-00125</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205768r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205768r877392_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-UR-000220</xccdf:version>
           <xccdf:title>Windows Server 2019 Take ownership of files or other objects user right must only be assigned to the Administrators group.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
@@ -5742,14 +5688,14 @@ Accounts with the "Take ownership of files or other objects" user right can take
 - Administrators</xccdf:fixtext>
           <xccdf:fix id="F-6033r355223_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2192" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2192" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205769">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205769r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205769r852470_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000090</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Account Management - Other Account Management Events successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5771,14 +5717,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-6034r355226_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Management &gt;&gt; "Audit Other Account Management Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6034r355226_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2032" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2032" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205770">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205770r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205770r852471_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000140</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Detailed Tracking - Process Creation successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5800,14 +5746,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6035r355229_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Detailed Tracking &gt;&gt; "Audit Process Creation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6035r355229_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2036" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2036" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205771">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205771r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205771r852472_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000260</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Policy Change - Audit Policy Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5829,14 +5775,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6036r355232_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Audit Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6036r355232_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2041" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2041" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205772">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205772r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205772r852473_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000270</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Policy Change - Audit Policy Change failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5858,14 +5804,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6037r355235_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Audit Policy Change" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6037r355235_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2042" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2042" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205773">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205773r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205773r852474_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000280</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Policy Change - Authentication Policy Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5887,14 +5833,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-6038r355238_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Authentication Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6038r355238_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2043" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2043" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205774">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205774r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205774r852475_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000290</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Policy Change - Authorization Policy Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5916,14 +5862,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-6039r355241_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Policy Change &gt;&gt; "Audit Authorization Policy Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6039r355241_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2044" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2044" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205775">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205775r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205775r852476_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000300</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Privilege Use - Sensitive Privilege Use successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5945,14 +5891,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-6040r355244_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Privilege Use &gt;&gt; "Audit Sensitive Privilege Use" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6040r355244_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2045" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2045" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205776">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205776r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205776r852477_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000310</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit Privilege Use - Sensitive Privilege Use failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -5974,14 +5920,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPO
           <xccdf:fixtext fixref="F-6041r355247_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Privilege Use &gt;&gt; "Audit Sensitive Privilege Use" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6041r355247_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2046" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2046" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205777">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205777r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205777r852478_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000320</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit System - IPsec Driver successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6003,14 +5949,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6042r355250_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit IPsec Driver" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6042r355250_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2047" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2047" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205778">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205778r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205778r852479_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000330</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit System - IPsec Driver failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6032,14 +5978,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6043r355253_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit IPsec Driver" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6043r355253_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2048" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2048" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205779">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205779r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205779r852480_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000340</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit System - Other System Events successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6061,14 +6007,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6044r355700_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6044r355700_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2198" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2198" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205780">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205780r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205780r852481_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000350</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit System - Other System Events failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6090,14 +6036,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6045r355703_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Other System Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6045r355703_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2204" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2204" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205781">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205781r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205781r852482_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000360</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit System - Security State Change successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6119,14 +6065,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6046r355706_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Security State Change" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6046r355706_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2049" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2049" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205782">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205782r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205782r852483_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000370</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit System - Security System Extension successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6148,14 +6094,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6047r355709_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit Security System Extension" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6047r355709_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2050" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2050" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205783">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205783r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205783r852484_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000380</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit System - System Integrity successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6177,14 +6123,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000471-GPOS-00215, SRG-OS-000471-GPO
           <xccdf:fixtext fixref="F-6048r355712_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit System Integrity" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6048r355712_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2051" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2051" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205784">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205784r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205784r852485_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AU-000390</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit System - System Integrity failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6206,14 +6152,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000471-GPOS-00215, SRG-OS-000471-GPO
           <xccdf:fixtext fixref="F-6049r355715_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; System &gt;&gt; "Audit System Integrity" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6049r355715_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2052" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2052" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205791">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205791r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205791r852492_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000240</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit DS Access - Directory Service Access successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6236,14 +6182,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6056r355736_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; DS Access &gt;&gt; "Directory Service Access" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6056r355736_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2100" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2100" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205792">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205792r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205792r852493_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000250</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit DS Access - Directory Service Access failures.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6266,14 +6212,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6057r355739_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; DS Access &gt;&gt; "Directory Service Access" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6057r355739_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2101" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2101" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205793">
         <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205793r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205793r852494_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000260</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to audit DS Access - Directory Service Changes successes.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
@@ -6296,44 +6242,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
           <xccdf:fixtext fixref="F-6058r355742_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; DS Access &gt;&gt; "Directory Service Changes" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6058r355742_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2102" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
-          </xccdf:check>
-        </xccdf:Rule>
-      </xccdf:Group>
-      <xccdf:Group id="xccdf_mil.disa.stig_group_V-205794">
-        <xccdf:title>SRG-OS-000327-GPOS-00127</xccdf:title>
-        <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205794r569188_rule" weight="10.0" severity="medium">
-          <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000270</xccdf:version>
-          <xccdf:title>Windows Server 2019 must be configured to audit DS Access - Directory Service Changes failures.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. Collecting this data is essential for analyzing the security of information assets and detecting signs of suspicious and unexpected behavior.
-
-Audit Directory Service Changes records events related to changes made to objects in Active Directory Domain Services.
-
-Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPOS-00207, SRG-OS-000468-GPOS-00212&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
-          <xccdf:reference>
-            <dc:title>DPMS Target Microsoft Windows Server 2019</dc:title>
-            <dc:publisher>DISA</dc:publisher>
-            <dc:type>DPMS Target</dc:type>
-            <dc:subject>Microsoft Windows Server 2019</dc:subject>
-            <dc:identifier>2907</dc:identifier>
-          </xccdf:reference>
-          <xccdf:platform idref="#xccdf_mil.disa.stig_platform_Windows_Server_2019_DC" />
-          <xccdf:ident system="http://cyber.mil/legacy">V-93139</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/legacy">SV-103227</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-000172</xccdf:ident>
-          <xccdf:ident system="http://cyber.mil/cci">CCI-002234</xccdf:ident>
-          <xccdf:fixtext fixref="F-6059r355745_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; DS Access &gt;&gt; "Directory Service Changes" with "Failure" selected.</xccdf:fixtext>
-          <xccdf:fix id="F-6059r355745_fix" />
-          <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2103" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2102" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205795">
         <xccdf:title>SRG-OS-000329-GPOS-00128</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205795r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205795r852496_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-AC-000010</xccdf:version>
           <xccdf:title>Windows Server 2019 account lockout duration must be configured to 15 minutes or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The account lockout feature, when enabled, prevents brute-force password attacks on the system. This parameter specifies the period of time that an account will remain locked after the specified number of failed logon attempts.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6352,14 +6268,14 @@ Satisfies: SRG-OS-000327-GPOS-00127, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPO
 A value of "0" is also acceptable, requiring an administrator to unlock the account.</xccdf:fixtext>
           <xccdf:fix id="F-6060r355748_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2013" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2013" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205796">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205796r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205796r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000270</xccdf:version>
           <xccdf:title>Windows Server 2019 Application event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6377,14 +6293,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-6061r355751_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_application_log_size_var" export-name="oval:mil.disa.stig.windows:var:110500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2071" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2071" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205797">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205797r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205797r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000280</xccdf:version>
           <xccdf:title>Windows Server 2019 Security event log size must be configured to 196608 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6402,14 +6318,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-6062r355754_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_security_log_size_var" export-name="oval:mil.disa.stig.windows:var:110600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2072" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2072" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205798">
         <xccdf:title>SRG-OS-000341-GPOS-00132</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205798r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205798r877391_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000290</xccdf:version>
           <xccdf:title>Windows Server 2019 System event log size must be configured to 32768 KB or greater.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Inadequate log size will cause the log to fill up quickly. This may prevent audit events from being recorded properly and require frequent attention by administrative personnel.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6427,14 +6343,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-6063r355757_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_maximum_system_log_size_var" export-name="oval:mil.disa.stig.windows:var:110700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2073" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2073" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205801">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205801r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205801r852502_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000420</xccdf:version>
           <xccdf:title>Windows Server 2019 must prevent users from changing installation options.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Installation options for applications are typically controlled by administrators. This setting prevents users from changing installation options that may bypass security features.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6452,14 +6368,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-6066r355766_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_user_control_over_installs_var" export-name="oval:mil.disa.stig.windows:var:111900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2085" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2085" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205802">
         <xccdf:title>SRG-OS-000362-GPOS-00149</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205802r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205802r852503_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000430</xccdf:version>
           <xccdf:title>Windows Server 2019 must disable the Windows Installer Always install with elevated privileges option.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Standard user accounts must not be granted elevated privileges. Enabling Windows Installer to elevate privileges when installing applications can allow malicious persons and applications to gain full control of a system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6476,14 +6392,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fixtext fixref="F-6067r355769_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Installer &gt;&gt; "Always install with elevated privileges" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-6067r355769_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2086" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2086" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205804">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205804r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205804r852506_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000210</xccdf:version>
           <xccdf:title>Windows Server 2019 Autoplay must be turned off for non-volume devices.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing AutoPlay to execute may introduce malicious code to a system. AutoPlay begins reading from a drive as soon as media is inserted into the drive. As a result, the setup file of programs or music on audio media may start. This setting will disable AutoPlay for non-volume devices, such as Media Transfer Protocol (MTP) devices.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6501,14 +6417,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-6069r355775_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_autoplay_for_non_volume_devices_var" export-name="oval:mil.disa.stig.windows:var:109700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2064" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2064" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205805">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205805r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205805r852507_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000220</xccdf:version>
           <xccdf:title>Windows Server 2019 default AutoRun behavior must be configured to prevent AutoRun commands.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing AutoRun commands to execute may introduce malicious code to a system. Configuring this setting prevents AutoRun commands from executing.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6526,14 +6442,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fix id="F-6070r355778_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_default_behavior_for_autorun_var" export-name="oval:mil.disa.stig.windows:var:109800" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2065" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2065" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205806">
         <xccdf:title>SRG-OS-000368-GPOS-00154</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205806r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205806r852508_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000230</xccdf:version>
           <xccdf:title>Windows Server 2019 AutoPlay must be disabled for all drives.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Allowing AutoPlay to execute may introduce malicious code to a system. AutoPlay begins reading from a drive as soon media is inserted into the drive. As a result, the setup file of programs or music on audio media may start. By default, AutoPlay is disabled on removable drives, such as the floppy disk drive (but not the CD-ROM drive) and on network drives. Enabling this policy disables AutoPlay on all drives.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6550,14 +6466,14 @@ A value of "0" is also acceptable, requiring an administrator to unlock the acco
           <xccdf:fixtext fixref="F-6071r355781_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; AutoPlay Policies &gt;&gt; "Turn off AutoPlay" to "Enabled" with "All Drives" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6071r355781_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2066" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2066" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205808">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205808r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205808r852510_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000340</xccdf:version>
           <xccdf:title>Windows Server 2019 must not save passwords in the Remote Desktop Client.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Saving passwords in the Remote Desktop Client could allow an unauthorized user to establish a remote desktop session to another system. The system must be configured to prevent users from saving passwords in the Remote Desktop Client.
@@ -6577,14 +6493,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fix id="F-6073r355787_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_do_not_allow_passwords_to_be_saved_var" export-name="oval:mil.disa.stig.windows:var:111200" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2078" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2078" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205809">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205809r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205809r852511_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000360</xccdf:version>
           <xccdf:title>Windows Server 2019 Remote Desktop Services must always prompt a client for passwords upon connection.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting controls the ability of users to supply passwords automatically as part of their remote desktop connection. Disabling this setting would allow anyone to use the stored credentials in a connection item to connect to the terminal server.
@@ -6604,14 +6520,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fix id="F-6074r355790_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_always_prompt_for_password_upon_connection_var" export-name="oval:mil.disa.stig.windows:var:111400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2080" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2080" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205810">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205810r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205810r852512_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000520</xccdf:version>
           <xccdf:title>Windows Server 2019 Windows Remote Management (WinRM) service must not store RunAs credentials.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Storage of administrative credentials could allow unauthorized access. Disallowing the storage of RunAs credentials for Windows Remote Management will prevent them from being used with plug-ins.
@@ -6630,14 +6546,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6075r355793_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Service &gt;&gt; "Disallow WinRM from storing RunAs credentials" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6075r355793_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2093" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2093" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205811">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205811r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205811r852513_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000380</xccdf:version>
           <xccdf:title>Windows Server 2019 User Account Control approval mode for the built-in Administrator must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized. This setting configures the built-in Administrator account so that it runs in Admin Approval Mode.
@@ -6656,14 +6572,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6076r355796_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Admin Approval Mode for the Built-in Administrator account" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6076r355796_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2163" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2163" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205812">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205812r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205812r852514_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000410</xccdf:version>
           <xccdf:title>Windows Server 2019 User Account Control must automatically deny standard user requests for elevation.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized. This setting controls the behavior of elevation when requested by a standard user account.
@@ -6682,14 +6598,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6077r355799_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Behavior of the elevation prompt for standard users" to "Automatically deny elevation requests".</xccdf:fixtext>
           <xccdf:fix id="F-6077r355799_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2166" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2166" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205813">
         <xccdf:title>SRG-OS-000373-GPOS-00157</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205813r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205813r852515_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000440</xccdf:version>
           <xccdf:title>Windows Server 2019 User Account Control must run all administrators in Admin Approval Mode, enabling UAC.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;User Account Control (UAC) is a security mechanism for limiting the elevation of privileges, including administrative accounts, unless authorized. This setting enables UAC.
@@ -6708,16 +6624,16 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6078r355802_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "User Account Control: Run all administrators in Admin Approval Mode" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6078r355802_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2169" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2169" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205814">
         <xccdf:title>SRG-OS-000379-GPOS-00164</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205814r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205814r877039_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000040</xccdf:version>
-          <xccdf:title>Windows Server 2019 must restrict unauthenticated Remote Procedure Call (RPC) clients from connecting to the RPC server on domain-joined member servers and standalone systems.</xccdf:title>
+          <xccdf:title>Windows Server 2019 must restrict unauthenticated Remote Procedure Call (RPC) clients from connecting to the RPC server on domain-joined member servers and standalone or nondomain-joined systems.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unauthenticated RPC clients may allow anonymous access to sensitive information. Configuring RPC to restrict unauthenticated RPC clients from connecting to the RPC server will prevent anonymous connections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2019</dc:title>
@@ -6734,14 +6650,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6079r355805_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Remote Procedure Call &gt;&gt; "Restrict Unauthenticated RPC clients" to "Enabled" with "Authenticated" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6079r355805_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2117" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2117" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205815">
         <xccdf:title>SRG-OS-000379-GPOS-00164</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205815r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205815r877039_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000090</xccdf:version>
           <xccdf:title>Windows Server 2019 computer account password must not be prevented from being reset.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Computer account passwords are changed automatically on a regular basis. Disabling automatic password changes can make the system more vulnerable to malicious access. Frequent password changes can be a significant safeguard for the system. A new password for the computer account will be generated every 30 days.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6758,14 +6674,14 @@ Satisfies: SRG-OS-000373-GPOS-00157, SRG-OS-000373-GPOS-00156&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6080r355808_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Disable machine account password changes" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-6080r355808_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2134" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2134" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205816">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205816r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205816r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000480</xccdf:version>
           <xccdf:title>Windows Server 2019 Windows Remote Management (WinRM) client must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised. Windows remote management connections must be encrypted to prevent this.
@@ -6786,14 +6702,14 @@ Satisfies: SRG-OS-000393-GPOS-00173, SRG-OS-000394-GPOS-00174&lt;/VulnDiscussion
           <xccdf:fix id="F-6081r355811_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_winrm_client_allow_unencrypted_traffic_var" export-name="oval:mil.disa.stig.windows:var:112400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2089" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2089" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205817">
         <xccdf:title>SRG-OS-000393-GPOS-00173</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205817r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205817r877382_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000510</xccdf:version>
           <xccdf:title>Windows Server 2019 Windows Remote Management (WinRM) service must not allow unencrypted traffic.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unencrypted remote access to a system can allow sensitive information to be compromised. Windows remote management connections must be encrypted to prevent this.
@@ -6813,14 +6729,14 @@ Satisfies: SRG-OS-000393-GPOS-00173, SRG-OS-000394-GPOS-00174&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6082r355814_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Remote Management (WinRM) &gt;&gt; WinRM Service &gt;&gt; "Allow unencrypted traffic" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-6082r355814_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2092" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2092" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205819">
         <xccdf:title>SRG-OS-000420-GPOS-00186</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205819r569188_rule" weight="10.0" severity="low">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205819r852521_rule" weight="10.0" severity="low">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000060</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to ignore NetBIOS name release requests except from WINS servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Configuring the system to ignore name release requests, except from WINS servers, prevents a denial of service (DoS) attack. The DoS consists of sending a NetBIOS name release request to the server for each entry in the server's cache, causing a response delay in the normal operation of the server's WINS resolution capability.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -6840,14 +6756,14 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-6084r355820_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_no_name_release_on_demand_var" export-name="oval:mil.disa.stig.windows:var:108700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2056" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2056" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205820">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205820r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205820r852522_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-DC-000320</xccdf:version>
           <xccdf:title>Windows Server 2019 domain controllers must require LDAP access signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Unsigned network traffic is susceptible to man-in-the-middle attacks, where an intruder captures packets between the server and the client and modifies them before forwarding them to the client. In the case of an LDAP server, this means that an attacker could cause a client to make decisions based on false records from the LDAP directory. The risk of an attacker pulling this off can be decreased by implementing strong physical security measures to protect the network infrastructure. Furthermore, implementing Internet Protocol security (IPsec) authentication header mode (AH), which performs mutual authentication and packet integrity for Internet Protocol (IP) traffic, can make all types of man-in-the-middle attacks extremely difficult.
@@ -6868,14 +6784,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6085r355823_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain controller: LDAP server signing requirements" to "Require signing".</xccdf:fixtext>
           <xccdf:fix id="F-6085r355823_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2104" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2104" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205821">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205821r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205821r852523_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000060</xccdf:version>
           <xccdf:title>Windows Server 2019 setting Domain member: Digitally encrypt or sign secure channel data (always) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted. If this policy is enabled, outgoing secure channel traffic will be encrypted and signed.
@@ -6895,14 +6811,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6086r355826_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Digitally encrypt or sign secure channel data (always)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6086r355826_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2131" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2131" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205822">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205822r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205822r852524_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000070</xccdf:version>
           <xccdf:title>Windows Server 2019 setting Domain member: Digitally encrypt secure channel data (when possible) must be configured to enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but not all information is encrypted. If this policy is enabled, outgoing secure channel traffic will be encrypted.
@@ -6922,14 +6838,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6087r355829_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Digitally encrypt secure channel data (when possible)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6087r355829_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2132" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2132" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205823">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205823r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205823r852525_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000080</xccdf:version>
           <xccdf:title>Windows Server 2019 setting Domain member: Digitally sign secure channel data (when possible) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Requests sent on the secure channel are authenticated, and sensitive information (such as passwords) is encrypted, but the channel is not integrity checked. If this policy is enabled, outgoing secure channel traffic will be signed.
@@ -6949,14 +6865,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6088r355832_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Digitally sign secure channel data (when possible)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6088r355832_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2133" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2133" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205824">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205824r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205824r852526_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000110</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to require a strong session key.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;A computer connecting to a domain controller will establish a secure channel. The secure channel connection may be subject to compromise, such as hijacking or eavesdropping, if strong session keys are not used to establish the connection. Requiring strong session keys enforces 128-bit encryption between systems.
@@ -6976,14 +6892,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6089r355835_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Require strong (Windows 2000 or Later) session key" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6089r355835_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2136" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2136" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205825">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205825r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205825r852527_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000160</xccdf:version>
           <xccdf:title>Windows Server 2019 setting Microsoft network client: Digitally sign communications (always) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations. Digitally signed SMB packets aid in preventing man-in-the-middle attacks. If this policy is enabled, the SMB client will only communicate with an SMB server that performs SMB packet signing.
@@ -7003,14 +6919,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6090r355838_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft network client: Digitally sign communications (always)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6090r355838_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2141" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2141" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205826">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205826r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205826r852528_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000170</xccdf:version>
           <xccdf:title>Windows Server 2019 setting Microsoft network client: Digitally sign communications (if server agrees) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations. If this policy is enabled, the SMB client will request packet signing when communicating with an SMB server that is enabled or required to perform SMB packet signing.
@@ -7030,14 +6946,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6091r355841_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft network client: Digitally sign communications (if server agrees)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6091r355841_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2142" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2142" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205827">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205827r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205827r852529_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000190</xccdf:version>
           <xccdf:title>Windows Server 2019 setting Microsoft network server: Digitally sign communications (always) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations. Digitally signed SMB packets aid in preventing man-in-the-middle attacks. If this policy is enabled, the SMB server will only communicate with an SMB client that performs SMB packet signing.
@@ -7057,14 +6973,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6092r355844_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft network server: Digitally sign communications (always)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6092r355844_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2144" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2144" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205828">
         <xccdf:title>SRG-OS-000423-GPOS-00187</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205828r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205828r852530_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000200</xccdf:version>
           <xccdf:title>Windows Server 2019 setting Microsoft network server: Digitally sign communications (if client agrees) must be configured to Enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The server message block (SMB) protocol provides the basis for many network operations. Digitally signed SMB packets aid in preventing man-in-the-middle attacks. If this policy is enabled, the SMB server will negotiate SMB packet signing as requested by the client.
@@ -7084,14 +7000,14 @@ Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6093r355847_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Microsoft network server: Digitally sign communications (if client agrees)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6093r355847_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2145" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2145" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205830">
         <xccdf:title>SRG-OS-000433-GPOS-00192</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205830r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205830r852532_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000310</xccdf:version>
           <xccdf:title>Windows Server 2019 Explorer Data Execution Prevention must be enabled.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Data Execution Prevention provides additional protection by performing checks on memory to help prevent malicious code from running. This setting will prevent Data Execution Prevention from being turned off for File Explorer.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7111,7 +7027,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-6095r355853_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_data_execution_prevention_for_explorer_var" export-name="oval:mil.disa.stig.windows:var:110900" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2075" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2075" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7137,7 +7053,7 @@ Credential Validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-6097r355859_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Logon &gt;&gt; "Audit Credential Validation" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6097r355859_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2030" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2030" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7163,7 +7079,7 @@ Credential Validation records events related to validation tests on credentials 
           <xccdf:fixtext fixref="F-6098r355862_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Account Logon &gt;&gt; "Audit Credential Validation" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6098r355862_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2031" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2031" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7191,7 +7107,7 @@ Satisfies: SRG-OS-000470-GPOS-00214, SRG-OS-000472-GPOS-00217, SRG-OS-000473-GPO
           <xccdf:fixtext fixref="F-6100r355868_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Special Logon" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6100r355868_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2040" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2040" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7217,7 +7133,7 @@ Auditing for other object access records events related to the management of tas
           <xccdf:fixtext fixref="F-6101r355871_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Object Access &gt;&gt; "Audit Other Object Access Events" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6101r355871_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2207" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2207" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7243,7 +7159,7 @@ Auditing for other object access records events related to the management of tas
           <xccdf:fixtext fixref="F-6102r355874_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Object Access &gt;&gt; "Audit Other Object Access Events" with "Failure" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6102r355874_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2208" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2208" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7272,14 +7188,14 @@ Satisfies: SRG-OS-000472-GPOS-00217, SRG-OS-000480-GPOS-00227&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6103r355877_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Advanced Audit Policy Configuration &gt;&gt; System Audit Policies &gt;&gt; Logon/Logoff &gt;&gt; "Audit Logoff" with "Success" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6103r355877_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2037" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2037" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205842">
         <xccdf:title>SRG-OS-000478-GPOS-00223</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205842r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205842r877466_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000360</xccdf:version>
           <xccdf:title>Windows Server 2019 must be configured to use FIPS-compliant algorithms for encryption, hashing, and signing.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;This setting ensures the system uses algorithms that are FIPS-compliant for encryption, hashing, and signing. FIPS-compliant algorithms meet specific standards established by the U.S. Government and must be the algorithms used for all OS encryption functions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7296,7 +7212,7 @@ Satisfies: SRG-OS-000472-GPOS-00217, SRG-OS-000480-GPOS-00227&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6107r355889_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "System cryptography: Use FIPS compliant algorithms for encryption, hashing, and signing" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6107r355889_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2161" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2161" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7320,7 +7236,7 @@ Satisfies: SRG-OS-000472-GPOS-00217, SRG-OS-000480-GPOS-00227&lt;/VulnDiscussion
           <xccdf:fixtext fixref="F-6114r355910_fix">Update the system to a Version 1809 (Build 17763.xxx) or greater.</xccdf:fixtext>
           <xccdf:fix id="F-6114r355910_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2011" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2011" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7347,7 +7263,7 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-6123r355937_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_MSS_IPv6_source_routing_protection_level_var" export-name="oval:mil.disa.stig.windows:var:108400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2053" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2053" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7374,7 +7290,7 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-6124r355940_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_ip_source_routing_protection_level_var" export-name="oval:mil.disa.stig.windows:var:108500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2054" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2054" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7401,7 +7317,7 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fix id="F-6125r355943_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_allow_icmp_redirects_var" export-name="oval:mil.disa.stig.windows:var:108600" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2055" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2055" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7425,14 +7341,14 @@ This policy setting requires the installation of the MSS-Legacy custom templates
           <xccdf:fixtext fixref="F-6126r355946_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Network &gt;&gt; Lanman Workstation &gt;&gt; "Enable insecure guest logons" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-6126r355946_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2217" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2217" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205862">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205862r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205862r857311_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000080</xccdf:version>
           <xccdf:title>Windows Server 2019 hardened Universal Naming Convention (UNC) paths must be defined to require mutual authentication and integrity for at least the \\*\SYSVOL and \\*\NETLOGON shares.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Additional security requirements are applied to UNC paths specified in hardened UNC paths before allowing access to them. This aids in preventing tampering with or spoofing of connections to these paths.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7457,7 +7373,7 @@ Value Name: \\*\NETLOGON
 Value: RequireMutualAuthentication=1, RequireIntegrity=1</xccdf:fixtext>
           <xccdf:fix id="F-6127r355949_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2212" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2212" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7481,7 +7397,7 @@ Value: RequireMutualAuthentication=1, RequireIntegrity=1</xccdf:fixtext>
           <xccdf:fixtext fixref="F-6128r355952_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Credentials Delegation &gt;&gt; "Remote host allows delegation of non-exportable credentials" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6128r355952_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2211" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2211" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7507,7 +7423,7 @@ Value: RequireMutualAuthentication=1, RequireIntegrity=1</xccdf:fixtext>
 If this needs to be corrected or a more secure setting is desired, configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Early Launch Antimalware &gt;&gt; "Boot-Start Driver Initialization Policy" to "Not Configured" or "Enabled" with any option other than "All" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6130r355958_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2057" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2057" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7531,7 +7447,7 @@ If this needs to be corrected or a more secure setting is desired, configure the
           <xccdf:fixtext fixref="F-6131r355961_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; System &gt;&gt; Group Policy &gt;&gt; "Configure registry policy processing" to "Enabled" with the option "Process even if the Group Policy objects have not changed" selected.</xccdf:fixtext>
           <xccdf:fix id="F-6131r355961_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2058" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2058" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7556,7 +7472,7 @@ If this needs to be corrected or a more secure setting is desired, configure the
           <xccdf:fix id="F-6132r355964_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_on_battery_var" export-name="oval:mil.disa.stig.windows:var:109400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2061" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2061" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7581,7 +7497,7 @@ If this needs to be corrected or a more secure setting is desired, configure the
           <xccdf:fix id="F-6133r355967_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_require_a_password_when_a_computer_wakes_plugged_var" export-name="oval:mil.disa.stig.windows:var:109500" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2062" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2062" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7605,7 +7521,7 @@ If this needs to be corrected or a more secure setting is desired, configure the
           <xccdf:fixtext fixref="F-6134r355970_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Data Collection and Preview Builds&gt;&gt; "Allow Telemetry" to "Enabled" with "0 - Security [Enterprise Only]" or "1 - Basic" selected in "Options".</xccdf:fixtext>
           <xccdf:fix id="F-6134r355970_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2213" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows2019:def:205869" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7637,7 +7553,7 @@ LAN (1)
 Simple (99)</xccdf:fixtext>
           <xccdf:fix id="F-6135r355973_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2012" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2012" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7664,7 +7580,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-6136r355976_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_heap_termination_corruption_var" export-name="oval:mil.disa.stig.windows:var:111000" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2076" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2076" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7691,7 +7607,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-6137r355979_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_turn_off_shell_protocol_protected_mode_var" export-name="oval:mil.disa.stig.windows:var:111100" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2077" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2077" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7716,7 +7632,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-6138r355982_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prevent_downloading_of_enclosures_var" export-name="oval:mil.disa.stig.windows:var:111700" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2083" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2083" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7743,7 +7659,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-6139r355985_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_prevent_internet_explorer_security_prompt_for_windows_installer_scripts_var" export-name="oval:mil.disa.stig.windows:var:112100" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2087" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2087" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7768,14 +7684,14 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-6141r355991_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain controller: Refuse machine account password changes" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-6141r355991_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2105" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2105" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205906">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205906r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205906r857326_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-MS-000050</xccdf:version>
           <xccdf:title>Windows Server 2019 must limit the caching of logon credentials to four or less on domain-joined member servers.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;The default Windows configuration caches the last logon credentials for users who log on interactively to a system. This feature is provided for system availability reasons, such as the user's machine being disconnected from the network or domain controllers being unavailable. Even though the credential cache is well protected, if a system is attacked, an unauthorized individual may isolate the password to a domain user account using a password-cracking program and gain access to the domain.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -7793,7 +7709,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-6171r356081_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive Logon: Number of previous logons to cache (in case Domain Controller is not available)" to "4" logons or less.</xccdf:fixtext>
           <xccdf:fix id="F-6171r356081_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2118" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2118" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7818,7 +7734,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fix id="F-6173r356087_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
             <xccdf:check-export value-id="xccdf_mil.disa.stig_value_limit_blank_password_use_var" export-name="oval:mil.disa.stig.windows:var:118400" />
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2127" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2127" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7842,7 +7758,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-6174r356090_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Accounts: Rename administrator account" to a name other than "Administrator".</xccdf:fixtext>
           <xccdf:fix id="F-6174r356090_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2128" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2128" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7866,7 +7782,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
           <xccdf:fixtext fixref="F-6175r356093_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Accounts: Rename guest account" to a name other than "Guest".</xccdf:fixtext>
           <xccdf:fix id="F-6175r356093_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2129" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2129" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7892,7 +7808,7 @@ If this needs to be corrected, configure the policy value for Computer Configura
 Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Domain member: Maximum machine account password age" to "30" or less (excluding "0", which is unacceptable).</xccdf:fixtext>
           <xccdf:fix id="F-6176r356096_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2135" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2135" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7916,7 +7832,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6177r356099_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Interactive logon: Smart card removal behavior" to "Lock Workstation" or "Force Logoff".</xccdf:fixtext>
           <xccdf:fix id="F-6177r356099_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2140" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2140" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7940,7 +7856,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6179r356105_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Do not allow anonymous enumeration of SAM accounts" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6179r356105_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2146" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2146" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7964,7 +7880,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6180r356108_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network access: Let Everyone permissions apply to anonymous users" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-6180r356108_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2148" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2148" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -7988,7 +7904,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6181r356111_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Allow Local System to use computer identity for NTLM" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6181r356111_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2151" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2151" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8012,7 +7928,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6182r356114_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Allow LocalSystem NULL session fallback" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-6182r356114_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2152" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2152" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8036,17 +7952,17 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6183r356117_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Allow PKU2U authentication requests to this computer to use online identities" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-6183r356117_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2153" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2153" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205919">
         <xccdf:title>SRG-OS-000480-GPOS-00227</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205919r569188_rule" weight="10.0" severity="high">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205919r857347_rule" weight="10.0" severity="high">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-SO-000310</xccdf:version>
           <xccdf:title>Windows Server 2019 LAN Manager authentication level must be configured to send NTLMv2 response only and to refuse LM and NTLM.</xccdf:title>
-          <xccdf:description>&lt;VulnDiscussion&gt;The Kerberos v5 authentication protocol is the default for authentication of users who are logging on to domain accounts. NTLM, which is less secure, is retained in later Windows versions for compatibility with clients and servers that are running earlier versions of Windows or applications that still use it. It is also used to authenticate logons to standalone computers that are running later versions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
+          <xccdf:description>&lt;VulnDiscussion&gt;The Kerberos v5 authentication protocol is the default for authentication of users who are logging on to domain accounts. NTLM, which is less secure, is retained in later Windows versions for compatibility with clients and servers that are running earlier versions of Windows or applications that still use it. It is also used to authenticate logons to standalone or nondomain-joined computers that are running later versions.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
           <xccdf:reference>
             <dc:title>DPMS Target Microsoft Windows Server 2019</dc:title>
             <dc:publisher>DISA</dc:publisher>
@@ -8060,7 +7976,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6184r356120_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: LAN Manager authentication level" to "Send NTLMv2 response only. Refuse LM &amp; NTLM".</xccdf:fixtext>
           <xccdf:fix id="F-6184r356120_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2156" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2156" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8084,7 +8000,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6185r356123_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: LDAP client signing requirements" to "Negotiate signing" at a minimum.</xccdf:fixtext>
           <xccdf:fix id="F-6185r356123_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2157" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2157" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8108,7 +8024,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6186r356126_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) clients" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-6186r356126_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2158" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2158" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8132,7 +8048,7 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6187r356129_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "Network security: Minimum session security for NTLM SSP based (including secure RPC) servers" to "Require NTLMv2 session security" and "Require 128-bit encryption" (all options selected).</xccdf:fixtext>
           <xccdf:fix id="F-6187r356129_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2159" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2159" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
@@ -8156,14 +8072,14 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6188r356132_fix">Configure the policy value for Computer Configuration &gt;&gt; Windows Settings &gt;&gt; Security Settings &gt;&gt; Local Policies &gt;&gt; Security Options &gt;&gt; "System objects: Strengthen default permissions of internal system objects (e.g., Symbolic Links)" to "Enabled".</xccdf:fixtext>
           <xccdf:fix id="F-6188r356132_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2162" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2162" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
       <xccdf:Group id="xccdf_mil.disa.stig_group_V-205925">
         <xccdf:title>SRG-OS-000480-GPOS-00229</xccdf:title>
         <xccdf:description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</xccdf:description>
-        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205925r569188_rule" weight="10.0" severity="medium">
+        <xccdf:Rule id="xccdf_mil.disa.stig_rule_SV-205925r877377_rule" weight="10.0" severity="medium">
           <xccdf:version update="http://iase.disa.mil/stigs">WN19-CC-000450</xccdf:version>
           <xccdf:title>Windows Server 2019 must disable automatically signing in the last interactive user after a system-initiated restart.</xccdf:title>
           <xccdf:description>&lt;VulnDiscussion&gt;Windows can be configured to automatically sign the user back in after a Windows Update restart. Some protections are in place to help ensure this is done in a secure fashion; however, disabling this will prevent the caching of credentials for this purpose and also ensure the user is aware of the restart.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</xccdf:description>
@@ -8180,18 +8096,18 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <xccdf:fixtext fixref="F-6190r356138_fix">Configure the policy value for Computer Configuration &gt;&gt; Administrative Templates &gt;&gt; Windows Components &gt;&gt; Windows Logon Options &gt;&gt; "Sign-in last interactive user automatically after a system-initiated restart" to "Disabled".</xccdf:fixtext>
           <xccdf:fix id="F-6190r356138_fix" />
           <xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2214" href="U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" />
+            <xccdf:check-content-ref name="oval:mil.disa.stig.windows:def:2214" href="U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" />
           </xccdf:check>
         </xccdf:Rule>
       </xccdf:Group>
     </xccdf:Benchmark>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2022-05-01T21:49:43">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-oval.xml" timestamp="2023-03-28T17:41:29">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-05-01T21:49:43</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:29</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.fso.windows:def:4595" version="1" class="compliance">
@@ -8578,16 +8494,177 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
             <criterion test_ref="oval:mil.disa.fso.windows:tst:497501" comment="Audit - Audit Policy Change - Success and Failure" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.fso.windows:def:4984" version="2" class="compliance">
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253303" version="2">
           <metadata>
-            <title>Event Viewer must be protected from unauthorized modification and deletion</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-            </affected>
-            <description>Verify the permissions on Event Viewer only allow TrustedInstaller permissions to change or modify.</description>
+            <title>Passwords must, at a minimum, be 14 characters.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25330300" comment="Verifies 'Minimum password length' is set to at least '14' characters" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253393" version="2">
+          <metadata>
+            <title>Windows Telemetry must not be configured to Full.</title>
+            <description />
           </metadata>
           <criteria>
-            <criterion test_ref="oval:mil.disa.fso.windows:tst:498400" comment="Eventvwr.exe: Read and Execute rights for Administrators, System, Users, All Application Packages" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25339300" comment="Verifies 'Allow Diagnostic Data' is set to 'Diagnostic Data Off (Not recommended)' or 'Send Required Diagnostic Data' selected in 'Options:'" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253427" version="1">
+          <metadata>
+            <title>The DoD Root CA certificates must be installed in the Trusted Root Store.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342700" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342701" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342702" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253429" version="3">
+          <metadata>
+            <title>The DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25342900" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253430" version="2">
+          <metadata>
+            <title>The US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25343000" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253444" version="1">
+          <metadata>
+            <title>The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.windows:tst:25344400" comment="The machine inactivity limit is set to 15 minutes or less" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253493" version="2">
+          <metadata>
+            <title>The "Deny log on as a service" user right on Windows domain-joined workstations must be configured to prevent access from highly privileged domain accounts.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25349300" comment="Deny log on as a service - Domain Admins" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25349301" comment="Deny log on as a service - Enterprise Admins" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:253503" version="1">
+          <metadata>
+            <title>The "Perform volume maintenance tasks" user right must only be assigned to the Administrators group.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25350300" comment="Perform volume maintenance tasks - Administrators" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254296" version="1">
+          <metadata>
+            <title>Windows permissions for the Application event log must prevent access by non-privileged accounts.</title>
+            <description />
+          </metadata>
+          <criteria operator="OR">
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429601" comment="The Application event log must have at least default permissions. Strict Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334002" negate="true" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429600" comment="The Application event log must have at least default permissions. Built Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334002" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254297" version="1">
+          <metadata>
+            <title>Windows permissions for the Security event log must prevent access by non-privileged accounts.</title>
+            <description />
+          </metadata>
+          <criteria operator="OR">
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429701" comment="The Security event log must have at least default permissions. Strict Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334102" negate="true" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429700" comment="The Security event log must have at least default permissions. Built Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334102" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254298" version="1">
+          <metadata>
+            <title>Windows permissions for the System event log must prevent access by non-privileged accounts.</title>
+            <description />
+          </metadata>
+          <criteria operator="OR">
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429801" comment="The System event log must have at least default permissions. Strict Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334202" negate="true" comment="The System event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+            <criteria operator="AND">
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25429800" comment="The System event log must have at least default permissions. Built Path" />
+              <criterion test_ref="oval:mil.disa.stig.win:tst:25334202" comment="The System event log registry specified location must have the %SystemRoot% environment variable." />
+            </criteria>
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254299" version="1">
+          <metadata>
+            <title>Windows Event Viewer must be protected from unauthorized modification and deletion.</title>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25429900" comment="Eventvwr.exe: Read and Execute rights for Administrators, System, Users, All Application Packages" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.defs:def:254391" version="1">
+          <metadata>
+            <title>Windows permissions on the Active Directory data files must only allow System and Administrators access.</title>
+            <description />
+          </metadata>
+          <criteria operator="AND">
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439100" comment="Database log files: NT Authority\SYSTEM has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439101" comment="Database log files: BUILTIN\Administrators has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439102" comment="Database log files: No other permissions" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439103" comment="DSA Database file: NT Authority\SYSTEM has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439104" comment="DSA Database file: BUILTIN\Administrators has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439105" comment="DSA Database file: No other permissions" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439106" comment="DSA Working Directory: NT Authority\SYSTEM has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439107" comment="DSA Working Directory: BUILTIN\Administrators has full control" />
+            <criterion test_ref="oval:mil.disa.stig.win:tst:25439108" comment="DSA Working Directory: No other permissions" />
+          </criteria>
+        </definition>
+        <definition class="inventory" id="oval:mil.disa.stig.win:def:100004" version="2">
+          <metadata>
+            <title>The system is a Windows Domain Member Server</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server</platform>
+            </affected>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:10000400" />
+          </criteria>
+        </definition>
+        <definition class="inventory" id="oval:mil.disa.stig.win:def:100005" version="2">
+          <metadata>
+            <title>The system is a Windows Domain Controller</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server</platform>
+            </affected>
+            <description />
+          </metadata>
+          <criteria>
+            <criterion test_ref="oval:mil.disa.stig.win:tst:10000500" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:19" version="3" class="compliance">
@@ -8606,20 +8683,6 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
               <criterion test_ref="oval:mil.disa.stig.windows:tst:1900" comment="Mutual Authentication and Integrity for \\*\SYSVOL" />
               <criterion test_ref="oval:mil.disa.stig.windows:tst:1901" comment="Mutual Authentication and Integrity for \\*\NETLOGON" />
             </criteria>
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:24" version="4" class="compliance">
-          <metadata>
-            <title>Windows Telemetry must be configured to the lowest level of data sent to Microsoft.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Windows Telemetry must be configured to the lowest level of data sent to Microsoft.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:2400" comment="AllowTelemetry = 0 or 1" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:65" version="2" class="compliance">
@@ -8703,20 +8766,6 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <criteria operator="OR" comment="Audit - Other System Events - Success">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:11800" comment="Audit - Other System Events - Success only" />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:11801" comment="Audit - Other System Events - Success and Failure" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:119" version="1" class="compliance">
-          <metadata>
-            <title>WN10-AU-000055</title>
-            <affected family="windows">
-              <platform>Microsoft Windows 8</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The system must be configured to audit Logon/Logoff - Account Lockout successes.</description>
-          </metadata>
-          <criteria operator="OR" comment="Audit - Special Logon - Success">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:11900" comment="Audit - Account Lockout - Success only" />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:11901" comment="Audit - Account Lockout - Success and Failure" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:147" version="1" class="compliance">
@@ -8898,20 +8947,6 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           </metadata>
           <criteria operator="AND">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:101600" comment="Verifies 'Minimum Password Age' is set to at least '1' day" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1017" version="1" class="compliance">
-          <metadata>
-            <title>Minimum Password Length</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference source="DISA" ref_id="73321" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-46914-8" />
-            <description>Passwords must, at a minimum, be 14 characters.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:101700" comment="Verifies 'Minimum password length' is set to at least '14' characters" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:1018" version="1" class="compliance">
@@ -9669,56 +9704,6 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
             <criterion test_ref="oval:mil.disa.stig.windows:tst:112800" comment="Verifies 'Disallow WinRM from storing RunAs credentials' is set to 'Enabled'" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1135" version="2" class="compliance">
-          <metadata>
-            <title>Active Directory data files must have proper access control permissions.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Active Directory data files must have proper access control permissions.</description>
-          </metadata>
-          <criteria operator="OR" comment="IF system is a DC, THEN do the permission checks.">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1010" negate="true" comment="System is a DC." />
-            <criteria operator="AND">
-              <criteria comment="Database log files path permissions OK" operator="OR">
-                <criteria comment="Database log files path permissions OK using SCC" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113500" comment="Database log files: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113501" comment="Database log files: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113502" comment="Database log files: No other permissions" />
-                </criteria>
-                <criteria comment="Database log files path permissions OK using McAfee products" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113506" comment="Database log files: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113507" comment="Database log files: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113508" comment="Database log files: No other permissions" />
-                </criteria>
-              </criteria>
-              <criteria comment="DSA Database file and files in the same folder permissions OK" operator="OR">
-                <criteria comment="DSA Database file and path permissions OK using SCC" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113503" comment="DSA Database file: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113504" comment="DSA Database file: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113505" comment="DSA Database file: No other permissions" />
-                </criteria>
-                <criteria comment="DSA Database file and path permissions OK using McAfee products" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113509" comment="DSA Database file: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113510" comment="DSA Database file: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113511" comment="DSA Database file: No other permissions" />
-                </criteria>
-              </criteria>
-              <criteria comment="DSA Working Directory permissions OK" operator="OR">
-                <criteria comment="DSA Working Directory permissions OK using SCC" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113512" comment="DSA Working Directory: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113513" comment="DSA Working Directory: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113514" comment="DSA Working Directory: No other permissions" />
-                </criteria>
-                <criteria comment="DSA Working Directory permissions OK using McAfee products" operator="AND">
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113515" comment="DSA Working Directory: NT Authority\SYSTEM has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113516" comment="DSA Working Directory: BUILTIN\Administrators has full control" />
-                  <criterion test_ref="oval:mil.disa.stig.windows:tst:113517" comment="DSA Working Directory: No other permissions" />
-                </criteria>
-              </criteria>
-            </criteria>
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:1152" version="3" class="compliance">
           <metadata>
             <title>Audit - Directory Service Access - Success</title>
@@ -9764,22 +9749,6 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
           <criteria operator="OR" comment="IF system is a DC, THEN check Audit - Directory Service Changes - Success">
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1010" negate="true" comment="System is a DC." />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:115400" comment="Audit - Directory Service Changes - Success only" />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:115401" comment="Audit - Directory Service Changes - Success and Failure" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1155" version="2" class="compliance">
-          <metadata>
-            <title>Audit - Directory Service Changes - Failure</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference source="DISA" ref_id="73441" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-46701-9" />
-            <description>The system must be configured to audit DS Access - Directory Service Changes failures.</description>
-          </metadata>
-          <criteria operator="OR" comment="IF system is a DC, THEN check for Audit - Directory Service Changes - Failure">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1010" negate="true" comment="System is a DC." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:115500" comment="Audit - Directory Service Changes - Failure only" />
             <criterion test_ref="oval:mil.disa.stig.windows:tst:115401" comment="Audit - Directory Service Changes - Success and Failure" />
           </criteria>
         </definition>
@@ -10085,35 +10054,6 @@ Configure the policy value for Computer Configuration &gt;&gt; Windows Settings 
               <criterion test_ref="oval:mil.disa.stig.windows:tst:117800" comment="Deny log on as a batch job - Guests" />
               <criterion test_ref="oval:mil.disa.stig.windows:tst:117801" comment="Deny log on as a batch job - Domain Admins" />
               <criterion test_ref="oval:mil.disa.stig.windows:tst:117802" comment="Deny log on as a batch job - Enterprise Admins" />
-            </criteria>
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1179" version="2" class="compliance">
-          <metadata>
-            <title>WN16-MS-000390 - The "Deny log on as a service" user right on member servers must be configured to prevent access from highly privileged domain accounts on domain systems. No other groups or accounts must be assigned this right.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference source="DISA" ref_id="26484" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-47121-9" />
-            <description>Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
-
-The "Deny log on as a service" user right defines accounts that are denied logon as a service.
-
-In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower-trust systems helps mitigate the risk of privilege escalation from credential theft attacks, which could lead to the compromise of an entire domain.
-
-Incorrect configurations could prevent services from starting and result in a denial of service.</description>
-          </metadata>
-          <criteria operator="OR">
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1010" negate="false" comment="IF system is a DC" />
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:117705" comment="IF system is a standalone server" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:117900" comment="Deny log on as a service - None" />
-            </criteria>
-            <criteria operator="AND">
-              <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1171" negate="false" comment="If the system is a domain joined member server" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:117901" comment="Deny log on as a service - Domain Admins" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:117902" comment="Deny log on as a service - Enterprise Admins" />
             </criteria>
           </criteria>
         </definition>
@@ -10960,20 +10900,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <criterion test_ref="oval:mil.disa.stig.windows:tst:125300" comment="Modify firmware environment values - Administrators" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1254" version="1" class="compliance">
-          <metadata>
-            <title>WN16-UR-000280</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <reference source="DISA" ref_id="73797" ref_url="http://iase.disa.mil/stigs/SRR/index.html" />
-            <reference ref_url="http://cce.mitre.org" source="CCE" ref_id="CCE-46126-9" />
-            <description>The Perform volume maintenance tasks user right must only be assigned to the Administrators group.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:125400" comment="Perform volume maintenance tasks - Administrators" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:1255" version="1" class="compliance">
           <metadata>
             <title>WN16-UR-000290</title>
@@ -11056,25 +10982,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <criterion test_ref="oval:mil.disa.stig.windows:tst:126200" comment="Verifies 'Allow indexing of encrypted files' is set to 'Disabled'" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1264" version="1" class="compliance">
-          <metadata>
-            <title>Permissions for the Security event log must prevent access by non-privileged accounts.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The Security event log may disclose sensitive information or be susceptible to tampering if proper permissions are not applied.</description>
-          </metadata>
-          <criteria operator="OR">
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:126401" comment="The Security event log must have at least default permissions. Strict Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:126402" negate="true" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:126400" comment="The Security event log must have at least default permissions. Built Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:126402" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:1265" version="1" class="compliance">
           <metadata>
             <title>WN16-00-000400</title>
@@ -11085,44 +10992,6 @@ Incorrect configurations could prevent services from starting and result in a de
           </metadata>
           <criteria operator="AND">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:126500" comment="Verifes TFTP Client feature is not installed" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1270" version="2" class="compliance">
-          <metadata>
-            <title>Permissions for the Application event log must prevent access by non-privileged accounts.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The Application event log may be susceptible to tampering if proper permissions are not applied.</description>
-          </metadata>
-          <criteria operator="OR">
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127001" comment="The Application event log must have at least default permissions. Strict Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127002" negate="true" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127000" comment="The Application event log must have at least default permissions. Built Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127002" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:1271" version="1" class="compliance">
-          <metadata>
-            <title>Permissions for the System event log must prevent access by non-privileged accounts.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2016</platform>
-            </affected>
-            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The System event log may be susceptible to tampering if proper permissions are not applied.</description>
-          </metadata>
-          <criteria operator="OR">
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127101" comment="The System event log must have at least default permissions. Strict Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127102" negate="true" comment="The System event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
-            <criteria operator="AND">
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127100" comment="The System event log must have at least default permissions. Built Path" />
-              <criterion test_ref="oval:mil.disa.stig.windows:tst:127102" comment="The System event log registry specified location must have the %SystemRoot% environment variable." />
-            </criteria>
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:1274" version="1" class="compliance">
@@ -11291,18 +11160,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1016" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2019" version="1" class="compliance">
-          <metadata>
-            <title>WN19-AC-000070</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 minimum password length must be configured to 14 characters.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1017" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:2020" version="1" class="compliance">
           <metadata>
             <title>WN19-AC-000080</title>
@@ -11397,18 +11254,6 @@ Incorrect configurations could prevent services from starting and result in a de
           </metadata>
           <criteria>
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1045" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2029" version="2" class="compliance">
-          <metadata>
-            <title>WN19-AU-000060</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 Event Viewer must be protected from unauthorized modification and deletion.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.fso.windows:def:4984" comment="Windows Event Viewer only has TrustedInstaller with Full Control or Modify in the file permissions." />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:2030" version="1" class="compliance">
@@ -11855,43 +11700,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1099" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2067" version="4" class="compliance">
-          <metadata>
-            <title>WN19-PK-000010 - Windows Server 2019 must have the DoD Root Certificate Authority (CA) certificates installed in the Trusted Root Store.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root CAs. The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:4200" comment="Verifies the DoD Root CA certificates are installed in the Trusted Root Store." />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2068" version="5" class="compliance">
-          <metadata>
-            <title>WN19-PK-000020 - Windows Server 2019 must have the DoD Interoperability Root Certificate Authority (CA) cross-certificates installed in the Untrusted Certificates Store on unclassified systems</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:206800" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:206801" comment="DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2069" version="3" class="compliance">
-          <metadata>
-            <title>WN19-PK-000030 - Windows Server 2019 must have the US DoD CCEB Interoperability Root CA cross-certificates in the Untrusted Certificates Store on unclassified systems</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.</description>
-          </metadata>
-          <criteria>
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:206900" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:2070" version="1" class="compliance">
           <metadata>
             <title>WN19-CC-000240</title>
@@ -12253,18 +12061,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <criterion test_ref="oval:mil.disa.stig.windows:tst:209800" comment="Kerberos Policy - Maximum tolerance for computer clock synchronization - 5 minutes or less" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2099" version="1" class="compliance">
-          <metadata>
-            <title>WN19-DC-000070</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 permissions on the Active Directory data files must only allow System and Administrators access.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1135" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:2100" version="1" class="compliance">
           <metadata>
             <title>WN19-DC-000240</title>
@@ -12301,18 +12097,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1154" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2103" version="1" class="compliance">
-          <metadata>
-            <title>WN19-DC-000270</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 must be configured to audit DS Access - Directory Service Changes failures.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1155" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:2104" version="1" class="compliance">
           <metadata>
             <title>WN19-DC-000320</title>
@@ -12343,7 +12127,7 @@ Incorrect configurations could prevent services from starting and result in a de
             <affected family="windows">
               <platform>Microsoft Windows Server 2019</platform>
             </affected>
-            <description>Windows Server 2019 "Access this computer from the network" user right must only be assigned to the Administrators, Authenticated Users, and 
+            <description>Windows Server 2019 "Access this computer from the network" user right must only be assigned to the Administrators, Authenticated Users, and
 Enterprise Domain Controllers groups on domain controllers.</description>
           </metadata>
           <criteria>
@@ -12530,24 +12314,6 @@ Enterprise Domain Controllers groups on domain controllers.</description>
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1178" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2122" version="3" class="compliance">
-          <metadata>
-            <title>WN19-MS-000100 - Windows Server 2019 "Deny log on as a service" user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts. No other groups or accounts must be assigned this right.</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
-
-The "Deny log on as a service" user right defines accounts that are denied logon as a service.
-
-In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower-trust systems helps mitigate the risk of privilege escalation from credential theft attacks, which could lead to the compromise of an entire domain.
-
-Incorrect configurations could prevent services from starting and result in a denial of service.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1179" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:2123" version="1" class="compliance">
           <metadata>
             <title>WN19-MS-000110</title>
@@ -12714,18 +12480,6 @@ Incorrect configurations could prevent services from starting and result in a de
           </metadata>
           <criteria>
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1193" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2137" version="2" class="compliance">
-          <metadata>
-            <title>WN19-SO-000120</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 machine inactivity limit must be set to 15 minutes or less, locking the system with the screen saver.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:4202" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:2140" version="1" class="compliance">
@@ -13316,18 +13070,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1253" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2189" version="1" class="compliance">
-          <metadata>
-            <title>WN19-UR-000190</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 "Perform volume maintenance tasks" user right must only be assigned to the Administrators group.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1254" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:2190" version="1" class="compliance">
           <metadata>
             <title>WN19-UR-000200</title>
@@ -13440,18 +13182,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:118" comment="Audit - Other System Events - Success" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2199" version="1" class="compliance">
-          <metadata>
-            <title>WN19-AU-000040</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 permissions for the Security event log must prevent access by non-privileged accounts.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1264" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:2200" version="1" class="compliance">
           <metadata>
             <title>WN19-00-000370</title>
@@ -13476,18 +13206,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <criterion test_ref="oval:mil.disa.stig.windows:tst:126600" comment="Verifies the Windows PowerShell 2.0 Engine server feature is not installed" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2202" version="2" class="compliance">
-          <metadata>
-            <title>WN19-AU-000150</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 must be configured to audit Logon/Logoff - Account Lockout successes.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:119" comment="Is Audit - Logon/Logoff - Account Lockout set to audit successes" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:2203" version="2" class="compliance">
           <metadata>
             <title>WN19-AU-000160</title>
@@ -13510,30 +13228,6 @@ Incorrect configurations could prevent services from starting and result in a de
           </metadata>
           <criteria>
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:117" comment="Audit System - Other System Events failures" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2205" version="1" class="compliance">
-          <metadata>
-            <title>WN19-AU-000030</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 permissions for the Application event log must prevent access by non-privileged accounts.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1270" />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2206" version="1" class="compliance">
-          <metadata>
-            <title>WN19-AU-000050</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 permissions for the System event log must prevent access by non-privileged accounts.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:1271" />
           </criteria>
         </definition>
         <definition id="oval:mil.disa.stig.windows:def:2207" version="1" class="compliance">
@@ -13608,18 +13302,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:19" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:2213" version="1" class="compliance">
-          <metadata>
-            <title>WN19-CC-000250</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2019</platform>
-            </affected>
-            <description>Windows Server 2019 Telemetry must be configured to Security or Basic.</description>
-          </metadata>
-          <criteria>
-            <extend_definition definition_ref="oval:mil.disa.stig.windows:def:24" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:2214" version="1" class="compliance">
           <metadata>
             <title>WN19-CC-000450</title>
@@ -13668,36 +13350,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <extend_definition definition_ref="oval:mil.disa.stig.windows:def:4203" comment="Insecure logons to an SMB server must be disabled" />
           </criteria>
         </definition>
-        <definition id="oval:mil.disa.stig.windows:def:4200" version="2" class="compliance">
-          <metadata>
-            <title>DoD Root CA Certificates</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The DoD Root CA certificates must be installed in the Trusted Root Store.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420001" comment="Verifies the DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420002" comment="Verifies the DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." />
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420003" comment="Verifies the DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." />
-          </criteria>
-        </definition>
-        <definition id="oval:mil.disa.stig.windows:def:4202" version="1" class="compliance">
-          <metadata>
-            <title>Machine Inactivity Limit</title>
-            <affected family="windows">
-              <platform>Microsoft Windows Server 2012</platform>
-              <platform>Microsoft Windows Server 2016</platform>
-              <platform>Microsoft Windows 10</platform>
-            </affected>
-            <description>The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver.</description>
-          </metadata>
-          <criteria operator="AND">
-            <criterion test_ref="oval:mil.disa.stig.windows:tst:420200" comment="Verifies 'Interactive logon: Machine inactivity limit' is set to '900' seconds or less" />
-          </criteria>
-        </definition>
         <definition id="oval:mil.disa.stig.windows:def:4203" version="1" class="compliance">
           <metadata>
             <title>Insecure logons to an SMB server must be disabled.</title>
@@ -13709,6 +13361,188 @@ Incorrect configurations could prevent services from starting and result in a de
           </metadata>
           <criteria operator="AND">
             <criterion test_ref="oval:mil.disa.stig.windows:tst:420300" comment="Verifies 'Enable insecure guest logons' is set to 'Disabled'" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205633" version="1">
+          <metadata>
+            <title>WN19-SO-000120 - Windows Server 2019 machine inactivity limit must be set to 15 minutes or less, locking the system with the screen saver.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Unattended systems are susceptible to unauthorized use and should be locked when unattended. The screen saver should be set at a maximum of 15 minutes and be password protected. This protects critical and sensitive data from exposure to unauthorized personnel with physical access to the computer.
+
+Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000029-GPOS-00010, SRG-OS-000031-GPOS-00012</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253444" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205640" version="1">
+          <metadata>
+            <title>WN19-AU-000030 - Windows Server 2019 permissions for the Application event log must prevent access by non-privileged accounts.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The Application event log may be susceptible to tampering if proper permissions are not applied.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254296" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205641" version="1">
+          <metadata>
+            <title>WN19-AU-000040 - Windows Server 2019 permissions for the Security event log must prevent access by non-privileged accounts.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The Security event log may disclose sensitive information or be susceptible to tampering if proper permissions are not applied.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254297" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205642" version="1">
+          <metadata>
+            <title>WN19-AU-000050 - Windows Server 2019 permissions for the System event log must prevent access by non-privileged accounts.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises that have occurred, as well as detect attacks. Audit logs are necessary to provide a trail of evidence in case the system or network is compromised. The System event log may be susceptible to tampering if proper permissions are not applied.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254298" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205648" version="1">
+          <metadata>
+            <title>WN19-PK-000010 - Windows Server 2019 must have the DoD Root Certificate Authority (CA) certificates installed in the Trusted Root Store.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>To ensure secure DoD websites and DoD-signed code are properly validated, the system must trust the DoD Root CAs. The DoD root certificates will ensure that the trust chain is established for server certificates issued from the DoD CAs.
+
+Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253427" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205649" version="1">
+          <metadata>
+            <title>WN19-PK-000020 - Windows Server 2019 must have the DoD Interoperability Root Certificate Authority (CA) cross-certificates installed in the Untrusted Certificates Store on unclassified systems.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the DoD Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.
+
+Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253429" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205650" version="1">
+          <metadata>
+            <title>WN19-PK-000030 - Windows Server 2019 must have the US DoD CCEB Interoperability Root CA cross-certificates in the Untrusted Certificates Store on unclassified systems.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>To ensure users do not experience denial of service when performing certificate-based authentication to DoD websites due to the system chaining to a root other than DoD Root CAs, the US DoD CCEB Interoperability Root CA cross-certificates must be installed in the Untrusted Certificate Store. This requirement only applies to unclassified systems.
+
+Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000403-GPOS-00182</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253430" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205662" version="1">
+          <metadata>
+            <title>WN19-AC-000070 - Windows Server 2019 minimum password length must be configured to 14 characters.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Information systems not protected with strong password schemes (including passwords of minimum length) provide the opportunity for anyone to crack the password, thus gaining access to the system and compromising the device, information, or the local network.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253303" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205674" version="1">
+          <metadata>
+            <title>WN19-MS-000100 - Windows Server 2019 "Deny log on as a service" user right on domain-joined member servers must be configured to prevent access from highly privileged domain accounts. No other groups or accounts must be assigned this right.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
+
+The "Deny log on as a service" user right defines accounts that are denied logon as a service.
+
+In an Active Directory Domain, denying logons to the Enterprise Admins and Domain Admins groups on lower-trust systems helps mitigate the risk of privilege escalation from credential theft attacks, which could lead to the compromise of an entire domain.
+
+Incorrect configurations could prevent services from starting and result in a denial of service.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253493" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205731" version="1">
+          <metadata>
+            <title>WN19-AU-000060 - Windows Server 2019 Event Viewer must be protected from unauthorized modification and deletion.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information.
+
+Operating systems providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user enjoys in order to make access decisions regarding the modification or deletion of audit tools.
+
+Satisfies: SRG-OS-000257-GPOS-00098, SRG-OS-000258-GPOS-00099</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254299" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205739" version="1">
+          <metadata>
+            <title>WN19-DC-000070 - Windows Server 2019 permissions on the Active Directory data files must only allow System and Administrators access.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Improper access permissions for directory data-related files could allow unauthorized users to read, modify, or delete directory data or audit trails.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:254391" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205765" version="1">
+          <metadata>
+            <title>WN19-UR-000190 - Windows Server 2019 Perform volume maintenance tasks user right must only be assigned to the Administrators group.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Inappropriate granting of user rights can provide system, administrative, and other high-level capabilities.
+
+Accounts with the "Perform volume maintenance tasks" user right can manage volume and disk configurations. This could be used to delete volumes, resulting in data loss or a denial of service.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253503" />
+          </criteria>
+        </definition>
+        <definition class="compliance" id="oval:mil.disa.stig.windows2019:def:205869" version="1">
+          <metadata>
+            <title>WN19-CC-000250 - Windows Server 2019 Telemetry must be configured to Security or Basic.</title>
+            <affected family="windows">
+              <platform>Microsoft Windows Server 2019</platform>
+            </affected>
+            <description>Some features may communicate with the vendor, sending system information or downloading data or components for the feature. Limiting this capability will prevent potentially sensitive information from being sent outside the enterprise. The "Security" option for Telemetry configures the lowest amount of data, effectively none outside of the Malicious Software Removal Tool (MSRT), Defender, and telemetry client settings. "Basic" sends basic diagnostic and usage data and may be required to support some Microsoft services.</description>
+          </metadata>
+          <criteria>
+            <extend_definition definition_ref="oval:mil.disa.stig.defs:def:253393" />
           </criteria>
         </definition>
       </definitions>
@@ -13893,10 +13727,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.fso.windows:obj:466400" />
           <state state_ref="oval:mil.disa.fso.windows:ste:497501" />
         </auditeventpolicysubcategories_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:498400" version="1" comment="Eventvwr.exe: Only Read and Execute rights for users other than TrustedInstaller" check_existence="any_exist" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:498404" />
-          <state state_ref="oval:mil.disa.fso.windows:ste:498408" />
-        </fileeffectiverights53_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:tst:498501" version="1" comment="'DownloadMode' is set to 'Enabled' with 'HTTP only, LAN, Group, Simple or Bypass' selected." state_operator="OR" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:498500" />
           <state state_ref="oval:mil.disa.fso.windows:ste:498500" />
@@ -13905,6 +13735,118 @@ Incorrect configurations could prevent services from starting and result in a de
           <state state_ref="oval:mil.disa.fso.windows:ste:498503" />
           <state state_ref="oval:mil.disa.fso.windows:ste:498504" />
         </registry_test>
+        <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" id="oval:mil.disa.stig.win:tst:10000400" comment="The system is a Windows Domain Member Server" version="1">
+          <object object_ref="oval:mil.disa.stig.win:obj:10000100" />
+          <state state_ref="oval:mil.disa.stig.win:ste:10000400" />
+        </wmi57_test>
+        <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" state_operator="OR" id="oval:mil.disa.stig.win:tst:10000500" comment="The system is a Windows Domain Controller" version="1">
+          <object object_ref="oval:mil.disa.stig.win:obj:10000100" />
+          <state state_ref="oval:mil.disa.stig.win:ste:10000500" />
+          <state state_ref="oval:mil.disa.stig.win:ste:10000501" />
+        </wmi57_test>
+        <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25330300" version="2" comment="'Minimum password length' is set to at least '14' characters" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000002" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25330300" />
+        </passwordpolicy_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25334002" version="1" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25334002" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000016" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25334102" version="1" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25334102" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000016" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25334202" version="1" comment="The System event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25334202" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000016" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25339300" version="2" comment="'Allow Diagnostic Data' is set to 'Enabled' with 'Diagnostic Data Off (Not recommended)' or 'Send Required Diagnostic Data' selected in 'Options:'" check_existence="at_least_one_exists" check="all" state_operator="OR">
+          <object object_ref="oval:mil.disa.stig.win:obj:25339300" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000000" />
+          <state state_ref="oval:mil.disa.stig.win:ste:20000001" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342700" version="2" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342700" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342701" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342705" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342702" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342710" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25342900" version="2" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25342900" />
+        </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25343000" version="2" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 7/18/2025 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:25343000" />
+        </registry_test>
+        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25349300" version="1" comment="Deny log on as a service - Domain Admins" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000003" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25349300" />
+        </accesstoken_test>
+        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25349301" version="1" comment="Deny log on as a service - Enterprise Admins" check="at least one">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000004" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25349300" />
+        </accesstoken_test>
+        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25350300" version="1" comment="Perform volume maintenance tasks - Administrators" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:20000009" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25350300" />
+        </accesstoken_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429600" version="1" comment="The Application event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429600" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429601" version="1" comment="The Application event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429601" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429700" version="1" comment="The Security event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429700" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429701" version="1" comment="The Security event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429701" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429800" version="1" comment="The System event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429800" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429801" version="1" comment="The System event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429801" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25429900" version="1" comment="Eventvwr.exe: Only Read and Execute rights for users other than TrustedInstaller" check_existence="any_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25429903" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25429901" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439100" version="1" comment="Database log files: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439102" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439101" version="1" comment="Database log files: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439103" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439102" version="1" comment="Database log files: No other permissions" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439104" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439103" version="1" comment="DSA Database file: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439105" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439104" version="1" comment="DSA Database file: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439106" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439105" version="1" comment="DSA Database file: No other permissions" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439107" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439106" version="1" comment="DSA Working Directory: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439108" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439107" version="1" comment="DSA Working Directory: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439109" />
+          <state state_ref="oval:mil.disa.stig.win:ste:25439102" />
+        </fileeffectiverights53_test>
+        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:tst:25439108" version="1" comment="DSA Working Directory: No other permissions" check_existence="none_exist" check="all">
+          <object object_ref="oval:mil.disa.stig.win:obj:25439110" />
+        </fileeffectiverights53_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:1900" version="1" comment="Mutual Authentication and Integrity for \\*\SYSVOL" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:1900" />
           <state state_ref="oval:mil.disa.stig.windows:ste:1900" />
@@ -13918,11 +13860,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <state state_ref="oval:mil.disa.stig.windows:ste:1901" />
           <state state_ref="oval:mil.disa.stig.windows:ste:1902" />
           <state state_ref="oval:mil.disa.stig.windows:ste:1903" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:2400" version="2" comment="AllowTelemetry = 0 or 1" check_existence="at_least_one_exists" check="all" state_operator="OR">
-          <object object_ref="oval:mil.disa.stig.windows:obj:2400" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:2400" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:2401" />
         </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:6500" version="1" comment="Verifies 'Sign-in last interactive user automatically after a system-initiated restart' is set to 'Disabled'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:6500" />
@@ -13956,10 +13893,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11801" version="1" comment="'Audit Other System Events' is set to 'Success' and 'Failure'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
           <state state_ref="oval:mil.disa.stig.windows:ste:11801" />
-        </auditeventpolicysubcategories_test>
-        <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11900" version="1" comment="'Audit Account Lockout' is set to 'Success'" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:11900" />
         </auditeventpolicysubcategories_test>
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:11901" version="1" comment="'Audit Account Lockout' is set to 'Success' and 'Failure'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.fso.windows:obj:394100" />
@@ -14035,10 +13968,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:101600" version="1" comment="'Minimum Password Age' is set to at least '1' day" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:101500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:101600" />
-        </passwordpolicy_test>
-        <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:101700" version="1" comment="'Minimum password length' is set to at least '14' characters" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:101500" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:101700" />
         </passwordpolicy_test>
         <passwordpolicy_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:101800" version="1" comment="'Password must meet complexity requirements' is set to 'Enabled'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:101500" />
@@ -14240,72 +14169,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:112800" />
           <state state_ref="oval:mil.disa.stig.windows:ste:112800" />
         </registry_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113500" version="1" comment="Database log files: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113502" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113501" version="1" comment="Database log files: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113503" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113502" version="1" comment="Database log files: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113504" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113503" version="1" comment="DSA Database file: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113505" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113504" version="1" comment="DSA Database file: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113506" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113505" version="1" comment="DSA Database file: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113507" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113506" version="1" comment="Database log files: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113508" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113507" version="1" comment="Database log files: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113509" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113508" version="1" comment="Database log files: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113510" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113509" version="1" comment="DSA Database file and all other files in the same directory: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113511" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113510" version="1" comment="DSA Database file and all other files in the same directory: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113512" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113511" version="1" comment="DSA Database file and all other files in the same directory: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113513" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113512" version="1" comment="DSA Working Directory: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113514" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113513" version="1" comment="DSA Working Directory: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113515" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113514" version="1" comment="DSA Working Directory: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113516" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113515" version="1" comment="DSA Working Directory: NT Authority\SYSTEM has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113517" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113516" version="1" comment="DSA Working Directory: BUILTIN\Administrators has full control" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113518" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:113502" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:113517" version="1" comment="DSA Working Directory: No other permissions" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:113519" />
-        </fileeffectiverights53_test>
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:115200" version="1" comment="Audit - Directory Service Access - Success only" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:105500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:115200" />
@@ -14325,10 +14188,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:115401" version="1" comment="Audit - Directory Service Changes - Success and Failure" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:105500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:115401" />
-        </auditeventpolicysubcategories_test>
-        <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:115500" version="1" comment="Audit - Directory Service Changes - Failure only" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:105500" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:115500" />
         </auditeventpolicysubcategories_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:116000" version="1" comment="'Domain Controller: LDAP Server signing requirements' is set to 'Require signing'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:116000" />
@@ -14433,18 +14292,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:117802" version="2" check="at least one" comment="Deny log on as a batch job - Enterprise Admins">
           <object object_ref="oval:mil.disa.stig.windows:obj:117702" />
           <state state_ref="oval:mil.disa.stig.windows:ste:117800" />
-        </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:117900" version="1" check="all" comment="Deny log on as a service - None">
-          <object object_ref="oval:mil.disa.stig.windows:obj:117900" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:117900" />
-        </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:117901" version="2" check="at least one" comment="Deny log on as a service - Domain Admins">
-          <object object_ref="oval:mil.disa.stig.windows:obj:117701" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:117901" />
-        </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:117902" version="2" check="at least one" comment="Deny log on as a service - Enterprise Admins">
-          <object object_ref="oval:mil.disa.stig.windows:obj:117702" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:117901" />
         </accesstoken_test>
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:118000" version="1" check="all" comment="Deny log on locally - Guests">
           <object object_ref="oval:mil.disa.stig.windows:obj:117700" />
@@ -14730,10 +14577,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:125300" />
           <state state_ref="oval:mil.disa.stig.windows:ste:125300" />
         </accesstoken_test>
-        <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:125400" version="1" check="all" comment="Perform volume maintenance tasks - Administrators">
-          <object object_ref="oval:mil.disa.stig.windows:obj:125400" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:125400" />
-        </accesstoken_test>
         <accesstoken_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:125500" version="1" check="all" comment="Profile single process - Administrators">
           <object object_ref="oval:mil.disa.stig.windows:obj:125500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:125500" />
@@ -14750,16 +14593,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:126200" />
           <state state_ref="oval:mil.disa.stig.windows:ste:126200" />
         </registry_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:126400" version="1" comment="The Security event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:126400" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:126401" version="1" comment="The Security event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:126401" />
-        </fileeffectiverights53_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:126402" version="1" comment="The Security event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:126402" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:5104" />
-        </registry_test>
         <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:126500" version="1" comment="TFTP Client feature is not installed" check_existence="all_exist" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:126500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:126500" />
@@ -14768,26 +14601,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:126500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:126600" />
         </wmi57_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127000" version="2" comment="The Application event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127000" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127001" version="2" comment="The Application event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127001" />
-        </fileeffectiverights53_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127002" version="1" comment="The Application event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127002" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:5104" />
-        </registry_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127100" version="1" comment="The System event log must have at least default permissions. Built Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127100" />
-        </fileeffectiverights53_test>
-        <fileeffectiverights53_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127101" version="1" comment="The System event log must have at least default permissions. Strict Path" check_existence="none_exist" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127101" />
-        </fileeffectiverights53_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127102" version="1" comment="The System event log registry specified location must have the %SystemRoot% environment variable." check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:127102" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:5104" />
-        </registry_test>
         <auditeventpolicysubcategories_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:127400" version="1" comment="'Audit Other Object Access Events' is set to 'Success'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:105500" />
           <state state_ref="oval:mil.disa.stig.windows:ste:127400" />
@@ -14829,15 +14642,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:201103" />
           <state state_ref="oval:mil.disa.stig.windows:ste:201103" />
         </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:206800" version="3" comment="DoD Interoperability Root CA 2 certificate expiring 11/16/2024 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:206800" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:206801" version="1" comment="DoD Interoperability Root CA 2 certificate expiring 1/22/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:206805" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:206900" version="1" comment="US DoD CCEB Interoperability Root CA 2 cross-certificate expiring 8/26/2022 is installed in the Untrusted Certificates Store" check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:206900" />
-        </registry_test>
         <wmi57_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:209400" version="1" check="all" comment="Kerberos user logon restrictions must be enforced, PA test = -1" check_existence="at_least_one_exists">
           <object object_ref="oval:mil.disa.stig.windows:obj:209400" />
           <state state_ref="oval:mil.disa.stig.windows:ste:209400" />
@@ -14874,31 +14678,17 @@ Incorrect configurations could prevent services from starting and result in a de
           <object object_ref="oval:mil.disa.stig.windows:obj:209800" />
           <state state_ref="oval:mil.disa.stig.windows:ste:209800" />
         </wmi57_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420001" version="1" comment="The DoD Root CA 3 Certificate expiring 12/30/2029 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420005" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420002" version="1" comment="The DoD Root CA 4 Certificate expiring 7/25/2032 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420010" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420003" version="1" comment="The DoD Root CA 5 Certificate expiring 6/14/2041 is installed into the Trusted Root Store." check_existence="at_least_one_exists" check="at least one">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420015" />
-        </registry_test>
-        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420200" version="1" comment="'Interactive logon: Machine inactivity limit' is set to '900' seconds or less" check_existence="at_least_one_exists" check="all">
-          <object object_ref="oval:mil.disa.stig.windows:obj:420200" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:420200" />
-          <state state_ref="oval:mil.disa.stig.windows:ste:420201" />
-        </registry_test>
         <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:420300" version="1" comment="'Enable insecure guest logons' is set to 'Disabled'" check_existence="at_least_one_exists" check="all">
           <object object_ref="oval:mil.disa.stig.windows:obj:420300" />
           <state state_ref="oval:mil.disa.stig.windows:ste:420300" />
         </registry_test>
+        <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:tst:25344400" version="1" comment="The machine inactivity limit is set to 15 minutes or less" check_existence="at_least_one_exists" check="all">
+          <object object_ref="oval:mil.disa.stig.windows:obj:25344400" />
+          <state state_ref="oval:mil.disa.stig.windows:ste:25344400" />
+          <state state_ref="oval:mil.disa.stig.windows:ste:25344401" />
+        </registry_test>
       </tests>
       <objects>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:388601" version="2" comment="System Root Directory Registry Object">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
-          <name datatype="string">SystemRoot</name>
-        </registry_object>
         <auditeventpolicysubcategories_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:394100" version="1" comment="Audit event subcategories policy" />
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:459400" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
@@ -14971,21 +14761,353 @@ Incorrect configurations could prevent services from starting and result in a de
           <key datatype="string">SOFTWARE\Policies\Microsoft\Cryptography</key>
           <name datatype="string">ForceKeyProtection</name>
         </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:498401" version="1" comment="Event Viewer Rights">
-          <path var_ref="oval:mil.disa.fso.windows:var:498401" var_check="at least one" datatype="string" />
-          <filename datatype="string">Eventvwr.exe</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:498404" version="1" comment="Eventvwr Rights except for TrustedInstaller">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.fso.windows:obj:498401</object_reference>
-            <filter>oval:mil.disa.fso.windows:ste:498402</filter>
-          </set>
-        </fileeffectiverights53_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:obj:498500" version="1">
           <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string" operation="equals">Software\Policies\Microsoft\Windows\DeliveryOptimization</key>
           <name datatype="string" operation="equals">DODownloadMode</name>
+        </registry_object>
+        <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:10000100" version="1">
+          <namespace>root\cimv2</namespace>
+          <wql>SELECT DomainRole FROM win32_computersystem</wql>
+        </wmi57_object>
+        <passwordpolicy_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000002" version="1" />
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000003" version="1">
+          <security_principle datatype="string" operation="pattern match">^(?i)(.+\\)?Domain Admins$</security_principle>
+        </accesstoken_object>
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000004" version="1">
+          <security_principle datatype="string" operation="pattern match">^(?i)(.+\\)?Enterprise Admins$</security_principle>
+        </accesstoken_object>
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000008" version="1" comment="All security principles">
+          <security_principle operation="pattern match">.+</security_principle>
+        </accesstoken_object>
+        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000009" version="1" comment="Administrators">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
+            <object_reference>oval:mil.disa.stig.win:obj:20000008</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000005</filter>
+          </set>
+        </accesstoken_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:20000015" version="1" comment="System Root Directory">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name datatype="string">SystemRoot</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334001" version="1" comment="The Application event log. Built filepath.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334001" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334002" version="1" comment="path Application.evtx">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\Application</key>
+          <name datatype="string">file</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334004" version="1" comment="The Application event log. Strict filepath, as listed.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334002" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334101" version="1" comment="The Security event log. Built filepath.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334101" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334102" version="1" comment="path Security.evtx">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\Security</key>
+          <name datatype="string">file</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334104" version="1" comment="The Security event log. Strict filepath, as listed.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334102" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334201" version="1" comment="The System event log. Built filepath.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334201" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334202" version="1" comment="path System.evtx">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\System</key>
+          <name datatype="string">file</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25334204" version="1" comment="The System event log. Strict filepath, as listed.">
+          <filepath var_ref="oval:mil.disa.stig.win:var:25334202" var_check="at least one" datatype="string" operation="case insensitive equals" />
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25339300" version="1">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\DataCollection</key>
+          <name datatype="string">AllowTelemetry</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342700" version="2">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342701</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342702</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342701" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342703</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342704</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342702" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342703" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342704" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342705" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342706</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342707</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342706" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342708</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342709</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342707" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342708" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342709" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342710" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342711</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342712</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342711" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342713</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342714</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342712" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342713" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342714" version="1">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342900" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342901</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342904</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342901" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25342902</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25342903</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342902" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342903" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25342904" version="3">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343000" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343001</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343004</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343001" version="1">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25343002</object_reference>
+            <object_reference>oval:mil.disa.stig.win:obj:25343003</object_reference>
+          </set>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343002" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343003" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25343004" version="2">
+          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\9B74964506C7ED9138070D08D5F8B969866560C8</key>
+          <name datatype="string" operation="pattern match">^.+$</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429600" version="1" comment="Permissions of Application event log, minus those allowed. Built filepath.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334001</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429601" version="1" comment="Permissions of Application event log, minus those allowed. Strict filepath, as listed.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334004</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429700" version="1" comment="Permissions of Security event log, minus those allowed. Built filepath.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334101</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429701" version="1" comment="Permissions of Security event log, minus those allowed. Strict filepath, as listed.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334104</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429800" version="1" comment="Permissions of System event log, minus those allowed. Built filepath.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334201</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429801" version="1" comment="Permissions of System event log, minus those allowed. Strict filepath, as listed.">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25334204</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:20000011</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000012</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000013</filter>
+            <filter>oval:mil.disa.stig.win:ste:20000014</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429901" version="1" comment="System Root Directory Registry Object">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
+          <name datatype="string">SystemRoot</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429902" version="3" comment="Event Viewer Rights">
+          <path var_ref="oval:mil.disa.stig.win:var:25429900" var_check="at least one" datatype="string" />
+          <filename datatype="string">Eventvwr.exe</filename>
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25429903" version="1" comment="Eventvwr Rights except for TrustedInstaller">
+          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+            <object_reference>oval:mil.disa.stig.win:obj:25429902</object_reference>
+            <filter>oval:mil.disa.stig.win:ste:25429900</filter>
+          </set>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439100" version="1" comment="Database log files path">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
+          <name datatype="string" operation="equals">Database log files path</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439101" version="1" comment="DSA Database file">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
+          <name datatype="string" operation="equals">DSA Database file</name>
+        </registry_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439102" version="4" comment="Database log files - SYSTEM permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439100" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-18</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439103" version="4" comment="Database log files - Administrators permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439100" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439104" version="4" comment="Database log files - Other permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439100" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439100</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439101</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439103</filter>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439105" version="4" comment="Files in the same directory as the DSA Database - SYSTEM permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439101" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-18</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439106" version="4" comment="Files in the same directory as the DSA Database - Administrators permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439101" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439107" version="4" comment="Files in the same directory as the DSA Database - Other permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439101" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439100</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439101</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439103</filter>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439108" version="4" comment="Files in the DSA Working Directory - SYSTEM permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439102" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-18</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439109" version="4" comment="Files in the DSA Working Directory - Administrators permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439102" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid>S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_object>
+        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439110" version="4" comment="Files in the DSA Working Directory - Other permissions">
+          <path var_ref="oval:mil.disa.stig.win:var:25439102" var_check="all" datatype="string" />
+          <filename datatype="string" operation="pattern match">^(.*)$</filename>
+          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439100</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439101</filter>
+          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.win:ste:25439103</filter>
+        </fileeffectiverights53_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:obj:25439111" version="1" comment="DSA Working Directory">
+          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
+          <name datatype="string" operation="equals">DSA Working Directory</name>
         </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:1900" version="1" comment="Hardened Path Config for \\*\SYSVOL">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
@@ -14996,11 +15118,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths</key>
           <name datatype="string">\\*\NETLOGON</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:2400" version="2" comment="AllowTelemetry">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\DataCollection</key>
-          <name datatype="string">AllowTelemetry</name>
         </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:6500" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
@@ -15276,129 +15393,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <key datatype="string" operation="equals">Software\Policies\Microsoft\Windows\WinRM\Service</key>
           <name datatype="string" operation="equals">DisableRunAs</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113500" version="1" comment="Database log files path">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
-          <name datatype="string" operation="equals">Database log files path</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113501" version="1" comment="DSA Database file">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
-          <name datatype="string" operation="equals">DSA Database file</name>
-        </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113502" version="2" comment="Database log files - SYSTEM permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113503" version="2" comment="Database log files - Administrators permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113504" version="2" comment="Database log files - Other permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113505" version="2" comment="Files in the same directory as the DSA Database - SYSTEM permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113506" version="2" comment="Files in the same directory as the DSA Database - Administrators permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113507" version="2" comment="Files in the same directory as the DSA Database - Other permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113508" version="2" comment="Database log files - SYSTEM permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113509" version="2" comment="Database log files - Administrators permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113510" version="2" comment="Database log files - Other permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113500" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113511" version="1" comment="Files in the same directory as the DSA Database - SYSTEM permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113512" version="1" comment="Files in the same directory as the DSA Database - Administrators permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113513" version="1" comment="Files in the same directory as the DSA Database - Other permissions">
-          <path var_ref="oval:mil.disa.stig.windows:var:113501" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113514" version="1" comment="Files in the DSA Working Directory - SYSTEM permissions, SCC">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113515" version="1" comment="Files in the DSA Working Directory - Administrators permissions, SCC">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113516" version="1" comment="Files in the DSA Working Directory - Other permissions, SCC">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" operation="case insensitive equals" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113517" version="1" comment="Files in the DSA Working Directory - SYSTEM permissions, McAfee tools">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113518" version="1" comment="Files in the DSA Working Directory - Administrators permissions, McAfee tools">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113519" version="1" comment="Files in the DSA Working Directory - Other permissions, McAfee tools">
-          <path var_ref="oval:mil.disa.stig.windows:var:113502" var_check="all" datatype="string" />
-          <filename datatype="string" operation="pattern match">^(.*)$</filename>
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113500</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113501</filter>
-          <filter xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">oval:mil.disa.stig.windows:ste:113503</filter>
-        </fileeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:113520" version="1" comment="DSA Working Directory">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
-          <name datatype="string" operation="equals">DSA Working Directory</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:116000" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">System\CurrentControlSet\Services\NTDS\Parameters</key>
@@ -15509,9 +15503,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </accesstoken_object>
         <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:117712" version="1" comment="Domain Admins strict">
           <security_principle datatype="string" operation="equals">Domain Admins</security_principle>
-        </accesstoken_object>
-        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:117900" version="1" comment="All security principles">
-          <security_principle datatype="string" operation="pattern match">.*</security_principle>
         </accesstoken_object>
         <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:118200" version="1" comment="All security principles">
           <security_principle datatype="string" operation="pattern match">.*</security_principle>
@@ -15803,15 +15794,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:125301" version="1" comment="All security principles">
           <security_principle datatype="string" operation="pattern match">.*</security_principle>
         </accesstoken_object>
-        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:125400" version="1" comment="Filter for Administrators">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
-            <object_reference>oval:mil.disa.stig.windows:obj:125401</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:125401</filter>
-          </set>
-        </accesstoken_object>
-        <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:125401" version="1" comment="All security principles">
-          <security_principle datatype="string" operation="pattern match">.*</security_principle>
-        </accesstoken_object>
         <accesstoken_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:125500" version="1" comment="Filter for Administrators">
           <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" set_operator="UNION">
             <object_reference>oval:mil.disa.stig.windows:obj:125501</object_reference>
@@ -15844,103 +15826,10 @@ Incorrect configurations could prevent services from starting and result in a de
           <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\Windows Search</key>
           <name datatype="string">AllowIndexingEncryptedStoresOrItems</name>
         </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126400" version="1" comment="Permissions of Security event log, minus those allowed. Built filepath.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:126403</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126401" version="1" comment="Permissions of Security event log, minus those allowed. Strict filepath, as listed.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:126404</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126402" version="1" comment="path Security.evtx">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\Security</key>
-          <name datatype="string">File</name>
-        </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126403" version="1" comment="The Security event log. Built filepath.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:126400" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126404" version="1" comment="The Security event log. Strict filepath, as listed.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:126401" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
         <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:126500" version="1" comment="Select the ids from 'Get-WindowsFeature | Where Installed'">
           <namespace datatype="string">root\cimv2</namespace>
           <wql datatype="string" operation="equals">SELECT id FROM win32_serverfeature</wql>
         </wmi57_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127000" version="1" comment="Permissions of Application event log, minus those allowed. Built filepath.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:127003</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127001" version="1" comment="Permissions of Application event log, minus those allowed. Strict filepath, as listed.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:127004</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127002" version="1" comment="path Application.evtx">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\Application</key>
-          <name datatype="string">File</name>
-        </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127003" version="1" comment="The Application event log. Built filepath.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:127000" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127004" version="1" comment="The Application event log. Strict filepath, as listed.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:127001" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127100" version="1" comment="Permissions of System event log, minus those allowed. Built filepath.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:127103</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127101" version="1" comment="Permissions of System event log, minus those allowed. Strict filepath, as listed.">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:127104</object_reference>
-            <filter>oval:mil.disa.stig.windows:ste:127000</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127001</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127002</filter>
-            <filter>oval:mil.disa.stig.windows:ste:127003</filter>
-          </set>
-        </fileeffectiverights53_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127102" version="1" comment="path System.evtx">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">SYSTEM\CurrentControlSet\Services\EventLog\System</key>
-          <name datatype="string">File</name>
-        </registry_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127103" version="1" comment="The System event log. Built filepath.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:127100" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
-        <fileeffectiverights53_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:127104" version="1" comment="The System event log. Strict filepath, as listed.">
-          <filepath var_ref="oval:mil.disa.stig.windows:var:127101" var_check="at least one" datatype="string" />
-          <trustee_sid operation="pattern match" datatype="string">.*</trustee_sid>
-        </fileeffectiverights53_object>
         <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:201000" version="1" comment="DomainRole property">
           <namespace datatype="string">root\cimv2</namespace>
           <wql datatype="string" operation="equals">SELECT DomainRole FROM win32_computersystem</wql>
@@ -15965,87 +15854,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <key datatype="string">SOFTWARE\Microsoft\Windows NT\CurrentVersion</key>
           <name datatype="string">CurrentBuildNumber</name>
         </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206800" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:206801</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:206804</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206801" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:206802</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:206803</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206802" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206803" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206804" version="2">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\49CBE933151872E17C8EAE7F0ABA97FB610F6477</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206805" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:206806</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:206809</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206806" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:206807</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:206808</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206807" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206808" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206809" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AC06108CA348CC03B53795C64BF84403C1DBD341</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206900" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:206901</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:206904</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206901" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:206902</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:206903</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206902" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206903" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:206904" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Disallowed\Certificates\AF132AC65DE86FC4FB3FE51FD637EBA0FF0B12A9</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
         <wmi57_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:209400" version="1" comment="Kerberos Policy - Enforce user logon restrictions">
           <namespace datatype="string">root\rsop\computer</namespace>
           <wql datatype="string">SELECT setting FROM RSOP_SecuritySettingBoolean WHERE KeyName='TicketValidateClient'</wql>
@@ -16066,96 +15874,15 @@ Incorrect configurations could prevent services from starting and result in a de
           <namespace datatype="string">root\rsop\computer</namespace>
           <wql datatype="string">SELECT setting FROM RSOP_SecuritySettingNumeric WHERE KeyName='MaxClockSkew'</wql>
         </wmi57_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420005" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420006</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420009</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420006" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420007</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420008</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420007" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420008" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420009" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\D73CA91102A2204A36459ED32213B467D7CE97FB</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420010" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420011</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420014</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420011" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420012</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420013</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420012" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420013" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420014" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\B8269F25DBD937ECAFD4C35A9838571723F2D026</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420015" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420016</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420019</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420016" version="1">
-          <set xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
-            <object_reference>oval:mil.disa.stig.windows:obj:420017</object_reference>
-            <object_reference>oval:mil.disa.stig.windows:obj:420018</object_reference>
-          </set>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420017" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420018" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Microsoft\EnterpriseCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420019" version="1">
-          <hive datatype="string" operation="equals">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string" operation="equals">SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\4ECB5CC3095670454DA1CBD410FC921F46B8564B</key>
-          <name datatype="string" operation="pattern match">^.+$</name>
-        </registry_object>
-        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420200" version="1">
-          <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
-          <key datatype="string">Software\Microsoft\Windows\CurrentVersion\Policies\System</key>
-          <name datatype="string">InactivityTimeoutSecs</name>
-        </registry_object>
         <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:420300" version="1">
           <hive datatype="string">HKEY_LOCAL_MACHINE</hive>
           <key datatype="string">SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation</key>
           <name datatype="string">AllowInsecureGuestAuth</name>
+        </registry_object>
+        <registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:obj:25344400" version="1">
+          <hive datatype="string" operation="case insensitive equals">HKEY_LOCAL_MACHINE</hive>
+          <key datatype="string" operation="case insensitive equals">Software\Microsoft\Windows\CurrentVersion\Policies\System</key>
+          <name datatype="string" operation="case insensitive equals">InactivityTimeoutSecs</name>
         </registry_object>
       </objects>
       <states>
@@ -16292,20 +16019,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:497501" version="2" comment="Audit - Audit Policy Change - Success and Failure">
           <authorization_policy_change datatype="string" operation="equals">AUDIT_SUCCESS_FAILURE</authorization_policy_change>
         </auditeventpolicysubcategories_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498402" version="1" comment="TrustedInstaller">
-          <trustee_sid operation="equals" datatype="string">S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498408" version="1" comment="No Rights except Read and Execute">
-          <standard_delete datatype="boolean" operation="equals" entity_check="all">false</standard_delete>
-          <standard_write_dac datatype="boolean" operation="equals" entity_check="all">false</standard_write_dac>
-          <standard_write_owner datatype="boolean" operation="equals" entity_check="all">false</standard_write_owner>
-          <generic_write datatype="boolean" operation="equals" entity_check="all">false</generic_write>
-          <file_write_data datatype="boolean" operation="equals" entity_check="all">false</file_write_data>
-          <file_append_data datatype="boolean" operation="equals" entity_check="all">false</file_append_data>
-          <file_write_ea datatype="boolean" operation="equals" entity_check="all">false</file_write_ea>
-          <file_delete_child datatype="boolean" operation="equals" entity_check="all">false</file_delete_child>
-          <file_write_attributes datatype="boolean" operation="equals" entity_check="all">false</file_write_attributes>
-        </fileeffectiverights53_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.fso.windows:ste:498500" version="3" comment="Reg_Dword type and value equals 0">
           <type>reg_dword</type>
           <value datatype="int" operation="equals">0</value>
@@ -16326,6 +16039,114 @@ Incorrect configurations could prevent services from starting and result in a de
           <type>reg_dword</type>
           <value datatype="int" operation="equals">100</value>
         </registry_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:10000400" comment="Domain Member Server" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="domainrole">3</field>
+          </result>
+        </wmi57_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:10000500" comment="Backup Domain Controller" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="domainrole">4</field>
+          </result>
+        </wmi57_state>
+        <wmi57_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:10000501" comment="Primary Domain Controller" version="1">
+          <result datatype="record" operation="equals">
+            <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="domainrole">5</field>
+          </result>
+        </wmi57_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000000" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">0</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000001" version="1">
+          <type>reg_dword</type>
+          <value datatype="int">1</value>
+        </registry_state>
+        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000005" version="1">
+          <security_principle datatype="string" operation="case insensitive equals">Administrators</security_principle>
+        </accesstoken_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000011" version="1" comment="Event Log process account. Deterministically built with respect to service name.">
+          <trustee_sid datatype="string">S-1-5-80-880578595-1860270145-482643319-2788375705-1540778122</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000012" version="1" comment="SYSTEM account.">
+          <trustee_sid datatype="string">S-1-5-18</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000013" version="1" comment="Administrators account.">
+          <trustee_sid datatype="string">S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000014" version="1" comment="LOCAL SERVICE account, the owner.">
+          <trustee_sid datatype="string">S-1-5-19</trustee_sid>
+        </fileeffectiverights53_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:20000016" version="1" comment="%SystemRoot% environment variable.">
+          <value datatype="string" operation="pattern match">^(?i)%SystemRoot%.*$</value>
+        </registry_state>
+        <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25330300" version="2" comment="Minimum Password Length is greater than or equal to 14">
+          <min_passwd_len operation="greater than or equal" datatype="int">14</min_passwd_len>
+        </passwordpolicy_state>
+        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25349300" version="1" comment="Deny log on as a service">
+          <sedenyservicelogonright datatype="boolean" operation="equals">1</sedenyservicelogonright>
+        </accesstoken_state>
+        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25350300" version="1" comment="Perform volume maintenance tasks">
+          <semanagevolumeprivilege datatype="boolean">0</semanagevolumeprivilege>
+        </accesstoken_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25429900" version="1" comment="TrustedInstaller">
+          <trustee_sid operation="equals" datatype="string">S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25429901" version="1" comment="No Rights except Read and Execute">
+          <standard_delete datatype="boolean" operation="equals" entity_check="all">false</standard_delete>
+          <standard_write_dac datatype="boolean" operation="equals" entity_check="all">false</standard_write_dac>
+          <standard_write_owner datatype="boolean" operation="equals" entity_check="all">false</standard_write_owner>
+          <generic_write datatype="boolean" operation="equals" entity_check="all">false</generic_write>
+          <file_write_data datatype="boolean" operation="equals" entity_check="all">false</file_write_data>
+          <file_append_data datatype="boolean" operation="equals" entity_check="all">false</file_append_data>
+          <file_write_ea datatype="boolean" operation="equals" entity_check="all">false</file_write_ea>
+          <file_delete_child datatype="boolean" operation="equals" entity_check="all">false</file_delete_child>
+          <file_write_attributes datatype="boolean" operation="equals" entity_check="all">false</file_write_attributes>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25439100" version="1" comment="Administrators Rights">
+          <trustee_sid>S-1-5-32-544</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25439101" version="1" comment="Local System Rights">
+          <trustee_sid>S-1-5-18</trustee_sid>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25439102" version="1" comment="Full Rights">
+          <standard_delete datatype="boolean">true</standard_delete>
+          <standard_read_control datatype="boolean">true</standard_read_control>
+          <standard_write_dac datatype="boolean">true</standard_write_dac>
+          <standard_write_owner datatype="boolean">true</standard_write_owner>
+          <standard_synchronize datatype="boolean">true</standard_synchronize>
+          <generic_read datatype="boolean">true</generic_read>
+          <generic_write datatype="boolean">true</generic_write>
+          <generic_execute datatype="boolean">true</generic_execute>
+          <file_read_data datatype="boolean">true</file_read_data>
+          <file_write_data datatype="boolean">true</file_write_data>
+          <file_append_data datatype="boolean">true</file_append_data>
+          <file_read_ea datatype="boolean">true</file_read_ea>
+          <file_write_ea datatype="boolean">true</file_write_ea>
+          <file_execute datatype="boolean">true</file_execute>
+          <file_delete_child datatype="boolean">true</file_delete_child>
+          <file_read_attributes datatype="boolean">true</file_read_attributes>
+          <file_write_attributes datatype="boolean">true</file_write_attributes>
+        </fileeffectiverights53_state>
+        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.win:ste:25439103" version="1" comment="No Rights">
+          <standard_delete datatype="boolean">false</standard_delete>
+          <standard_read_control datatype="boolean">false</standard_read_control>
+          <standard_write_dac datatype="boolean">false</standard_write_dac>
+          <standard_write_owner datatype="boolean">false</standard_write_owner>
+          <standard_synchronize datatype="boolean">false</standard_synchronize>
+          <generic_read datatype="boolean">false</generic_read>
+          <generic_write datatype="boolean">false</generic_write>
+          <generic_execute datatype="boolean">false</generic_execute>
+          <file_read_data datatype="boolean">false</file_read_data>
+          <file_write_data datatype="boolean">false</file_write_data>
+          <file_append_data datatype="boolean">false</file_append_data>
+          <file_read_ea datatype="boolean">false</file_read_ea>
+          <file_write_ea datatype="boolean">false</file_write_ea>
+          <file_execute datatype="boolean">false</file_execute>
+          <file_delete_child datatype="boolean">false</file_delete_child>
+          <file_read_attributes datatype="boolean">false</file_read_attributes>
+          <file_write_attributes datatype="boolean">false</file_write_attributes>
+        </fileeffectiverights53_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:1900" version="2" comment="RequireMutualAuthentication=1">
           <type>reg_sz</type>
           <value datatype="string" operation="pattern match">(^| *, *)RequireMutualAuthentication=1( *, *|$)</value>
@@ -16341,17 +16162,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:1903" version="2" comment="No RequireIntegrity!=1">
           <type>reg_sz</type>
           <value datatype="string" entity_check="none satisfy" operation="pattern match">(^| *, *)RequireIntegrity=(?!1( *, *|$))</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:2400" version="1" comment="AllowTelemetry = 0 (reg_dword)">
-          <type>reg_dword</type>
-          <value datatype="int">0</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:2401" version="1" comment="AllowTelemetry = 1 (reg_dword)">
-          <type>reg_dword</type>
-          <value datatype="int">1</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:5104" version="2" comment="%SystemRoot% environment variable.">
-          <value datatype="string" operation="pattern match">^%[Ss][Yy][Ss][Tt][Ee][Mm][Rr][Oo][Oo][Tt]%.*$</value>
         </registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:6500" version="1" comment="DisableAutomaticRestartSignOn = 1 (reg_dword)">
           <type>reg_dword</type>
@@ -16382,9 +16192,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </auditeventpolicysubcategories_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11801" version="1" comment="'Other System Events' is set to 'Success' and 'Failure'">
           <other_system_events datatype="string">AUDIT_SUCCESS_FAILURE</other_system_events>
-        </auditeventpolicysubcategories_state>
-        <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11900" version="1" comment="'Account Lockout' is set to 'Success'">
-          <account_lockout datatype="string">AUDIT_SUCCESS</account_lockout>
         </auditeventpolicysubcategories_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:11901" version="1" comment="'Account Lockout' is set to 'Success' and 'Failure'">
           <account_lockout datatype="string">AUDIT_SUCCESS_FAILURE</account_lockout>
@@ -16459,9 +16266,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </passwordpolicy_state>
         <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:101600" version="1" comment="Minimum Password Age is greater than or equal to variable">
           <min_passwd_age datatype="int" operation="greater than or equal" var_ref="oval:mil.disa.stig.windows:var:101600" />
-        </passwordpolicy_state>
-        <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:101700" version="1" comment="Minimum Password Length is greater than or equal to variable">
-          <min_passwd_len operation="greater than or equal" datatype="int" var_ref="oval:mil.disa.stig.windows:var:101700" />
         </passwordpolicy_state>
         <passwordpolicy_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:101800" version="1" comment="Password Complexity equals variable">
           <password_complexity datatype="boolean" var_ref="oval:mil.disa.stig.windows:var:101800" />
@@ -16639,50 +16443,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <type>reg_dword</type>
           <value datatype="int" operation="equals">1</value>
         </registry_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:113500" version="1" comment="Administrators Rights">
-          <trustee_sid>S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:113501" version="1" comment="Local System Rights">
-          <trustee_sid>S-1-5-18</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:113502" version="1" comment="Full Rights">
-          <standard_delete datatype="boolean">true</standard_delete>
-          <standard_read_control datatype="boolean">true</standard_read_control>
-          <standard_write_dac datatype="boolean">true</standard_write_dac>
-          <standard_write_owner datatype="boolean">true</standard_write_owner>
-          <standard_synchronize datatype="boolean">true</standard_synchronize>
-          <generic_read datatype="boolean">true</generic_read>
-          <generic_write datatype="boolean">true</generic_write>
-          <generic_execute datatype="boolean">true</generic_execute>
-          <file_read_data datatype="boolean">true</file_read_data>
-          <file_write_data datatype="boolean">true</file_write_data>
-          <file_append_data datatype="boolean">true</file_append_data>
-          <file_read_ea datatype="boolean">true</file_read_ea>
-          <file_write_ea datatype="boolean">true</file_write_ea>
-          <file_execute datatype="boolean">true</file_execute>
-          <file_delete_child datatype="boolean">true</file_delete_child>
-          <file_read_attributes datatype="boolean">true</file_read_attributes>
-          <file_write_attributes datatype="boolean">true</file_write_attributes>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:113503" version="1" comment="No Rights">
-          <standard_delete datatype="boolean">false</standard_delete>
-          <standard_read_control datatype="boolean">false</standard_read_control>
-          <standard_write_dac datatype="boolean">false</standard_write_dac>
-          <standard_write_owner datatype="boolean">false</standard_write_owner>
-          <standard_synchronize datatype="boolean">false</standard_synchronize>
-          <generic_read datatype="boolean">false</generic_read>
-          <generic_write datatype="boolean">false</generic_write>
-          <generic_execute datatype="boolean">false</generic_execute>
-          <file_read_data datatype="boolean">false</file_read_data>
-          <file_write_data datatype="boolean">false</file_write_data>
-          <file_append_data datatype="boolean">false</file_append_data>
-          <file_read_ea datatype="boolean">false</file_read_ea>
-          <file_write_ea datatype="boolean">false</file_write_ea>
-          <file_execute datatype="boolean">false</file_execute>
-          <file_delete_child datatype="boolean">false</file_delete_child>
-          <file_read_attributes datatype="boolean">false</file_read_attributes>
-          <file_write_attributes datatype="boolean">false</file_write_attributes>
-        </fileeffectiverights53_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:115200" version="1" comment="Audit - Directory Service Access - Success only">
           <directory_service_access datatype="string" operation="equals">AUDIT_SUCCESS</directory_service_access>
         </auditeventpolicysubcategories_state>
@@ -16697,9 +16457,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </auditeventpolicysubcategories_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:115401" version="1" comment="Audit - Directory Service Changes - Success and Failure">
           <directory_service_changes datatype="string" operation="equals">AUDIT_SUCCESS_FAILURE</directory_service_changes>
-        </auditeventpolicysubcategories_state>
-        <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:115500" version="1" comment="Audit - Directory Service Changes - Failure only">
-          <directory_service_changes datatype="string" operation="equals">AUDIT_FAILURE</directory_service_changes>
         </auditeventpolicysubcategories_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:116000" version="1" comment="Reg_Dword type and value equals 2">
           <type>reg_dword</type>
@@ -16785,12 +16542,6 @@ Incorrect configurations could prevent services from starting and result in a de
         </wmi57_state>
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:117800" version="1" comment="Deny log on as a batch job">
           <sedenybatchLogonright datatype="boolean" operation="equals">1</sedenybatchLogonright>
-        </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:117900" version="1" comment="Deny log on as a service">
-          <sedenyservicelogonright datatype="boolean" operation="equals">0</sedenyservicelogonright>
-        </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:117901" version="1" comment="Deny log on as a service">
-          <sedenyservicelogonright datatype="boolean" operation="equals">1</sedenyservicelogonright>
         </accesstoken_state>
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:118000" version="1" comment="Deny log on locally">
           <sedenyinteractivelogonright datatype="boolean" operation="equals">1</sedenyinteractivelogonright>
@@ -17088,12 +16839,6 @@ Incorrect configurations could prevent services from starting and result in a de
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:125301" version="1" comment="Administrators">
           <security_principle datatype="string" operation="equals">Administrators</security_principle>
         </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:125400" version="1" comment="Perform volume maintenance tasks">
-          <semanagevolumeprivilege datatype="boolean" operation="equals">0</semanagevolumeprivilege>
-        </accesstoken_state>
-        <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:125401" version="1" comment="Administrators">
-          <security_principle datatype="string" operation="equals">Administrators</security_principle>
-        </accesstoken_state>
         <accesstoken_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:125500" version="1" comment="Profile single process">
           <seprofilesingleprocessprivilege datatype="boolean" operation="equals">0</seprofilesingleprocessprivilege>
         </accesstoken_state>
@@ -17126,18 +16871,6 @@ Incorrect configurations could prevent services from starting and result in a de
             <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" name="id" entity_check="none satisfy" datatype="int">411</field>
           </result>
         </wmi57_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127000" version="1" comment="Event Log process account SID. Deterministically built with respect to service name.">
-          <trustee_sid datatype="string">S-1-5-80-880578595-1860270145-482643319-2788375705-1540778122</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127001" version="1" comment="SYSTEM account SID.">
-          <trustee_sid datatype="string">S-1-5-18</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127002" version="1" comment="Administrators group SID.">
-          <trustee_sid datatype="string">S-1-5-32-544</trustee_sid>
-        </fileeffectiverights53_state>
-        <fileeffectiverights53_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127003" version="1" comment="LOCAL SERVICE account SID, the owner.">
-          <trustee_sid datatype="string">S-1-5-19</trustee_sid>
-        </fileeffectiverights53_state>
         <auditeventpolicysubcategories_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:127400" version="1" comment="'Other Object Access Events' is set to 'Success'">
           <other_object_access_events datatype="string">AUDIT_SUCCESS</other_object_access_events>
         </auditeventpolicysubcategories_state>
@@ -17224,25 +16957,75 @@ Incorrect configurations could prevent services from starting and result in a de
             <field xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" datatype="int" operation="less than or equal" name="setting">5</field>
           </result>
         </wmi57_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:420200" version="1" comment="Reg_Dword type and value is less than or equals 900">
-          <type>reg_dword</type>
-          <value datatype="int" operation="less than or equal">900</value>
-        </registry_state>
-        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:420201" version="1" comment="Reg_Dword type and value is greater than 0">
-          <type>reg_dword</type>
-          <value datatype="int" operation="greater than">0</value>
-        </registry_state>
         <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:420300" version="1" comment="Reg_Dword type and value is 0">
           <type>reg_dword</type>
           <value datatype="int">0</value>
         </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:25344400" version="1">
+          <type>reg_dword</type>
+          <value datatype="int" operation="less than or equal">900</value>
+        </registry_state>
+        <registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" id="oval:mil.disa.stig.windows:ste:25344401" version="1">
+          <type>reg_dword</type>
+          <value datatype="int" operation="greater than">0</value>
+        </registry_state>
       </states>
       <variables>
-        <local_variable id="oval:mil.disa.fso.windows:var:498401" version="1" datatype="string" comment="SystemRoot\System32">
+        <local_variable id="oval:mil.disa.stig.win:var:25334001" version="1" datatype="string" comment="Path to Application.evtx with the SystemRoot environment variable replaced with its value.">
           <concat>
-            <object_component object_ref="oval:mil.disa.fso.windows:obj:388601" item_field="value" />
+            <object_component object_ref="oval:mil.disa.stig.win:obj:20000015" item_field="value" />
+            <regex_capture pattern="^%.*%(.*)$">
+              <object_component object_ref="oval:mil.disa.stig.win:obj:25334002" item_field="value" />
+            </regex_capture>
+          </concat>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334002" version="1" datatype="string" comment="Strict path to Application.evtx.">
+          <regex_capture pattern="^(.*)$">
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25334002" item_field="value" />
+          </regex_capture>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334101" version="1" datatype="string" comment="Path to Security.evtx with the SystemRoot environment variable replaced with its value.">
+          <concat>
+            <object_component object_ref="oval:mil.disa.stig.win:obj:20000015" item_field="value" />
+            <regex_capture pattern="^%.*%(.*)$">
+              <object_component object_ref="oval:mil.disa.stig.win:obj:25334102" item_field="value" />
+            </regex_capture>
+          </concat>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334102" version="1" datatype="string" comment="Strict path to Security.evtx.">
+          <regex_capture pattern="^(.*)$">
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25334102" item_field="value" />
+          </regex_capture>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334201" version="1" datatype="string" comment="Path to System.evtx with the SystemRoot environment variable replaced with its value.">
+          <concat>
+            <object_component object_ref="oval:mil.disa.stig.win:obj:20000015" item_field="value" />
+            <regex_capture pattern="^%.*%(.*)$">
+              <object_component object_ref="oval:mil.disa.stig.win:obj:25334202" item_field="value" />
+            </regex_capture>
+          </concat>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25334202" version="1" datatype="string" comment="Strict path to System.evtx.">
+          <regex_capture pattern="^(.*)$">
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25334202" item_field="value" />
+          </regex_capture>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25429900" version="1" datatype="string" comment="SystemRoot\System32">
+          <concat>
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25429901" item_field="value" />
             <literal_component>\System32</literal_component>
           </concat>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25439100" version="1" datatype="string" comment="Database log files path">
+          <object_component object_ref="oval:mil.disa.stig.win:obj:25439100" item_field="value" />
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25439101" version="1" datatype="string" comment="DSA Database working path">
+          <regex_capture pattern="^(.+)\\">
+            <object_component object_ref="oval:mil.disa.stig.win:obj:25439101" item_field="value" />
+          </regex_capture>
+        </local_variable>
+        <local_variable id="oval:mil.disa.stig.win:var:25439102" version="1" datatype="string" comment="DSA Working Directory">
+          <object_component object_ref="oval:mil.disa.stig.win:obj:25439111" item_field="value" />
         </local_variable>
         <external_variable id="oval:mil.disa.stig.windows:var:101200" version="1" datatype="int" comment="Account Lockout Threshold">
           <possible_value hint="3_attempts">3</possible_value>
@@ -17267,13 +17050,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <possible_value hint="86400_seconds">86400</possible_value>
           <possible_value hint="172800_seconds">172800</possible_value>
           <possible_value hint="432000_seconds">432000</possible_value>
-        </external_variable>
-        <external_variable id="oval:mil.disa.stig.windows:var:101700" version="1" datatype="int" comment="Minimum Password Length">
-          <possible_value hint="8_characters">8</possible_value>
-          <possible_value hint="9_characters">9</possible_value>
-          <possible_value hint="12_characters">12</possible_value>
-          <possible_value hint="14_characters">14</possible_value>
-          <possible_value hint="15_characters">15</possible_value>
         </external_variable>
         <external_variable id="oval:mil.disa.stig.windows:var:101800" version="1" datatype="boolean" comment="Enforce Password Complexity">
           <possible_value hint="disabled">0</possible_value>
@@ -17401,17 +17177,6 @@ Incorrect configurations could prevent services from starting and result in a de
           <possible_value hint="disabled">0</possible_value>
           <possible_value hint="enabled">1</possible_value>
         </external_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:113500" version="1" datatype="string" comment="Database log files path">
-          <object_component object_ref="oval:mil.disa.stig.windows:obj:113500" item_field="value" />
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:113501" version="2" datatype="string" comment="DSA Database working path">
-          <regex_capture pattern="^(.+)\\">
-            <object_component object_ref="oval:mil.disa.stig.windows:obj:113501" item_field="value" />
-          </regex_capture>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:113502" version="1" datatype="string" comment="DSA Working Directory">
-          <object_component object_ref="oval:mil.disa.stig.windows:obj:113520" item_field="value" />
-        </local_variable>
         <local_variable id="oval:mil.disa.stig.windows:var:118300" version="2" datatype="string" comment="Built-in Guest">
           <object_component object_ref="oval:mil.disa.stig.windows:obj:118301" item_field="trustee_sid" />
         </local_variable>
@@ -17435,54 +17200,15 @@ Incorrect configurations could prevent services from starting and result in a de
             <literal_component>\Guest</literal_component>
           </concat>
         </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:126400" version="2" datatype="string" comment="Path to Security.evtx, with %SystemRoot% variable swapped for its value, usually C:\Windows.">
-          <concat>
-            <object_component object_ref="oval:mil.disa.fso.windows:obj:388601" item_field="value" />
-            <regex_capture pattern="^%.*%(.*)$">
-              <object_component object_ref="oval:mil.disa.stig.windows:obj:126402" item_field="value" />
-            </regex_capture>
-          </concat>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:126401" version="3" datatype="string" comment="Full strict path to Security.evtx.">
-          <regex_capture pattern="^(.*)$">
-            <object_component object_ref="oval:mil.disa.stig.windows:obj:126402" item_field="value" />
-          </regex_capture>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:127000" version="2" datatype="string" comment="Path to Application.evtx with %SystemRoot% variable swapped for its value, usually C:\Windows.">
-          <concat>
-            <object_component object_ref="oval:mil.disa.fso.windows:obj:388601" item_field="value" />
-            <regex_capture pattern="^%.*%(.*)$">
-              <object_component object_ref="oval:mil.disa.stig.windows:obj:127002" item_field="value" />
-            </regex_capture>
-          </concat>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:127001" version="3" datatype="string" comment="Full strict path to Application.evtx">
-          <regex_capture pattern="^(.*)$">
-            <object_component object_ref="oval:mil.disa.stig.windows:obj:127002" item_field="value" />
-          </regex_capture>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:127100" version="2" datatype="string" comment="Path to System.evtx with %SystemRoot% variable swapped for its value, usually C:\Windows.">
-          <concat>
-            <object_component object_ref="oval:mil.disa.fso.windows:obj:388601" item_field="value" />
-            <regex_capture pattern="^%.*%(.*)$">
-              <object_component object_ref="oval:mil.disa.stig.windows:obj:127102" item_field="value" />
-            </regex_capture>
-          </concat>
-        </local_variable>
-        <local_variable id="oval:mil.disa.stig.windows:var:127101" version="3" datatype="string" comment="Full strict path to System.evtx.">
-          <regex_capture pattern="^(.*)$">
-            <object_component object_ref="oval:mil.disa.stig.windows:obj:127102" item_field="value" />
-          </regex_capture>
-        </local_variable>
       </variables>
     </oval_definitions>
   </component>
-  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R2_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2022-05-01T21:49:43">
+  <component id="scap_mil.disa.stig_comp_U_MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark-cpe-oval.xml" timestamp="2023-03-28T17:41:29">
     <oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5">
       <generator>
         <oval:product_name>repotool</oval:product_name>
         <oval:schema_version>5.10</oval:schema_version>
-        <oval:timestamp>2022-05-01T21:49:43</oval:timestamp>
+        <oval:timestamp>2023-03-28T17:41:29</oval:timestamp>
       </generator>
       <definitions>
         <definition id="oval:mil.disa.stig.windows:def:2001" version="2" class="inventory">


### PR DESCRIPTION
Includes updates from the following DISA SCAP Benchmarks:

* DotNet_Framework_4-0_V2R2_STIG_SCAP_1-2_Benchmark
* MS_IE11_V2R5_STIG_SCAP_1-2_Benchmark
* MS_Windows_10_V2R8_STIG_SCAP_1-2_Benchmark
* MS_Windows_2012_and_2012_R2_DC_V3R5_STIG_SCAP_1-2_Benchmark
* MS_Windows_2012_and_2012_R2_MS_V3R5_STIG_SCAP_1-2_Benchmark
* MS_Windows_Server_2016_V2R4_STIG_SCAP_1-2_Benchmark
* MS_Windows_Server_2019_V2R4_STIG_SCAP_1-2_Benchmark
* RHEL_7_V3R11_STIG_SCAP_1-2_Benchmark
* RHEL_8_V1R9_STIG_SCAP_1-2_Benchmark
